### PR TITLE
Protect the prefix tree flush process from inconsistent KV and indexer.

### DIFF
--- a/app/src/prefix_tree/indexing_strategy.h
+++ b/app/src/prefix_tree/indexing_strategy.h
@@ -91,7 +91,7 @@ namespace scitt
      * digest for this transaction. Only once the transaction is globally
      * committed will the tree be modified.
      */
-    pt::summary<> start_flush() const
+    pt::summary<> prepare_flush() const
     {
       std::shared_lock l1(pending_mutex_);
       std::unique_lock l2(tree_mutex_);


### PR DESCRIPTION
After a leader election, or a recovery, it is possible to have moved backwards from the perspective of the "continued leader", in which case the KV may contain an entry that is not known to the indexer yet.

Performing a flush in these circumstances would lead to the entry in the KV to move backwards as well, where the latest entry would have a smaller upper bound than its predecessor.

There were already asserts in batched_prefix_tree to protect against this, but these only run in debug mode, and catch the problem much too late.

We unfortunately still don't have a good way of testing these atypical interleavings and interactions between the KV and the indexer.