### PR TITLE
Add a flag to tests to start cchost.

### DIFF
--- a/.pipelines/ccf.yml
+++ b/.pipelines/ccf.yml
@@ -12,8 +12,11 @@ steps:
       git clone --single-branch -b ccf-${{ parameters.Version }} https://github.com/microsoft/CCF $(Pipeline.Workspace)/CCF
     displayName: Checkout CCF ${{ parameters.Version }}
 
-  # This commit is in the main branch of CCF. Once it gets backported to 2.x we can bump the CCF version and stop patching.
-  - script: curl -L https://github.com/microsoft/CCF/commit/3c7f7cbaf6b27cff0cae61c02bda4af7fb6fff92.diff | patch -p1
+  # These are commits from the main branch of CCF to fix ASAN builds, but which
+  # aren't getting backported to 2.x. We can remove them once we upgrade to 3.x.
+  - script: |
+      curl -L https://github.com/microsoft/CCF/commit/3c7f7cbaf6b27cff0cae61c02bda4af7fb6fff92.diff | patch -p1
+      curl -L https://github.com/microsoft/CCF/commit/3be424fb8318f130f57feaa2e6b95b4d2defec18.diff | patch -p1
     workingDirectory: $(Pipeline.Workspace)/CCF
     displayName: Patch CCF
 

--- a/app/fetch-did-web-doc-attested.sh
+++ b/app/fetch-did-web-doc-attested.sh
@@ -4,20 +4,18 @@
 
 set -x
 
-# This script invokes attested-fetch, and, if successful,
-# POSTs the response back to the CCF app at /did/{did}/doc.
+# This script invokes attested-fetch, and, if successful, POSTs the response
+# back to the CCF app. The callback URL to the CCF app is given as a command
+# line argument.
 
 # TODO remove this again once CCF logs output from subprocesses
 exec >  >(tee -i /tmp/scitt-fetch-did-web-doc-attested.log)
 exec 2>&1
 
 AFETCH_DIR="/tmp/scitt"
-did=$1
-url=$2
-nonce=$3
-CCF_SERVICE_HOST=${CCF_SERVICE_HOST:-"127.0.0.1"}
-CCF_SERVICE_PORT=${CCF_SERVICE_PORT:-"8000"}
-callback_url="https://${CCF_SERVICE_HOST}:${CCF_SERVICE_PORT}/app/did/${did}/doc"
+url=$1
+nonce=$2
+callback_url=$3
 out_path=$(mktemp "${AFETCH_DIR}/out.XXXXXX")
 trap "rm -f ${out_path}" 0 2 3 15
 

--- a/app/fetch-did-web-doc-unattested.sh
+++ b/app/fetch-did-web-doc-unattested.sh
@@ -4,8 +4,8 @@
 
 set -x
 
-# This script invokes curl, and, if successful,
-# POSTs the response back to the CCF app at /did/{did}/doc.
+# This script invokes curl, and, if successful, POSTs the response back to the
+# CCF app. The callback URL to the CCF app is given as a command line argument.
 # It is only used for testing in non-SGX environments.
 
 # TODO remove this again once CCF logs output from subprocesses
@@ -13,12 +13,9 @@ exec >  >(tee -i /tmp/scitt-fetch-did-web-doc-unattested.log)
 exec 2>&1
 
 AFETCH_DIR="/tmp/scitt"
-did=$1
-url=$2
-nonce=$3
-CCF_SERVICE_HOST=${CCF_SERVICE_HOST:-"127.0.0.1"}
-CCF_SERVICE_PORT=${CCF_SERVICE_PORT:-"8000"}
-callback_url="https://${CCF_SERVICE_HOST}:${CCF_SERVICE_PORT}/app/did/${did}/doc"
+url=$1
+nonce=$2
+callback_url=$3
 out_path=$(mktemp "${AFETCH_DIR}/out.XXXXXX")
 trap "rm -f ${out_path}" 0 2 3 15
 

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -106,11 +106,9 @@ namespace scitt
         ENTRY_TABLE, context, 10000, 20);
       context.get_indexing_strategies().install_strategy(entry_seqno_index);
 
-      auto host_processes = context.get_subsystem<ccf::AbstractHostProcesses>();
-
       auto resolver = std::make_unique<did::UniversalResolver>();
       resolver->register_resolver(
-        std::make_unique<did::web::DidWebResolver>(host_processes));
+        std::make_unique<did::web::DidWebResolver>(context));
 
       verifier = std::make_unique<verifier::Verifier>(std::move(resolver));
 

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -18,8 +18,7 @@ CCF_URL="https://${CCF_HOST}:${CCF_PORT}"
 DOCKER_TAG=${DOCKER_TAG:-"scitt-ccf-ledger-$ENCLAVE_TYPE"}
 CONTAINER_NAME=${CONTAINER_NAME:-"scitt-ccf-ledger-dev-$(date +%s)"}
 
-# TODO: remove sandbox_common/ subfolder once start.sh doesn't use sandbox.sh anymore
-WORKSPACE=${WORKSPACE:-"workspace/sandbox_common"}
+WORKSPACE=${WORKSPACE:-"workspace/"}
 
 VOLUME_NAME="${CONTAINER_NAME}-vol"
 

