### PR TITLE
Add an isolated_test marker for functional tests.

### DIFF
--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -60,7 +60,7 @@ class ManagedCCHostFixtures:
         Start a managed SCITT service, using cchost.
 
         This fixture returns a function, which creates a new service everytime
-        it is called. Test should bot use this fixture directly. Instead the
+        it is called. Tests should not use this fixture directly. Instead the
         cchost (or client) fixture should be used, which provides access to an
         already running instance.
         """

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -384,10 +384,14 @@ def test_registration_info(run, tmp_path: Path):
     }
 
 
+@pytest.mark.isolated_test
 class TestUpdateScittConstitution:
-    # We make an effort to save and restore the constitution, but if something
-    # goes wrong during these tests we may break the service and render it unusable.
-    # Subsequent tests would likely fail if this were the case.
+    # These tests run in an isolated cchost process. This ensures that if
+    # something goes wrong with the test and leaves the service with an invalid
+    # constitution, the other tests can carry on unaffected.
+    #
+    # The isolated process is shared by the entire class though, so one broken
+    # test could still affect other tests of this class.
 
     @pytest.fixture(autouse=True)
     def original_constitution(self, run, tmp_path_factory):

--- a/test/test_prefix_tree.py
+++ b/test/test_prefix_tree.py
@@ -73,10 +73,9 @@ def test_prefix_tree(did_web, client):
         receipt.verify(first_claims, service_parameters)
 
 
-@pytest.mark.xfail(
-    reason="Test requires an isolated empty service, which the infrastructure doesn't support yet",
-    raises=pytest.fail.Exception,
-)
+# This test only works on an isolated cchost instance, since we require the service to be blank.
+@pytest.mark.isolated_test
+@pytest.mark.needs_cchost
 @pytest.mark.needs_prefix_tree
 def test_empty_prefix_tree(client):
     """Before any flush has been committed, fetching the prefix tree receipt returns a graceful error."""


### PR DESCRIPTION
If a test class is annotated with the marker, a separate cchost process is started for this test class. This provides isolation between tests, which is useful either if the test is deemed risky and can leave the service in an irrecoverably bad state (eg. by modifying the constitution), or if the test depends on having an empty ledger at start.

Note that when using an external service, it is impossible to provide isolation and even tests marked with isolated_test will use the shared instance. The marker can be combined with the needs_cchost marker to skip the test in these cases where isolation cannot be guaranteed.