### PR TITLE
Add a patch_constitution governance command.

### DIFF
--- a/app/constitution/scitt.js
+++ b/app/constitution/scitt.js
@@ -1,3 +1,11 @@
+// ----- SCITT Constitution starts here -----
+//
+// The marker above is used by the patch_constitution tool, as a way to split an
+// existing service's constitution in its operator and application halves, and
+// update only the latter.
+//
+// Do not remove it! Do not add anything before it.
+
 actions.set("set_scitt_configuration",
   new Action(
     function(args) {
@@ -24,3 +32,7 @@ actions.set("set_scitt_configuration",
     function(args) {
       ccf.kv["public:ccf.gov.scitt.configuration"].set(getSingletonKvKey(), ccf.jsonCompatibleToBuf(args.configuration));
     }))
+
+// The marker below is used by the patch_constitution tool.
+// Do not remove it! Do not add anything after it.
+// ----- SCITT Constitution ends here -----

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -723,6 +723,24 @@ namespace scitt
         .set_auto_schema<void, Configuration>()
         .install();
 
+      static constexpr auto get_constitution_path = "/constitution";
+      auto get_constitution = [&](EndpointContext& ctx) {
+        auto constitution =
+          ctx.tx.template ro<ccf::Constitution>(ccf::Tables::CONSTITUTION)
+            ->get()
+            .value();
+
+        ctx.rpc_ctx->set_response_body(std::move(constitution));
+        ctx.rpc_ctx->set_response_header(
+          http::headers::CONTENT_TYPE, "application/javascript");
+      };
+      make_endpoint(
+        get_constitution_path,
+        HTTP_GET,
+        error_adapter(get_constitution),
+        no_authn_policy)
+        .install();
+
 #ifdef ENABLE_PREFIX_TREE
       PrefixTreeFrontend::init_handlers(context, *this);
 #endif

--- a/pyscitt/pyscitt/cli/governance.py
+++ b/pyscitt/pyscitt/cli/governance.py
@@ -3,7 +3,11 @@
 
 import argparse
 import json
+import sys
+from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Optional, Union
 
 import certifi
@@ -13,16 +17,44 @@ from ..client import Client
 from .client_arguments import add_client_arguments, create_client
 
 
-def execute_governance(
-    client: Client, proposal: Union[dict, bytes], dump_only: bool = False
-):
-    if isinstance(proposal, dict):
-        proposal = json.dumps(proposal).encode("ascii")
+@dataclass
+class GovernanceAction:
+    proposal: Union[dict, bytes]
+    ballot: Optional[str] = None
 
-    if dump_only:
+
+def add_proposal_arguments(p, *, enable_dump_only=True):
+    if enable_dump_only:
+        p.add_argument(
+            "--dump-only",
+            action="store_true",
+            help="Dumps the proposal to proposal.json and exits",
+        )
+    else:
+        p.set_defaults(dump_only=False)
+
+    p.add_argument(
+        "--allow-open",
+        action="store_true",
+        help="Do not fail if the proposal remains open",
+    )
+
+
+def execute_action(client: Client, action: GovernanceAction, args: argparse.Namespace):
+    if isinstance(action.proposal, bytes):
+        proposal = action.proposal
+    else:
+        proposal = json.dumps(action.proposal).encode("ascii")
+
+    if args.dump_only:
         Path("proposal.json").write_bytes(proposal)
     else:
-        result = client.governance.propose(proposal)
+        result = client.governance.propose(proposal, vote=False)
+        if not result.is_accepted:
+            result = client.governance.vote(
+                result.id, ballot=action.ballot, must_pass=not args.allow_open
+            )
+
         if result.is_accepted:
             print(f"Proposal was accepted!")
         elif result.is_open:
@@ -31,38 +63,127 @@ def execute_governance(
             print(f"Proposal {result.id} is {result.state}")
 
 
-def propose_root_ca_certs(
-    client: Client, bundle_name: str, ca_cert_path: Path, dump_only: bool
-):
+def propose_root_ca_certs(bundle_name: str, ca_cert_path: Path):
     cert_bundle = ca_cert_path.read_text()
     proposal = governance.set_ca_bundle_proposal(bundle_name, cert_bundle)
-    execute_governance(client, proposal, dump_only)
+    return GovernanceAction(proposal)
 
 
-def propose_configuration(client: Client, configuration_path: Path, dump_only: bool):
+def propose_configuration(configuration_path: Path):
     with open(configuration_path) as f:
         configuration = json.load(f)
 
     proposal = governance.set_scitt_configuration_proposal(configuration)
-    execute_governance(client, proposal, dump_only)
+    return GovernanceAction(proposal)
 
 
-def propose_open_service(
-    client: Client, next_service_certificate_path: Path, dump_only: bool
-):
+def propose_open_service(next_service_certificate_path: Path):
     next_service_certificate = next_service_certificate_path.read_text()
     proposal = governance.transition_service_to_open_proposal(next_service_certificate)
-    execute_governance(client, proposal, dump_only)
+    return GovernanceAction(proposal)
 
 
-def propose_generic(client: Client, path: Path):
-    proposal = path.read_bytes()
-    execute_governance(client, proposal)
+def propose_generic(path: Path):
+    return GovernanceAction(path.read_bytes())
+
+
+def propose_constitution(path: Path):
+    constitution = path.read_text()
+    proposal = governance.set_constitution_proposal(constitution)
+    return GovernanceAction(proposal)
+
+
+CONSTITUTION_MARKER_START = "// ----- SCITT Constitution starts here -----\n"
+CONSTITUTION_MARKER_END = "// ----- SCITT Constitution ends here -----"
+
+
+def apply_constitution_patch(constitution: str, patch: str) -> str:
+    if not patch.startswith(CONSTITUTION_MARKER_START):
+        raise RuntimeError(
+            f"New SCITT constitution does not start with marker {repr(CONSTITUTION_MARKER_START)}"
+        )
+    if not patch.rstrip().endswith(CONSTITUTION_MARKER_END):
+        raise RuntimeError(
+            f"New SCITT constitution does not end with marker {repr(CONSTITUTION_MARKER_END)}"
+        )
+    if patch.count(CONSTITUTION_MARKER_START) > 1:
+        raise RuntimeError(f"New SCITT constitution contains multiple start markers")
+    if patch.count(CONSTITUTION_MARKER_END) > 1:
+        raise RuntimeError(f"New SCITT constitution contains multiple end markers")
+
+    parts = constitution.split(CONSTITUTION_MARKER_START)
+    if len(parts) == 1:
+        print(
+            "Did not find any marker in existing constitution. The SCITT constitution will be appended to it"
+        )
+    elif len(parts) == 2:
+        if not parts[1].rstrip().endswith(CONSTITUTION_MARKER_END):
+            raise RuntimeError(
+                "Existing constitution does not end with the right marker"
+            )
+    else:
+        assert len(parts) > 2
+        raise RuntimeError("Found multiple markers in constitution")
+
+    core_constitution = parts[0]
+    if not core_constitution.endswith("\n"):
+        core_constitution += "\n"
+
+    return core_constitution + patch
+
+
+def patch_constitution(client: Client, constitution_path: Path, yes: bool):
+    scitt_constitution = constitution_path.read_text()
+    initial_constitution = client.get_constitution()
+    final_constitution = apply_constitution_patch(
+        initial_constitution, scitt_constitution
+    )
+
+    if not yes:
+        with TemporaryDirectory() as d:
+            path = Path(d).joinpath("constitution.js")
+            path.write_text(final_constitution)
+
+            print(f"Updated constitution was written to {path}.")
+            print("You may review and modify the file before proceeding.")
+            answer = input("Do you wish to continue [y/N]: ").lower()
+
+            if answer == "y" or answer == "yes":
+                final_constitution = path.read_text()
+                pass
+            else:
+                print("Aborting")
+                sys.exit(1)
+
+    proposal = governance.set_constitution_proposal(final_constitution)
+
+    # The ballot we submit will only approve the proposal if the constitution
+    # found in the KV still matches the original value we used for the patch.
+    # Otherwise a concurrent change has happened, and we shouldn't be making any
+    # changes.
+    # Note the use of `repr` to turn the constitution into a valid Javascript
+    # string literal, in particular, escaping quotations marks and newlines.
+    #
+    # sandbox.sh has the inconvenient property of accepting proposals immediately,
+    # without even a single ballot. This makes this defensive measure ineffective
+    # in this context.
+    ballot = f"""
+        export function vote (rawProposal, proposerId) {{
+            const singletonKey = new ArrayBuffer(8);
+            const constitution = ccf.bufToJsonCompatible(ccf.kv["public:ccf.gov.constitution"].get(singletonKey));
+            return constitution == {repr(initial_constitution)};
+        }}
+    """
+    return GovernanceAction(proposal, ballot)
 
 
 def activate_member(client: Client):
     r = client.post("/gov/ack/update_state_digest", sign_request=True)
     client.post("/gov/ack", content=r.content, sign_request=True)
+
+
+def get_constitution(client: Client, path: Path):
+    path.write_text(client.get("/app/constitution").text)
 
 
 def setup_local_development(
@@ -112,6 +233,7 @@ def cli(fn):
 
     p = sub.add_parser("propose_ca_certs")
     add_client_arguments(p, with_member_auth=True)
+    add_proposal_arguments(p)
     p.add_argument(
         "--name",
         choices=["did_web_tls_roots", "x509_roots"],
@@ -125,62 +247,98 @@ def cli(fn):
         help="Path to PEM-encoded CA Cert bundle",
         required=True,
     )
-    p.add_argument(
-        "--dump-only",
-        action="store_true",
-        help="Dumps the proposal to proposal.json and exits",
-    )
     p.set_defaults(
-        func=lambda args: propose_root_ca_certs(
-            create_client(args), args.bundle_name, args.ca_certs, args.dump_only
+        func=lambda args: execute_action(
+            create_client(args),
+            propose_root_ca_certs(args.bundle_name, args.ca_certs),
+            args,
         )
     )
 
     p = sub.add_parser("propose_configuration")
     add_client_arguments(p, with_member_auth=True)
+    add_proposal_arguments(p)
     p.add_argument(
         "--configuration", type=Path, help="JSON configuration", required=True
     )
-    p.add_argument(
-        "--dump-only",
-        action="store_true",
-        help="Dumps the proposal to proposal.json and exits",
-    )
     p.set_defaults(
-        func=lambda args: propose_configuration(
-            create_client(args), args.configuration, args.dump_only
+        func=lambda args: execute_action(
+            create_client(args),
+            propose_configuration(args.configuration),
+            args,
         )
     )
 
     p = sub.add_parser("propose_generic")
     add_client_arguments(p, with_member_auth=True)
+    add_proposal_arguments(p, enable_dump_only=False)
     p.add_argument("--proposal-path", type=Path, help="JSON proposal", required=True)
     p.set_defaults(
-        func=lambda args: propose_generic(create_client(args), args.proposal_path)
+        func=lambda args: execute_action(
+            create_client(args),
+            propose_generic(args.proposal_path),
+            args,
+        )
     )
 
     p = sub.add_parser("propose_open_service")
     add_client_arguments(p, with_member_auth=True)
+    add_proposal_arguments(p)
     p.add_argument(
         "--next-service-certificate",
         type=Path,
         help="Path to next service certificate",
         required=True,
     )
-    p.add_argument(
-        "--dump-only",
-        action="store_true",
-        help="Dumps the proposal to proposal.json and exits",
-    )
     p.set_defaults(
-        func=lambda args: propose_open_service(
-            create_client(args), args.next_service_certificate, args.dump_only
+        func=lambda args: execute_action(
+            create_client(args),
+            propose_open_service(args.next_service_certificate),
+            args,
         )
     )
+
+    p = sub.add_parser(
+        "propose_constitution", help="Propose a new service constitution"
+    )
+    add_client_arguments(p, with_member_auth=True)
+    add_proposal_arguments(p)
+    p.add_argument("--constitution-file", type=Path, required=True)
+    p.set_defaults(
+        func=lambda args: execute_action(
+            create_client(args),
+            propose_constitution(args.constitution_file),
+            args,
+        )
+    )
+
+    p = sub.add_parser(
+        "patch_constitution",
+        help="Update the SCITT component of the service's constitution",
+    )
+    add_client_arguments(p, with_member_auth=True)
+    add_proposal_arguments(p)
+    p.add_argument("--constitution-file", type=Path, required=True)
+    p.add_argument("--yes", action="store_true", help="Do not ask for confirmation")
+
+    def func(args):
+        client = create_client(args)
+        action = patch_constitution(client, args.constitution_file, args.yes)
+        execute_action(client, action, args)
+
+    p.set_defaults(func=func)
 
     p = sub.add_parser("activate_member")
     add_client_arguments(p, with_member_auth=True)
     p.set_defaults(func=lambda args: activate_member(create_client(args)))
+
+    p = sub.add_parser(
+        "constitution",
+        help="Fetch the service's current constitution and write it to a file",
+    )
+    add_client_arguments(p)
+    p.add_argument("--output", type=Path, help="Output file", required=True)
+    p.set_defaults(func=lambda args: get_constitution(create_client(args), args.output))
 
     p = sub.add_parser(
         "local_development", help="Configure a SCITT ledger for local development."

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -300,6 +300,9 @@ class Client(BaseClient):
         service_id = params.get("serviceId")
         return {service_id: params}
 
+    def get_constitution(self) -> str:
+        return self.get("/app/constitution").text
+
     def submit_claim(
         self, claim: bytes, *, skip_confirmation=False, decode=True
     ) -> Submission:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -459,7 +459,10 @@ class TestUpdateScittConstitution:
         ):
             update_scitt_constitution("")
 
-    @pytest.mark.xfail(reason="Test does not work with sandbox.sh, only cchost", raises=pytest.fail.Exception)
+    @pytest.mark.xfail(
+        reason="Test does not work with sandbox.sh, only cchost",
+        raises=pytest.fail.Exception,
+    )
     def test_race_condition(self, update_scitt_constitution, monkeypatch):
         # We want to make two concurrent modifications to the constitution, and
         # make sure update_scitt_constitution detects this.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,7 +12,10 @@ from loguru import logger as LOG
 
 from infra.did_web_server import DIDWebServer
 from pyscitt import crypto, did
-from pyscitt.cli.governance import CONSTITUTION_MARKER_END, CONSTITUTION_MARKER_START
+from pyscitt.cli.governance import (
+    SCITT_CONSTITUTION_MARKER_END,
+    SCITT_CONSTITUTION_MARKER_START,
+)
 from pyscitt.cli.main import main
 from pyscitt.client import Client, ServiceError
 from pyscitt.governance import ProposalNotAccepted
@@ -310,15 +313,15 @@ def test_registration_info(tmp_path: Path):
     }
 
 
-class TestPatchConstitution:
-    # We make an effort to save and restore the consititution, but if something
-    # goes wrong during these test we may break the service and render it unusable.
+class TestUpdateScittConstitution:
+    # We make an effort to save and restore the constitution, but if something
+    # goes wrong during these tests we may break the service and render it unusable.
     # Subsequent tests would likely fail if this were the case.
 
     @pytest.fixture(autouse=True)
     def original_constitution(self, tmp_path_factory):
         """
-        Save the original consititution and restore it after the test has run.
+        Save the original constitution and restore it after the test has run.
         The fixture provides the core constitution's contents, that is with the
         SCITT amendments stripped.
 
@@ -330,7 +333,8 @@ class TestPatchConstitution:
         run("governance", "constitution", output=path, development=True)
 
         try:
-            core_constitution = path.read_text().split(CONSTITUTION_MARKER_START)[0]
+            parts = path.read_text().split(SCITT_CONSTITUTION_MARKER_START)
+            core_constitution = parts[0]
 
             # Propose a new constitution, truncating anything after the marker.
             # This provides a consistent starting point for all the tests.
@@ -355,27 +359,29 @@ class TestPatchConstitution:
             )
 
     @pytest.fixture
-    def patch_constitution(self, tmp_path):
+    def update_scitt_constitution(self, tmp_path):
         def f(script, include_markers=True, yes=True):
             path = tmp_path / "scitt.js"
             if include_markers:
                 path.write_text(
-                    CONSTITUTION_MARKER_START + script + CONSTITUTION_MARKER_END
+                    SCITT_CONSTITUTION_MARKER_START
+                    + script
+                    + SCITT_CONSTITUTION_MARKER_END
                 )
             else:
                 path.write_text(script)
 
             run(
                 "governance",
-                "patch_constitution",
-                constitution_file=path,
+                "update_scitt_constitution",
+                scitt_constitution_file=path,
                 yes=yes,
                 development=True,
             )
 
         return f
 
-    def test_patch_constitution(self, tmp_path, patch_constitution):
+    def test_update_scitt_constitution(self, tmp_path, update_scitt_constitution):
         proposal = tmp_path / "proposal.json"
         proposal.write_text(json.dumps({"actions": [{"name": "my_action"}]}))
 
@@ -388,17 +394,17 @@ class TestPatchConstitution:
                 development=True,
             )
 
-        patch_constitution(
+        update_scitt_constitution(
             'actions.set("my_action", new Action(function(args) { }, function(args) { }))'
         )
 
         run("governance", "propose_generic", proposal_path=proposal, development=True)
 
-        patch_constitution(
+        update_scitt_constitution(
             'actions.set("another_action", new Action(function(args) { }, function(args) { }))'
         )
 
-        # After patching the constitution again, the my_action action will
+        # After updating the constitution again, the my_action action will
         # fail to run, showing that we actually modified the SCITT constitution,
         # and didn't just append to it.
         with pytest.raises(ServiceError, match="my_action: no such action"):
@@ -409,27 +415,33 @@ class TestPatchConstitution:
                 development=True,
             )
 
-    def test_invalid_patch(self, patch_constitution):
+    def test_invalid_constitution(self, update_scitt_constitution):
         with pytest.raises(RuntimeError, match="does not start with marker"):
-            patch_constitution("", include_markers=False)
+            update_scitt_constitution("", include_markers=False)
 
         with pytest.raises(RuntimeError, match="does not end with marker"):
-            patch_constitution(CONSTITUTION_MARKER_START, include_markers=False)
+            update_scitt_constitution(
+                SCITT_CONSTITUTION_MARKER_START, include_markers=False
+            )
 
         with pytest.raises(RuntimeError, match="does not end with marker"):
-            patch_constitution(
-                CONSTITUTION_MARKER_START + CONSTITUTION_MARKER_END + "// Trailing",
+            update_scitt_constitution(
+                SCITT_CONSTITUTION_MARKER_START
+                + SCITT_CONSTITUTION_MARKER_END
+                + "// Trailing",
                 include_markers=False,
             )
 
-    def test_trailing_text(self, original_constitution, patch_constitution, tmp_path):
+    def test_trailing_text(
+        self, original_constitution, update_scitt_constitution, tmp_path
+    ):
         # Write a constitution with the right markers, but with some text after it.
-        # We can't use patch_constitution for this because of its safety rails so
+        # We can't use update_scitt_constitution for this because of its safety rails so
         # we use the more low-level propose_constitution.
         tmp_path.joinpath("constitution.js").write_text(
             original_constitution
-            + CONSTITUTION_MARKER_START
-            + CONSTITUTION_MARKER_END
+            + SCITT_CONSTITUTION_MARKER_START
+            + SCITT_CONSTITUTION_MARKER_END
             + "// Trailing stuff"
         )
 
@@ -445,18 +457,18 @@ class TestPatchConstitution:
             RuntimeError,
             match="Existing constitution does not end with the right marker",
         ):
-            patch_constitution("")
+            update_scitt_constitution("")
 
-    @pytest.mark.skip("Test does not work with sandbox.sh, only cchost")
-    def test_race_condition(self, patch_constitution, monkeypatch):
+    @pytest.mark.xfail(reason="Test does not work with sandbox.sh, only cchost", raises=pytest.fail.Exception)
+    def test_race_condition(self, update_scitt_constitution, monkeypatch):
         # We want to make two concurrent modifications to the constitution, and
-        # make sure patch_constitution detects this.
-        # The way we do this is by running patch_constitution in interactive mode (yes=False),
+        # make sure update_scitt_constitution detects this.
+        # The way we do this is by running update_scitt_constitution in interactive mode (yes=False),
         # but monkeypatch the input() function. The input will always return yes
-        # to proceed, but before doing so it makes it's own change to the constitution
+        # to proceed, but before doing so it makes its own change to the constitution
         def confirm(*args):
             try:
-                patch_constitution("// Concurrent change")
+                update_scitt_constitution("// Concurrent change")
             except ProposalNotAccepted:
                 raise RuntimeError("concurrent change not accepted")
 
@@ -464,4 +476,4 @@ class TestPatchConstitution:
 
         monkeypatch.setattr("builtins.input", confirm)
         with pytest.raises(ProposalNotAccepted):
-            patch_constitution("// Main change", yes=False)
+            update_scitt_constitution("// Main change", yes=False)


### PR DESCRIPTION
This will load the current service's constitution, split the operator-specific part from the SCITT part, and modify the latter.

Because modifying the constitution is a fairly risky procedure, there are a number of precaution measures.