--- a/pyscitt/pyscitt/cli/client_arguments.py
+++ b/pyscitt/pyscitt/cli/client_arguments.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ..client import Client
 
 CCF_URL_DEFAULT = "https://127.0.0.1:8000"
-CCF_SANDBOX_WORKSPACE = Path("workspace") / "sandbox_common"
+CCF_SANDBOX_WORKSPACE = Path("workspace")
 CCF_MEMBER_KEY_DEFAULT = CCF_SANDBOX_WORKSPACE / "member0_privk.pem"
 CCF_MEMBER_CERT_DEFAULT = CCF_SANDBOX_WORKSPACE / "member0_cert.pem"
 

--- a/pyscitt/pyscitt/cli/governance.py
+++ b/pyscitt/pyscitt/cli/governance.py
@@ -165,10 +165,6 @@ def update_scitt_constitution(client: Client, scitt_constitution_path: Path, yes
     # any changes.
     # Note the use of `repr` to turn the constitution into a valid Javascript
     # string literal, in particular, escaping quotations marks and newlines.
-    #
-    # sandbox.sh has the inconvenient property of accepting proposals immediately,
-    # without even a single ballot. This makes this defensive measure ineffective
-    # in this context.
     ballot = f"""
         export function vote (rawProposal, proposerId) {{
             const singletonKey = new ArrayBuffer(8);

--- a/pyscitt/pyscitt/cli/governance.py
+++ b/pyscitt/pyscitt/cli/governance.py
@@ -179,11 +179,6 @@ def update_scitt_constitution(client: Client, scitt_constitution_path: Path, yes
     return GovernanceAction(proposal, ballot)
 
 
-def activate_member(client: Client):
-    r = client.post("/gov/ack/update_state_digest", sign_request=True)
-    client.post("/gov/ack", content=r.content, sign_request=True)
-
-
 def get_constitution(client: Client, path: Path):
     path.write_text(client.get_constitution())
 
@@ -196,7 +191,7 @@ def setup_local_development(
     # They are idempotent operation anyway, so no harm in doing them again.
 
     print("Activating member credentials...")
-    activate_member(client)
+    client.governance.activate_member()
 
     print("Configuring DID Web root CA bundle...")
     if did_web_ca_certs:
@@ -219,6 +214,7 @@ def setup_local_development(
         network["service_certificate"]
     )
     client.governance.propose(proposal, must_pass=True)
+    client.wait_for_network_open()
 
     if trust_store_dir:
         print(f"Adding service to {trust_store_dir} ...")
@@ -344,7 +340,7 @@ def cli(fn):
 
     p = sub.add_parser("activate_member")
     add_client_arguments(p, with_member_auth=True)
-    p.set_defaults(func=lambda args: activate_member(create_client(args)))
+    p.set_defaults(func=lambda args: create_client(args).governance.activate_member())
 
     p = sub.add_parser(
         "constitution",

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -183,6 +183,10 @@ class BaseClient:
             else:
                 kwargs["auth"] = self.member_http_sig
 
+            # Content-length is necessary for signing, even on GET requests.
+            if method == "GET":
+                kwargs.setdefault("headers", {}).setdefault("Content-Length", "0")
+
         default_wait_time = 2
         timeout = 30
         deadline = time.monotonic() + timeout
@@ -366,6 +370,12 @@ class Client(BaseClient):
                 yield tx
 
             link = body.get("nextLink")
+
+    def wait_for_network_open(self):
+        self.get(
+            "/node/network",
+            retry_on=[lambda r: r.is_success and r.json()["service_status"] != "Open"],
+        )
 
     @property
     def governance(self):

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -183,10 +183,6 @@ class BaseClient:
             else:
                 kwargs["auth"] = self.member_http_sig
 
-            # Content-length is necessary for signing, even on GET requests.
-            if method == "GET":
-                kwargs.setdefault("headers", {}).setdefault("Content-Length", "0")
-
         default_wait_time = 2
         timeout = 30
         deadline = time.monotonic() + timeout

--- a/pyscitt/pyscitt/governance.py
+++ b/pyscitt/pyscitt/governance.py
@@ -99,6 +99,10 @@ class GovernanceClient:
 
         return result
 
+    def activate_member(self):
+        r = self.client.post("/gov/ack/update_state_digest", sign_request=True)
+        self.client.post("/gov/ack", content=r.content, sign_request=True)
+
 
 def set_scitt_configuration_proposal(configuration: dict) -> dict:
     return {

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -23,6 +23,18 @@ if [ "$DOCKER" = "1" ]; then
     CCF_NETWORK_PID=$!
     trap "kill $CCF_NETWORK_PID" EXIT
 
+    # wait until the network is ready
+    timeout=120
+    while ! curl -s -f -k $CCF_URL/app/parameters > /dev/null; do
+        echo "Waiting for service to be ready..."
+        sleep 1
+        timeout=$((timeout - 1))
+        if [ $timeout -eq 0 ]; then
+            echo "Service failed to become ready, exiting"
+            exit 1
+        fi
+    done
+
     # Turn off pytest output capture to allow test logs to be interleaved with
     # the docker logs.
     TEST_ARGS="-s"

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -5,14 +5,7 @@
 set -e
 
 DOCKER=${DOCKER:-0}
-
-if [ "$DOCKER" = "1" ]; then
-    CCF_HOST=${CCF_HOST:-"localhost"}
-    CCF_PORT=${CCF_PORT:-8000}
-    CCF_URL="https://${CCF_HOST}:${CCF_PORT}"
-else
-    CCF_URL=${CCF_URL:-"https://localhost:8000"}
-fi
+ENCLAVE_TYPE=${ENCLAVE_TYPE:-release}
 
 # If ELEVATE_PRIVILEGES is non-empty, the functional tests will be run with
 # the NET_BIND_SERVICE capability, allowing certain tests that bind
@@ -22,26 +15,21 @@ fi
 ELEVATE_PRIVILEGES=${ELEVATE_PRIVILEGES:-}
 
 if [ "$DOCKER" = "1" ]; then
-    CCF_HOST=$CCF_HOST CCF_PORT=$CCF_PORT \
-        ./docker/run-dev.sh &
+    export CCF_HOST=${CCF_HOST:-"localhost"}
+    export CCF_PORT=${CCF_PORT:-8000}
+    export CCF_URL="https://${CCF_HOST}:${CCF_PORT}"
+
+    ./docker/run-dev.sh &
+    CCF_NETWORK_PID=$!
+    trap "kill $CCF_NETWORK_PID" EXIT
+
+    # Turn off pytest output capture to allow test logs to be interleaved with
+    # the docker logs.
+    TEST_ARGS="-s"
 else
-    ./start.sh &
+    SCITT_DIR=/tmp/scitt
+    TEST_ARGS="--start-cchost --enclave-type=$ENCLAVE_TYPE --enclave-package=$SCITT_DIR/lib/libscitt --constitution=$SCITT_DIR/share/scitt/constitution"
 fi
-
-CCF_NETWORK_PID=$!
-trap "kill $CCF_NETWORK_PID" EXIT
-
-# wait until the network is ready
-timeout=120
-while ! curl -s -f -k $CCF_URL/app/parameters > /dev/null; do
-    echo "Waiting for service to be ready..."
-    sleep 1
-    timeout=$((timeout - 1))
-    if [ $timeout -eq 0 ]; then
-        echo "Service failed to become ready, exiting"
-        exit 1
-    fi
-done
 
 echo "Setting up python virtual environment."
 if [ ! -f "venv/bin/activate" ]; then
@@ -49,15 +37,13 @@ if [ ! -f "venv/bin/activate" ]; then
 fi
 source venv/bin/activate 
 pip install --disable-pip-version-check -q -e ./pyscitt
-pip install pytest
-
-export CCF_URL
+pip install --disable-pip-version-check -q -r test/requirements.txt
 
 echo "Running functional tests..."
 if [ -n "$ELEVATE_PRIVILEGES" ]; then
     sudo -E --preserve-env=PATH \
         capsh --keep=1 --user=$(id -un) --inh=cap_net_bind_service --addamb=cap_net_bind_service \
-        -- -c "pytest ./test -s -rA -v --ignore-glob=*test_perf* $(printf "'%s' " "$@")"
+        -- -c "pytest ./test -v -rA $TEST_ARGS $(printf "'%s' " "$@")"
 else
-    pytest ./test -s -rA -v --ignore-glob=*test_perf* "$@"
+    pytest ./test -v -rA $TEST_ARGS "$@"
 fi

--- a/start.sh
+++ b/start.sh
@@ -30,4 +30,5 @@ exec python3.8 test/infra/cchost.py \
     --cchost $CCF_DIR/bin/cchost \
     --package $SCITT_DIR/lib/libscitt \
     --constitution $SCITT_DIR/share/scitt/constitution \
-    --enclave-type "$ENCLAVE_TYPE"
+    --enclave-type "$ENCLAVE_TYPE" \
+    "$@"

--- a/start.sh
+++ b/start.sh
@@ -8,28 +8,26 @@
 set -ex
 
 ENCLAVE_TYPE=${ENCLAVE_TYPE:-release}
+CCF_DIR=${CCF_DIR:-/opt/ccf}
+# TODO: Don't use /tmp
+SCITT_DIR=/tmp/scitt
+
 if [ "$ENCLAVE_TYPE" != "release" ] && [ "$ENCLAVE_TYPE" != "virtual" ]; then
     echo "Invalid enclave type: $ENCLAVE_TYPE"
     exit 1
 fi
 
-CCF_DIR=${CCF_DIR:-/opt/ccf}
-# TODO: Don't use /tmp
-SCITT_DIR=/tmp/scitt
+echo "Setting up python virtual environment."
+if [ ! -f "venv/bin/activate" ]; then
+    python3.8 -m venv "venv"
+fi
+source venv/bin/activate
+pip install --disable-pip-version-check -e ./pyscitt
+pip install --disable-pip-version-check -q -r test/requirements.txt
 
-echo "NOTE: Set \$PYTHON_PACKAGE_PATH to /path/to/ccf/repo/python if not using a release"
-
-# Note: 23 worker threads is currently the CCF maximum.
-# Note: --sig-tx-interval 10 reduces memory usage when a lot of transactions are in flight.
-exec "${CCF_DIR}/bin/sandbox.sh" \
+exec python3.8 test/infra/cchost.py \
+    --port 8000 \
+    --cchost $CCF_DIR/bin/cchost \
     --package $SCITT_DIR/lib/libscitt \
-    --constitution $SCITT_DIR/share/scitt/constitution/scitt.js \
-    --verbose \
-    --host-log-level info \
-    -n "local://0.0.0.0:8000,127.0.0.1:8000" \
-    --enclave-type "$ENCLAVE_TYPE" \
-    --sig-ms-interval 1000 \
-    --sig-tx-interval 10 \
-    --worker-threads 0 \
-    "$@"
-#     --config-file "$(pwd)/ccf-config.sandbox.json" \
+    --constitution $SCITT_DIR/share/scitt/constitution \
+    --enclave-type "$ENCLAVE_TYPE"

--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,8 @@ CCF_DIR=${CCF_DIR:-/opt/ccf}
 # TODO: Don't use /tmp
 SCITT_DIR=/tmp/scitt
 
+CONSTITUTION_DIR=$SCITT_DIR/share/scitt/constitution
+
 if [ "$ENCLAVE_TYPE" != "release" ] && [ "$ENCLAVE_TYPE" != "virtual" ]; then
     echo "Invalid enclave type: $ENCLAVE_TYPE"
     exit 1
@@ -29,6 +31,10 @@ exec python3.8 test/infra/cchost.py \
     --port 8000 \
     --cchost $CCF_DIR/bin/cchost \
     --package $SCITT_DIR/lib/libscitt \
-    --constitution $SCITT_DIR/share/scitt/constitution \
+    --constitution-file $CONSTITUTION_DIR/validate.js \
+    --constitution-file $CONSTITUTION_DIR/apply.js \
+    --constitution-file $CONSTITUTION_DIR/resolve.js \
+    --constitution-file $CONSTITUTION_DIR/actions.js \
+    --constitution-file $CONSTITUTION_DIR/scitt.js \
     --enclave-type "$ENCLAVE_TYPE" \
     "$@"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,13 +16,16 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "prefix_tree: only run test if prefix tree support is enabled."
+        "markers", "needs_prefix_tree: only run test if prefix tree support is enabled."
     )
 
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--enable-prefix-tree"):
-        skip = pytest.mark.skip(reason="prefix tree support was not enabled")
+        needs_prefix_tree_skip = pytest.mark.skip(
+            reason="prefix tree support was not enabled"
+        )
+
         for item in items:
-            if "prefix_tree" in item.keywords:
-                item.add_marker(skip)
+            if "needs_prefix_tree" in item.keywords:
+                item.add_marker(needs_prefix_tree_skip)

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 import aiotools
 from loguru import logger as LOG
 
-from pyscitt import crypto, governance
+from pyscitt import crypto
 
 
 class ShutdownRequestException(Exception):
@@ -28,6 +28,8 @@ class UnexpectedExitException(Exception):
     ...
 
 
+# Register some log levels used by cchost that have, by default, no equivalent
+# in loguru.
 LOG.level("FAIL", no=60, color="<red>")
 LOG.level("FATAL", no=60, color="<red>")
 

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -1,0 +1,414 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import signal
+import ssl
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import List, Optional
+
+import aiotools
+from loguru import logger as LOG
+
+from pyscitt import crypto, governance
+
+
+class ShutdownRequestException(Exception):
+    ...
+
+
+class UnexpectedExitException(Exception):
+    ...
+
+
+LOG.level("FAIL", no=60, color="<red>")
+LOG.level("FATAL", no=60, color="<red>")
+
+# Python 3.11 would make this obsolete with 'except*'
+def match_taskgroup_error(group: aiotools.TaskGroupError, expected: type):
+    errors = group.__errors__
+    if len(errors) == 1:
+        if isinstance(errors[0], expected):
+            return True
+        elif isinstance(errors[0], aiotools.TaskGroupError):
+            return match_taskgroup_error(errors[0], expected)
+
+    return False
+
+
+class CCHost:
+    binary: str
+    rpc_port: int
+    node_port: int
+    enclave_file: Path
+    enclave_type: str
+    workspace: Path
+    constitution: Path
+
+    # Cryptographic material of the member
+    member_private_key: crypto.Pem
+    member_cert: crypto.Pem
+    encryption_private_key: crypto.Pem
+
+    # Background thread on which an asyncio event loop runs
+    thread: threading.Thread
+    loop: asyncio.AbstractEventLoop
+
+    # Events used to communicate from the main thread to the asyncio thread.
+    # These must not be set directly from the main thread, but instead using
+    # `loop.call_soon_threadsafe`
+    shutdown_request: asyncio.Event
+
+    # State used to communicate from the asyncio thread back to the main thread.
+    # The condition variable is signaled whenever these change.
+    cond: threading.Condition
+    ready: bool  # True once the service is accepting connections
+    thread_exception: Optional[BaseException]
+
+    def __init__(
+        self,
+        binary: str,
+        rpc_port: int,
+        node_port: int,
+        enclave_type: str,
+        enclave_file: Path,
+        workspace: Path,
+        constitution: Path,
+    ):
+        self.binary = binary
+        self.rpc_port = rpc_port
+        self.node_port = node_port
+        self.enclave_type = enclave_type
+        self.enclave_file = enclave_file.absolute()
+        self.workspace = workspace.absolute()
+        self.constitution = constitution.absolute()
+
+        if not self.enclave_file.exists():
+            raise ValueError(f"Enclave file at {self.enclave_file} does not exist")
+
+        self.member_private_key, _ = crypto.generate_keypair(kty="ec")
+        self.member_cert = crypto.generate_cert(self.member_private_key)
+        self.encryption_private_key, encryption_public_key = crypto.generate_keypair(
+            kty="rsa"
+        )
+
+        self.workspace.joinpath("member0_privk.pem").write_text(self.member_private_key)
+        self.workspace.joinpath("member0_cert.pem").write_text(self.member_cert)
+        self.workspace.joinpath("member0_enc_privk.pem").write_text(
+            self.encryption_private_key
+        )
+        self.workspace.joinpath("member0_enc_pubk.pem").write_text(
+            encryption_public_key
+        )
+
+        self.thread = threading.Thread(target=self._execute)
+
+        self.cond = threading.Condition()
+        self.ready = False
+        self.thread_exception = None
+
+        self.loop = asyncio.new_event_loop()
+
+        # Event objects must be created on the loop they will be accessed from.
+        async def create_event():
+            return asyncio.Event()
+
+        self.shutdown_request = self.loop.run_until_complete(create_event())
+
+    def __enter__(self):
+        self.thread.start()
+
+        try:
+            with self.cond:
+                while not self.ready:
+                    self.cond.wait()
+                    if self.thread_exception is not None:
+                        raise self.thread_exception
+
+        except:
+            # This is to handle the case where the wait is interrupted,
+            # by a KeyboardInterrupt for example.
+            self.loop.call_soon_threadsafe(self.shutdown_request.set)
+            self.thread.join()
+            raise
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            self.loop.call_soon_threadsafe(self.shutdown_request.set)
+        finally:
+            self.thread.join()
+
+        if self.thread_exception is not None:
+            raise self.thread_exception
+
+    def _execute(self):
+        """
+        Entrypoint for the background thread.
+        """
+        try:
+            self.loop.run_until_complete(self._start_service())
+        except BaseException as e:
+            with self.cond:
+                self.thread_exception = e
+                self.cond.notify_all()
+
+    async def _start_service(self):
+        """
+        Run cchost in a loop, handling shutdown requests.
+        """
+        self._populate_workspace()
+
+        try:
+            await self._start_process()
+        except aiotools.TaskGroupError as e:
+            if match_taskgroup_error(e, ShutdownRequestException):
+                return
+            else:
+                raise
+
+    async def _start_process(self):
+        process = await asyncio.create_subprocess_exec(
+            self.binary,
+            "--config",
+            self.workspace / "config.json",
+            cwd=self.workspace,
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={
+                **os.environ,
+                # This is needed for the attested fetch script to know where
+                # to contact the CCF service. The script is started by cchost,
+                # so it inherits any of cchost's environment variables.
+                "CCF_SERVICE_PORT": str(self.rpc_port),
+            },
+        )
+
+        # We use two nested task groups. The reason for this is we want the log
+        # processing tasks to keep running all the way until after the process
+        # has exited.
+        async with aiotools.TaskGroup() as tg_logs:
+            tg_logs.create_task(self._process_stdout(process.stdout))
+            tg_logs.create_task(self._process_stderr(process.stderr))
+
+            try:
+                async with aiotools.TaskGroup() as tg:
+                    tg.create_task(self._wait_ready())
+
+                    # This method will raise exceptions when requests come
+                    # in from the main thread. The exceptions will cancel the
+                    # other tasks and be handled by the caller.
+                    tg.create_task(self._handle_shutdown(process))
+
+                    await process.wait()
+                    raise UnexpectedExitException()
+
+            finally:
+                # We want to kill the process whatever happens.
+                try:
+                    process.terminate()
+                    try:
+                        LOG.info("Waiting for cchost process to terminate gracefully")
+                        await asyncio.wait_for(process.wait(), timeout=5)
+                    except asyncio.TimeoutError:
+                        LOG.info(
+                            "cchost process failed to terminate gracefully, sending SIGKILL"
+                        )
+                        process.kill()
+                        await process.wait()
+
+                except ProcessLookupError:
+                    # This can happen if the process is already dead.
+                    pass
+
+    async def _handle_shutdown(self, process):
+        await self.shutdown_request.wait()
+        raise ShutdownRequestException()
+
+    async def _process_stdout(self, stream):
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line)
+            except json.decoder.JSONDecodeError:
+                LOG.error("Log line is not JSON: {}", line)
+            else:
+                # Translate the CCF log message into seomthing usable by loguru.
+                # We map the filename to function, even though loguru supports filenames,
+                # because the latter isn't printed by default.
+                # We use the presence of an enclave timestamp (e_ts) to distinguish
+                # between host and enclave messages.
+                level = msg["level"].upper()
+                context = {"function": msg["file"], "line": msg["number"]}
+                if "e_ts" in msg:
+                    context["name"] = "enclave"
+                else:
+                    context["name"] = "host"
+                LOG.patch(lambda r: r.update(context)).log(level, "{}", msg["msg"])
+
+    async def _process_stderr(self, stream):
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            LOG.warning("{}", line)
+
+    async def _wait_ready(self):
+        """
+        Monitor the service and set the `ready` flag once it accepts connections.
+        """
+        ssl_ctx = ssl.SSLContext()
+        while True:
+            try:
+                await asyncio.open_connection("127.0.0.1", self.rpc_port, ssl=ssl_ctx)
+                break
+            except OSError:
+                pass
+
+            await asyncio.sleep(0.5)
+
+        with self.cond:
+            self.ready = True
+            self.cond.notify_all()
+
+    def _populate_workspace(self):
+        service_cert = self.workspace / "service_cert.pem"
+
+        ENCLAVE_TYPES = {
+            "virtual": "Virtual",
+            "release": "Release",
+        }
+
+        config = {
+            "enclave": {
+                "file": str(self.enclave_file),
+                "type": ENCLAVE_TYPES[self.enclave_type],
+            },
+            "network": {
+                "node_to_node_interface": {"bind_address": f"0.0.0.0:{self.node_port}"},
+                "rpc_interfaces": {
+                    "interface_name": {
+                        "bind_address": f"0.0.0.0:{self.rpc_port}",
+                        "published_address": "ccf.dummy.com:12345",
+                    }
+                },
+            },
+            "logging": {"format": "Json", "host_level": "Trace"},
+            "command": {
+                "type": "Start",
+                "service_certificate_file": str(service_cert),
+                "start": {
+                    "constitution_files": [str(f) for f in self._constitution_files()],
+                    "members": [
+                        {
+                            "certificate_file": str(
+                                self.workspace / "member0_cert.pem"
+                            ),
+                            "encryption_public_key_file": str(
+                                self.workspace / "member0_enc_pubk.pem"
+                            ),
+                        }
+                    ],
+                },
+            },
+        }
+
+        with open(self.workspace / "config.json", "w") as f:
+            json.dump(config, f)
+
+    def _constitution_files(self) -> List[Path]:
+        return [
+            self.constitution / "validate.js",
+            self.constitution / "apply.js",
+            self.constitution / "resolve.js",
+            self.constitution / "actions.js",
+            self.constitution / "scitt.js",
+        ]
+
+
+def get_enclave_path(enclave_type, enclave_package) -> Path:
+    ENCLAVE_SUFFIX = {
+        "virtual": "virtual.so",
+        "release": "enclave.so.signed",
+    }
+    return Path(f"{enclave_package}.{ENCLAVE_SUFFIX[enclave_type]}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cchost", default="/opt/ccf/bin/cchost", help="Path to the cchost binary"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port on which cchost will listen for RPC",
+    )
+    parser.add_argument(
+        "--node-port",
+        type=int,
+        default=8001,
+        help="Port on which cchost will listen for node to node communication",
+    )
+    parser.add_argument(
+        "--enclave-type",
+        "-e",
+        default="virtual",
+        help="Type of enclave used when starting cchost",
+    )
+    parser.add_argument(
+        "--package",
+        "-p",
+        default="/tmp/scitt/lib/libscitt",
+        help="The enclave package to load",
+    )
+    parser.add_argument(
+        "--constitution",
+        type=Path,
+        default="/tmp/scitt/share/scitt/constitution",
+        help="Path to the directory containing the initial constitution",
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default="workspace",
+        help="Path to a workspace directory",
+    )
+
+    args = parser.parse_args()
+    if args.workspace.exists():
+        shutil.rmtree(args.workspace)
+    args.workspace.mkdir()
+
+    enclave_file = get_enclave_path(args.enclave_type, args.package)
+    with CCHost(
+        args.cchost,
+        args.port,
+        args.node_port,
+        args.enclave_type,
+        enclave_file,
+        workspace=args.workspace,
+        constitution=args.constitution,
+    ) as cchost:
+        while True:
+            signal.pause()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -245,7 +245,7 @@ class CCHost:
             except json.decoder.JSONDecodeError:
                 LOG.error("Log line is not JSON: {}", line)
             else:
-                # Translate the CCF log message into seomthing usable by loguru.
+                # Translate the CCF log message into something usable by loguru.
                 # We map the filename to function, even though loguru supports filenames,
                 # because the latter isn't printed by default.
                 # We use the presence of an enclave timestamp (e_ts) to distinguish

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -25,9 +25,8 @@ from .did_web_server import DIDWebServer
 
 
 class ManagedCCHostFixtures:
-    def __init__(self, binary, port, enclave_type, enclave_file, constitution):
+    def __init__(self, binary, enclave_type, enclave_file, constitution):
         self.binary = binary
-        self.port = port
         self.enclave_type = enclave_type
         self.enclave_file = enclave_file
         self.constitution = constitution
@@ -43,8 +42,6 @@ class ManagedCCHostFixtures:
         workspace = tmp_path_factory.mktemp("workspace")
         cchost = CCHost(
             self.binary,
-            self.port,
-            self.port + 1,
             self.enclave_type,
             self.enclave_file,
             workspace=workspace,
@@ -119,12 +116,6 @@ def pytest_addoption(parser):
         help="Path to the cchost binary. Requires --start-cchost.",
     )
     parser.addoption(
-        "--cchost-port",
-        type=int,
-        default=8000,
-        help="Port on which cchost will listen. Requires --start-cchost.",
-    )
-    parser.addoption(
         "--enclave-type",
         default="virtual",
         help="Type of enclave used when starting cchost. Requires --start-cchost.",
@@ -150,15 +141,12 @@ def pytest_configure(config):
 
     if config.getoption("--start-cchost"):
         binary = config.getoption("--cchost-binary")
-        port = config.getoption("--cchost-port")
         enclave_package = config.getoption("--enclave-package")
         enclave_type = config.getoption("--enclave-type")
         constitution = config.getoption("--constitution")
         enclave_file = get_enclave_path(enclave_type, enclave_package)
         config.pluginmanager.register(
-            ManagedCCHostFixtures(
-                binary, port, enclave_type, enclave_file, constitution
-            )
+            ManagedCCHostFixtures(binary, enclave_type, enclave_file, constitution)
         )
     else:
         config.pluginmanager.register(ExternalLedgerFixtures())

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -1,7 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import itertools
 import os
+import time
+from contextlib import contextmanager
 from http import HTTPStatus
 from pathlib import Path
 
@@ -10,29 +13,165 @@ import pytest
 from pyscitt import governance
 from pyscitt.client import Client
 
+from .cchost import CCHost, get_enclave_path
 from .did_web_server import DIDWebServer
 
 # This file defines a collection of pytest fixtures used to manage and
 # interact with the SCITT ledger.
+#
+# It defines three pytest plugins, ManagedCCHostFixtures, ExternalLedgerFixtures
+# and Fixtures. The first two provide the same functionality, but one starts a
+# cchost process whereas the other connects to an already running service.
 
 
-@pytest.fixture(scope="session")
-def service_url():
-    return os.environ.get("CCF_URL", "https://127.0.0.1:8000")
+class ManagedCCHostFixtures:
+    def __init__(self, binary, port, enclave_type, enclave_file, constitution):
+        self.binary = binary
+        self.port = port
+        self.enclave_type = enclave_type
+        self.enclave_file = enclave_file
+        self.constitution = constitution
+
+    @pytest.fixture(scope="session")
+    def cchost(self, tmp_path_factory):
+        """
+        Start a managed SCITT service, using cchost.
+
+        The service will keep running for the entire test session, and therefore
+        shared among tests.
+        """
+        workspace = tmp_path_factory.mktemp("workspace")
+        cchost = CCHost(
+            self.binary,
+            self.port,
+            self.port + 1,
+            self.enclave_type,
+            self.enclave_file,
+            workspace=workspace,
+            constitution=self.constitution,
+        )
+        with cchost:
+            # There's a bit of setup involved before we can use this service.
+            # When using an external ledger we assume this has been done already,
+            # but in this case we need to do it here.
+            client = Client(
+                f"https://127.0.0.1:{cchost.rpc_port}",
+                development=True,
+                member_auth=(cchost.member_cert, cchost.member_private_key),
+            )
+            client.governance.activate_member()
+
+            network = client.get("node/network").json()
+            proposal = governance.transition_service_to_open_proposal(
+                network["service_certificate"]
+            )
+            client.governance.propose(proposal, must_pass=True)
+            client.get(
+                "/app/parameters",
+                retry_on=[(HTTPStatus.NOT_FOUND, "FrontendNotOpen")],
+            )
+
+            yield cchost
+
+    @pytest.fixture(scope="session")
+    def service_url(self, cchost):
+        return f"https://127.0.0.1:{cchost.rpc_port}"
+
+    @pytest.fixture(scope="session")
+    def member_auth(self, cchost):
+        return (cchost.member_cert, cchost.member_private_key)
+
+    @pytest.fixture(scope="session")
+    def member_auth_path(self, member_auth, tmp_path_factory):
+        path = tmp_path_factory.mktemp("member")
+        path.joinpath("member0_cert.pem").write_text(member_auth[0])
+        path.joinpath("member0_privk.pem").write_text(member_auth[1])
+        return (path.joinpath("member0_cert.pem"), path.joinpath("member0_privk.pem"))
 
 
-@pytest.fixture(scope="session")
-def member_auth_path():
-    workspace_dir = Path("workspace") / "sandbox_common"
-    return (
-        workspace_dir.joinpath("member0_cert.pem"),
-        workspace_dir.joinpath("member0_privk.pem"),
+class ExternalLedgerFixtures:
+    @pytest.fixture(scope="session")
+    def service_url(self):
+        return os.environ.get("CCF_URL", "https://127.0.0.1:8000")
+
+    @pytest.fixture(scope="session")
+    def member_auth_path(self):
+        workspace_dir = Path("workspace")
+        return (
+            workspace_dir.joinpath("member0_cert.pem"),
+            workspace_dir.joinpath("member0_privk.pem"),
+        )
+
+    @pytest.fixture(scope="session")
+    def member_auth(self, member_auth_path):
+        return (member_auth_path[0].read_text(), member_auth_path[1].read_text())
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--start-cchost",
+        action="store_true",
+        help="Start a cchost process managed by the test framework",
+    )
+    parser.addoption(
+        "--cchost-binary",
+        default="/opt/ccf/bin/cchost",
+        help="Path to the cchost binary. Requires --start-cchost.",
+    )
+    parser.addoption(
+        "--cchost-port",
+        type=int,
+        default=8000,
+        help="Port on which cchost will listen. Requires --start-cchost.",
+    )
+    parser.addoption(
+        "--enclave-type",
+        default="virtual",
+        help="Type of enclave used when starting cchost. Requires --start-cchost.",
+    )
+    parser.addoption(
+        "--enclave-package",
+        default="/tmp/scitt/lib/libscitt",
+        help="The enclave package to load. Requires --start-cchost.",
+    )
+    parser.addoption(
+        "--constitution",
+        type=Path,
+        default="/tmp/scitt/share/scitt/constitution",
+        help="Path to the directory containing the constitution. Requires --start-cchost.",
     )
 
 
-@pytest.fixture(scope="session")
-def member_auth(member_auth_path):
-    return (member_auth_path[0].read_text(), member_auth_path[1].read_text())
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "needs_cchost: only run test if cchost is managed by the test framework.",
+    )
+
+    if config.getoption("--start-cchost"):
+        binary = config.getoption("--cchost-binary")
+        port = config.getoption("--cchost-port")
+        enclave_package = config.getoption("--enclave-package")
+        enclave_type = config.getoption("--enclave-type")
+        constitution = config.getoption("--constitution")
+        enclave_file = get_enclave_path(enclave_type, enclave_package)
+        config.pluginmanager.register(
+            ManagedCCHostFixtures(
+                binary, port, enclave_type, enclave_file, constitution
+            )
+        )
+    else:
+        config.pluginmanager.register(ExternalLedgerFixtures())
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--start-cchost"):
+        needs_cchost_skip = pytest.mark.skip(
+            reason="Test requires a managed cchost process"
+        )
+        for item in items:
+            if "needs_cchost" in item.keywords:
+                item.add_marker(needs_cchost_skip)
 
 
 @pytest.fixture(scope="class")

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -40,12 +40,21 @@ class ManagedCCHostFixtures:
         shared among tests.
         """
         workspace = tmp_path_factory.mktemp("workspace")
+
+        constitution_files = [
+            self.constitution / "validate.js",
+            self.constitution / "apply.js",
+            self.constitution / "resolve.js",
+            self.constitution / "actions.js",
+            self.constitution / "scitt.js",
+        ]
+
         cchost = CCHost(
             self.binary,
             self.enclave_type,
             self.enclave_file,
             workspace=workspace,
-            constitution=self.constitution,
+            constitution=constitution_files,
         )
         with cchost:
             # There's a bit of setup involved before we can use this service.

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,4 @@ locust
 httpx
 pytest
 loguru
+aiotools

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -555,11 +555,6 @@ class TestUpdateScittConstitution:
         ):
             update_scitt_constitution("")
 
