### PR TITLE
Detect the sgx_prv group ID in CI automatically.

### DIFF
--- a/.pipelines/common.yml
+++ b/.pipelines/common.yml
@@ -41,7 +41,7 @@ jobs:
 
       - ${{ if eq(parameters.Container, 'sgx') }}:
         - script: |
-            sudo groupadd -fg 119 sgx_prv
+            sudo groupadd -fg $(/usr/bin/stat -Lc '%g' /dev/sgx/provision) sgx_prv
             sudo usermod -a -G sgx_prv $(whoami)
           displayName: Add sgx_prv group
 


### PR DESCRIPTION
During CI, we need to create the sgx_prv group inside the Docker container and add the current user to it.

We used to hardcode 119 as the group ID, but this value has changed on recent build machines.

Instead we can use stat to examine the /dev/sgx/provision file using stat and obtain the group ID from its ownership.