### PR TITLE
Change patch_constitution command and variable names to be more SCITT-specific

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,7 +12,10 @@ from loguru import logger as LOG
 
 from infra.did_web_server import DIDWebServer
 from pyscitt import crypto, did
-from pyscitt.cli.governance import CONSTITUTION_MARKER_END, CONSTITUTION_MARKER_START
+from pyscitt.cli.governance import (
+    SCITT_CONSTITUTION_MARKER_END,
+    SCITT_CONSTITUTION_MARKER_START,
+)
 from pyscitt.cli.main import main
 from pyscitt.client import Client, ServiceError
 from pyscitt.governance import ProposalNotAccepted
@@ -310,15 +313,15 @@ def test_registration_info(tmp_path: Path):
     }
 
 
-class TestPatchConstitution:
-    # We make an effort to save and restore the consititution, but if something
-    # goes wrong during these test we may break the service and render it unusable.
+class TestUpdateScittConstitution:
+    # We make an effort to save and restore the constitution, but if something
+    # goes wrong during these tests we may break the service and render it unusable.
     # Subsequent tests would likely fail if this were the case.
 
     @pytest.fixture(autouse=True)
     def original_constitution(self, tmp_path_factory):
         """
-        Save the original consititution and restore it after the test has run.
+        Save the original constitution and restore it after the test has run.
         The fixture provides the core constitution's contents, that is with the
         SCITT amendments stripped.
 
@@ -330,7 +333,8 @@ class TestPatchConstitution:
         run("governance", "constitution", output=path, development=True)
 
         try:
-            core_constitution = path.read_text().split(CONSTITUTION_MARKER_START)[0]
+            parts = path.read_text().split(SCITT_CONSTITUTION_MARKER_START)
+            core_constitution = parts[0]
 
             # Propose a new constitution, truncating anything after the marker.
             # This provides a consistent starting point for all the tests.
@@ -355,27 +359,29 @@ class TestPatchConstitution:
             )
 
     @pytest.fixture
-    def patch_constitution(self, tmp_path):
+    def update_scitt_constitution(self, tmp_path):
         def f(script, include_markers=True, yes=True):
             path = tmp_path / "scitt.js"
             if include_markers:
                 path.write_text(
-                    CONSTITUTION_MARKER_START + script + CONSTITUTION_MARKER_END
+                    SCITT_CONSTITUTION_MARKER_START
+                    + script
+                    + SCITT_CONSTITUTION_MARKER_END
                 )
             else:
                 path.write_text(script)
 
             run(
                 "governance",
-                "patch_constitution",
-                constitution_file=path,
+                "update_scitt_constitution",
+                scitt_constitution_file=path,
                 yes=yes,
                 development=True,
             )
 
         return f
 
-    def test_patch_constitution(self, tmp_path, patch_constitution):
+    def test_update_scitt_constitution(self, tmp_path, update_scitt_constitution):
         proposal = tmp_path / "proposal.json"
         proposal.write_text(json.dumps({"actions": [{"name": "my_action"}]}))
 
@@ -388,17 +394,17 @@ class TestPatchConstitution:
                 development=True,
             )
 
-        patch_constitution(
+        update_scitt_constitution(
             'actions.set("my_action", new Action(function(args) { }, function(args) { }))'
         )
 
         run("governance", "propose_generic", proposal_path=proposal, development=True)
 
-        patch_constitution(
+        update_scitt_constitution(
             'actions.set("another_action", new Action(function(args) { }, function(args) { }))'
         )
 
-        # After patching the constitution again, the my_action action will
+        # After updating the constitution again, the my_action action will
         # fail to run, showing that we actually modified the SCITT constitution,
         # and didn't just append to it.
         with pytest.raises(ServiceError, match="my_action: no such action"):
@@ -409,27 +415,33 @@ class TestPatchConstitution:
                 development=True,
             )
 
-    def test_invalid_patch(self, patch_constitution):
+    def test_invalid_constitution(self, update_scitt_constitution):
         with pytest.raises(RuntimeError, match="does not start with marker"):
-            patch_constitution("", include_markers=False)
+            update_scitt_constitution("", include_markers=False)
 
         with pytest.raises(RuntimeError, match="does not end with marker"):
-            patch_constitution(CONSTITUTION_MARKER_START, include_markers=False)
+            update_scitt_constitution(
+                SCITT_CONSTITUTION_MARKER_START, include_markers=False
+            )
 
         with pytest.raises(RuntimeError, match="does not end with marker"):
-            patch_constitution(
-                CONSTITUTION_MARKER_START + CONSTITUTION_MARKER_END + "// Trailing",
+            update_scitt_constitution(
+                SCITT_CONSTITUTION_MARKER_START
+                + SCITT_CONSTITUTION_MARKER_END
+                + "// Trailing",
                 include_markers=False,
             )
 
-    def test_trailing_text(self, original_constitution, patch_constitution, tmp_path):
+    def test_trailing_text(
+        self, original_constitution, update_scitt_constitution, tmp_path
+    ):
         # Write a constitution with the right markers, but with some text after it.
-        # We can't use patch_constitution for this because of its safety rails so
+        # We can't use update_scitt_constitution for this because of its safety rails so
         # we use the more low-level propose_constitution.
         tmp_path.joinpath("constitution.js").write_text(
             original_constitution
-            + CONSTITUTION_MARKER_START
-            + CONSTITUTION_MARKER_END
+            + SCITT_CONSTITUTION_MARKER_START
+            + SCITT_CONSTITUTION_MARKER_END
             + "// Trailing stuff"
         )
 
@@ -445,18 +457,21 @@ class TestPatchConstitution:
             RuntimeError,
             match="Existing constitution does not end with the right marker",
         ):
-            patch_constitution("")
+            update_scitt_constitution("")
 
-    @pytest.mark.skip("Test does not work with sandbox.sh, only cchost")
-    def test_race_condition(self, patch_constitution, monkeypatch):
+    @pytest.mark.xfail(
+        reason="Test does not work with sandbox.sh, only cchost",
+        raises=pytest.fail.Exception,
+    )
+    def test_race_condition(self, update_scitt_constitution, monkeypatch):
         # We want to make two concurrent modifications to the constitution, and
-        # make sure patch_constitution detects this.
-        # The way we do this is by running patch_constitution in interactive mode (yes=False),
+        # make sure update_scitt_constitution detects this.
+        # The way we do this is by running update_scitt_constitution in interactive mode (yes=False),
         # but monkeypatch the input() function. The input will always return yes
-        # to proceed, but before doing so it makes it's own change to the constitution
+        # to proceed, but before doing so it makes its own change to the constitution
         def confirm(*args):
             try:
-                patch_constitution("// Concurrent change")
+                update_scitt_constitution("// Concurrent change")
             except ProposalNotAccepted:
                 raise RuntimeError("concurrent change not accepted")
 
@@ -464,4 +479,4 @@ class TestPatchConstitution:
 
         monkeypatch.setattr("builtins.input", confirm)
         with pytest.raises(ProposalNotAccepted):
-            patch_constitution("// Main change", yes=False)
+            update_scitt_constitution("// Main change", yes=False)


### PR DESCRIPTION
This change was part of the orginal PR #3 that introduced the command, but somehow GitHub skipped the additional commits??