-    # sandbox.sh uses a special consitution that accepts proposals without even
-    # waiting for a single vote, so we have no way of detecting this race
-    # condition. The test is therefore disabled when not running with a managed
-    # cchost.
-    @pytest.mark.needs_cchost
     def test_race_condition(self, update_scitt_constitution, monkeypatch):
         # We want to make two concurrent modifications to the constitution, and
         # make sure update_scitt_constitution detects this.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -261,7 +261,7 @@ def test_adhoc_signer(run, tmp_path: Path):
     )
 
 
-@pytest.mark.prefix_tree
+@pytest.mark.needs_prefix_tree
 def test_prefix_tree(run, tmp_path: Path):
     (tmp_path / "claims.json").write_text(json.dumps({"foo": "bar"}))
 
@@ -555,10 +555,11 @@ class TestUpdateScittConstitution:
         ):
             update_scitt_constitution("")
 
-    @pytest.mark.xfail(
-        reason="Test does not work with sandbox.sh, only cchost",
-        raises=pytest.fail.Exception,
-    )
+    # sandbox.sh uses a special consitution that accepts proposals without even
+    # waiting for a single vote, so we have no way of detecting this race
+    # condition. The test is therefore disabled when not running with a managed
+    # cchost.
+    @pytest.mark.needs_cchost
     def test_race_condition(self, update_scitt_constitution, monkeypatch):
         # We want to make two concurrent modifications to the constitution, and
         # make sure update_scitt_constitution detects this.

