### PR TITLE
Return a nice error when no prefix tree has been committed yet.

### DIFF
--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -36,6 +36,7 @@ namespace scitt
     const std::string QueryParameterError = "QueryParameterError";
     const std::string PayloadTooLarge = "PayloadTooLarge";
     const std::string UnknownFeed = "UnknownFeed";
+    const std::string NoPrefixTree = "NoPrefixTree";
   } // namespace errors
 
 } // namespace scitt

--- a/app/src/http_error.h
+++ b/app/src/http_error.h
@@ -30,6 +30,13 @@ namespace scitt
     {}
   };
 
+  struct NotFoundError : public HTTPError
+  {
+    NotFoundError(std::string code, std::string msg) :
+      HTTPError(HTTP_STATUS_NOT_FOUND, code, msg)
+    {}
+  };
+
   struct UnauthorizedError : public HTTPError
   {
     UnauthorizedError(std::string code, std::string msg) :

--- a/app/src/prefix_tree/frontend.h
+++ b/app/src/prefix_tree/frontend.h
@@ -97,10 +97,8 @@ namespace scitt
       auto entry = index->get(issuer, feed);
       if (!entry)
       {
-        throw HTTPError(
-          HTTP_STATUS_NOT_FOUND,
-          errors::UnknownFeed,
-          "No claim found for given issuer and feed");
+        throw NotFoundError(
+          errors::UnknownFeed, "No claim found for given issuer and feed");
       }
 
       auto info = fetch_tree_receipt(*ctx.rpc_ctx, entry->prefix_tree_seqno);
@@ -120,7 +118,14 @@ namespace scitt
 
     void current(ccf::endpoints::ReadOnlyEndpointContext& ctx)
     {
-      auto [seqno, tree] = index->current();
+      auto current = index->current();
+      if (!current)
+      {
+        throw NotFoundError(
+          errors::NoPrefixTree, "No prefix tree has been committed yet.");
+      }
+
+      auto [seqno, tree] = *current;
 
       auto info = fetch_tree_receipt(*ctx.rpc_ctx, seqno);
       if (!info)

--- a/pyscitt/pyscitt/prefix_tree.py
+++ b/pyscitt/pyscitt/prefix_tree.py
@@ -3,6 +3,7 @@
 
 import hashlib
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import TYPE_CHECKING, List, Union
 
 import cbor2
@@ -196,12 +197,14 @@ class PrefixTreeClient:
         # process the commit.
         #
         # Query the indexer until its upper bound is greater or equal to what
-        # we got when flushing.
+        # we got when flushing. We also need to handle the NoPrefixTree 404 error,
+        # which can happen on a fresh service.
         self.client.get_historical(
             "/app/prefix_tree",
             retry_on=[
+                (HTTPStatus.NOT_FOUND, "NoPrefixTree"),
                 lambda r: r.is_success
-                and not is_indexed(r.content, info["upper_bound"])
+                and not is_indexed(r.content, info["upper_bound"]),
             ],
         )
         return info

--- a/test/test_prefix_tree.py
+++ b/test/test_prefix_tree.py
@@ -79,3 +79,23 @@ def test_prefix_tree(tmp_path: Path):
         receipt.verify(second_claims, fixture.service_parameters)
         with pytest.raises(InvalidSignature):
             receipt.verify(first_claims, fixture.service_parameters)
+
+
+@pytest.mark.xfail(
+    reason="Test requires an isolated empty service, which the infrastructure doesn't support yet",
+    raises=pytest.fail.Exception,
+)
+@pytest.mark.prefix_tree
+def test_empty_prefix_tree(tmp_path):
+    """Before any flush has been committed, fetching the prefix tree receipt returns a graceful error."""
+
+    with SCITTFixture(tmp_path) as fixture:
+        with pytest.raises(
+            ServiceError, match="NoPrefixTree: No prefix tree has been committed yet"
+        ):
+            fixture.client.get_historical("/app/prefix_tree")
+
+        fixture.client.prefix_tree.flush()
+
+        # Now we're okay since we have at least one PT root committed.
+        fixture.client.get_historical("/app/prefix_tree")


### PR DESCRIPTION
If no prefix tree commit has been indexed yet, the field in the indexing strategy that stores the seqno is 0. Previously the frontend would get this sequence number and attempt to perform a historical query on it, which led to CCF throwing an exception.

Instead we detect that case and return a nullopt from the indexing strategy, which gets turned into a 404 to the client.

This was only an issue for the top-level `/app/prefix_tree` endpoint. On the `/app/prefix_tree/{issuer}/{feed}` endpoint, looking up a receipt in an empty/missing prefix tree always fails anyway, and was already returning a 404 error.

A test for this is added, but is marked as XFAIL, as it cannot currently be executed reliably since this only happens on an empty service. Once the test framework supports starting isolated services for individual test cases, we can remove the XFAIL marker.

In the future we may want to automatically issue a flush for the empty prefix tree on service startup. This won't eliminate the problem completely since there will be a window of time between the automatic initial flush and it getting indexed where no prefix tree receipt is available, but we would consider that a transient IndexingInProgress error instead.