### PR TITLE
Switch imports from cose to pycose.

### DIFF
--- a/pyscitt/pyscitt/cli/prefix_tree.py
+++ b/pyscitt/pyscitt/cli/prefix_tree.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from cose.messages import CoseMessage
+from pycose.messages import CoseMessage
 
 from .. import crypto, prefix_tree
 from ..client import Client

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -13,31 +13,9 @@ from uuid import uuid4
 warnings.filterwarnings("ignore", category=Warning)
 
 import cbor2
-import cose.algorithms
-import cose.headers
 import jwt
-from cose.keys.curves import P256, P384, P521, Ed25519
-from cose.keys.ec2 import EC2Key
-from cose.keys.keyparam import (
-    EC2KpCurve,
-    EC2KpD,
-    EC2KpX,
-    EC2KpY,
-    OKPKpCurve,
-    OKPKpD,
-    OKPKpX,
-    RSAKpD,
-    RSAKpDP,
-    RSAKpDQ,
-    RSAKpE,
-    RSAKpN,
-    RSAKpP,
-    RSAKpQ,
-    RSAKpQInv,
-)
-from cose.keys.okp import OKPKey
-from cose.keys.rsa import RSAKey
-from cose.messages import CoseMessage, Sign1Message
+import pycose.algorithms
+import pycose.headers
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
@@ -63,6 +41,28 @@ from cryptography.hazmat.primitives.serialization import (
 )
 from cryptography.x509 import load_der_x509_certificate, load_pem_x509_certificate
 from cryptography.x509.oid import NameOID
+from pycose.keys.curves import P256, P384, P521, Ed25519
+from pycose.keys.ec2 import EC2Key
+from pycose.keys.keyparam import (
+    EC2KpCurve,
+    EC2KpD,
+    EC2KpX,
+    EC2KpY,
+    OKPKpCurve,
+    OKPKpD,
+    OKPKpX,
+    RSAKpD,
+    RSAKpDP,
+    RSAKpDQ,
+    RSAKpE,
+    RSAKpN,
+    RSAKpP,
+    RSAKpQ,
+    RSAKpQInv,
+)
+from pycose.keys.okp import OKPKey
+from pycose.keys.rsa import RSAKey
+from pycose.messages import CoseMessage, Sign1Message
 
 from .receipt import Receipt
 
@@ -684,13 +684,13 @@ def sign_claimset(
     registration_info: RegistrationInfo = {},
 ) -> bytes:
     headers = {}
-    headers[cose.headers.Algorithm] = signer.algorithm
-    headers[cose.headers.ContentType] = content_type
+    headers[pycose.headers.Algorithm] = signer.algorithm
+    headers[pycose.headers.ContentType] = content_type
 
     if signer.x5c is not None:
-        headers[cose.headers.X5chain] = [cert_pem_to_der(x5) for x5 in signer.x5c]
+        headers[pycose.headers.X5chain] = [cert_pem_to_der(x5) for x5 in signer.x5c]
     if signer.kid is not None:
-        headers[cose.headers.KID] = signer.kid.encode("utf-8")
+        headers[pycose.headers.KID] = signer.kid.encode("utf-8")
     if signer.issuer is not None:
         headers[COSE_HEADER_PARAM_ISSUER] = signer.issuer
     if feed is not None:

--- a/pyscitt/pyscitt/prefix_tree.py
+++ b/pyscitt/pyscitt/prefix_tree.py
@@ -7,8 +7,8 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, List, Union
 
 import cbor2
-from cose.messages import CoseMessage, Sign1Message
-from cose.messages.cosebase import CoseBase
+from pycose.messages import CoseMessage, Sign1Message
+from pycose.messages.cosebase import CoseBase
 
 if TYPE_CHECKING:
     from .client import BaseClient

--- a/pyscitt/pyscitt/receipt.py
+++ b/pyscitt/pyscitt/receipt.py
@@ -9,11 +9,11 @@ from typing import Any
 
 import cbor2
 import ccf.receipt
-from cose.messages import Sign1Message
-from cose.messages.cosebase import CoseBase
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509 import load_der_x509_certificate
+from pycose.messages import Sign1Message
+from pycose.messages.cosebase import CoseBase
 
 HEADER_PARAM_TREE_ALGORITHM = "tree_alg"
 TREE_ALGORITHM_CCF = "CCF"

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -16,7 +16,7 @@ setup(
         "httpx",
         "cryptography",
         "cbor2",
-        "cose>=0.9.dev8",
+        "pycose>=1.0.1",
         "ccf>=2.0.0",
         "pyjwt",
     ],

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,8 +7,8 @@ import shlex
 from pathlib import Path
 
 import pytest
-from cose.messages import CoseMessage
 from loguru import logger as LOG
+from pycose.messages import CoseMessage
 
 from infra.did_web_server import DIDWebServer
 from pyscitt import crypto, did


### PR DESCRIPTION
Starting with 1.0, pycose is now published under that very same name, rather than the previous cose name.

See https://github.com/TimothyClaeys/pycose/releases/tag/v1.0.0

Fixes #28