--- a/test/test_prefix_tree.py
+++ b/test/test_prefix_tree.py
@@ -8,7 +8,7 @@ from pyscitt import crypto
 from pyscitt.client import ServiceError
 
 
-@pytest.mark.prefix_tree
+@pytest.mark.needs_prefix_tree
 def test_prefix_tree(did_web, client):
     feed = "hello"
     identity = did_web.create_identity()
@@ -77,7 +77,7 @@ def test_prefix_tree(did_web, client):
     reason="Test requires an isolated empty service, which the infrastructure doesn't support yet",
     raises=pytest.fail.Exception,
 )
-@pytest.mark.prefix_tree
+@pytest.mark.needs_prefix_tree
 def test_empty_prefix_tree(client):
     """Before any flush has been committed, fetching the prefix tree receipt returns a graceful error."""
 


### PR DESCRIPTION
We replace sandbox.sh with our own Python implementation, in `test/infra/cchost.py`.

The functional tests can be called with a `--start-cchost`, in which case the test infrastructure will launch a start and configure a new cchost process for the duration of the test session. This provides tighter and more powerful integration with the tests and opens up the door for new possibilities, such as starting an isolated cchost process for certain tests or performing a disaster recovery on the service. It is also friendlier to use, as a single command and console output manages everything.

It is still possible to run the tests against an external service, which is necessary to run the Docker based test jobs. While most test support this scenario, in the future individual tests may be annotated with `needs_cchost` and will be skipped if using an external service.

The `cchost.py` file may also be executed as a standalone script, which is useful for local development. The `run.sh` script has been updated to use this script instead of `sandbox.sh`.

Fixes #6.