### PR TITLE
Add iss and kid fields to receipts.

### DIFF
--- a/app/constitution/scitt.js
+++ b/app/constitution/scitt.js
@@ -34,6 +34,8 @@ actions.set("set_scitt_configuration",
           checkType(args.configuration.authentication.jwt.required_claims, "object?", "configuration.authentication.jwt.required_claims");
         }
       }
+
+      checkType(args.configuration.service_identity, "string?", "configuration.service_identity");
     },
     function(args) {
       ccf.kv["public:ccf.gov.scitt.configuration"].set(getSingletonKvKey(), ccf.jsonCompatibleToBuf(args.configuration));

--- a/app/constitution/scitt.js
+++ b/app/constitution/scitt.js
@@ -35,7 +35,7 @@ actions.set("set_scitt_configuration",
         }
       }
 
-      checkType(args.configuration.service_identity, "string?", "configuration.service_identity");
+      checkType(args.configuration.service_identifier, "string?", "configuration.service_identifier");
     },
     function(args) {
       ccf.kv["public:ccf.gov.scitt.configuration"].set(getSingletonKvKey(), ccf.jsonCompatibleToBuf(args.configuration));

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -127,6 +127,10 @@ namespace scitt
 
     Policy policy = {};
     Authentication authentication = {};
+
+    // The long-term stable identity of this service, as a DID.
+    // If set, it will be used to populated the issuer field of receipts
+    std::optional<std::string> service_identity;
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration::Policy);
@@ -146,7 +150,8 @@ namespace scitt
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration);
   DECLARE_JSON_REQUIRED_FIELDS(Configuration);
-  DECLARE_JSON_OPTIONAL_FIELDS(Configuration, policy, authentication);
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    Configuration, policy, authentication, service_identity);
 
   // Tables
 

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -129,7 +129,7 @@ namespace scitt
     Authentication authentication = {};
 
     // The long-term stable identity of this service, as a DID.
-    // If set, it will be used to populated the issuer field of receipts
+    // If set, it will be used to populate the issuer field of receipts
     std::optional<std::string> service_identity;
   };
 

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -128,9 +128,9 @@ namespace scitt
     Policy policy = {};
     Authentication authentication = {};
 
-    // The long-term stable identity of this service, as a DID.
+    // The long-term stable identifier of this service, as a DID.
     // If set, it will be used to populate the issuer field of receipts
-    std::optional<std::string> service_identity;
+    std::optional<std::string> service_identifier;
   };
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration::Policy);
@@ -151,7 +151,7 @@ namespace scitt
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration);
   DECLARE_JSON_REQUIRED_FIELDS(Configuration);
   DECLARE_JSON_OPTIONAL_FIELDS(
-    Configuration, policy, authentication, service_identity);
+    Configuration, policy, authentication, service_identifier);
 
   // Tables
 

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -173,7 +173,7 @@ namespace scitt
         // time being, the kid is the same as the service certificate hash.
         // Eventually, this may change to become eg. an RFC7638 JWK thumbprint.
         std::vector<uint8_t> sign_protected;
-        if (cfg.service_identity.has_value())
+        if (cfg.service_identifier.has_value())
         {
           // TODO: clarify the format of KID. We currently use the hex digest,
           // encoded in ASCII. Since the COSE field is a bstr, we could skip the
@@ -185,7 +185,7 @@ namespace scitt
           };
 
           sign_protected = create_countersign_protected_header(
-            time, *cfg.service_identity, kid, service_cert_digest);
+            time, *cfg.service_identifier, kid, service_cert_digest);
         }
         else
         {

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -166,10 +166,32 @@ namespace scitt
         auto service_info = service->get().value();
         auto service_cert = service_info.cert;
         auto service_cert_der = crypto::cert_pem_to_der(service_cert);
-        auto service_id = crypto::Sha256Hash(service_cert_der).hex_str();
+        auto service_cert_digest =
+          crypto::Sha256Hash(service_cert_der).hex_str();
 
-        auto sign_protected =
-          create_countersign_protected_header(time, service_id);
+        // Take the service's DID from the configuration, if present. For the
+        // time being, the kid is the same as the service certificate hash.
+        // Eventually, this may change to become eg. an RFC7638 JWK thumbprint.
+        std::vector<uint8_t> sign_protected;
+        if (cfg.service_identity.has_value())
+        {
+          // TODO: clarify the format of KID. We currently use the hex digest,
+          // encoded in ASCII. Since the COSE field is a bstr, we could skip the
+          // hex/ASCII encoding part of it and embed the digest directly, but
+          // this would not be valid as-is in the corresponding JWK.
+          std::span<const uint8_t> kid = {
+            reinterpret_cast<const uint8_t*>(service_cert_digest.data()),
+            service_cert_digest.size(),
+          };
+
+          sign_protected = create_countersign_protected_header(
+            time, *cfg.service_identity, kid, service_cert_digest);
+        }
+        else
+        {
+          sign_protected = create_countersign_protected_header(
+            time, std::nullopt, std::nullopt, service_cert_digest);
+        }
 
         // Compute the hash of the to-be-signed countersigning structure
         // and set it as CCF transaction claim for use in receipt validation.

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -104,20 +104,20 @@ class TestAcceptedDIDIssuers:
 
 class TestServiceIdentifier:
     @pytest.fixture
-    def claims(self, did_web):
+    def claim(self, did_web):
         identity = did_web.create_identity()
         return crypto.sign_json_claimset(identity, {"foo": "bar"})
 
-    def test_without_identifier(self, client, configure_service, claims):
+    def test_without_identifier(self, client, configure_service, claim):
         configure_service({})
 
         # By default, the service runs without a configured identity.
         # The receipts it returns have no issuer or kid.
-        receipt = client.submit_claim(claims).receipt
+        receipt = client.submit_claim(claim).receipt
         assert crypto.COSE_HEADER_PARAM_ISSUER not in receipt.phdr
         assert pycose.headers.KID not in receipt.phdr
 
-    def test_with_identifier(self, client, configure_service, claims):
+    def test_with_identifier(self, client, configure_service, claim):
         parameters = client.get_parameters()
         service_identifier = "did:web:ledger.example.com"
         configure_service({"service_identifier": service_identifier})
@@ -126,7 +126,7 @@ class TestServiceIdentifier:
         # and kid.
         # Somewhat confusingly, what the old `/app/parameters` endpoint calls the
         # "service identity" is used as a KID in the receipts.
-        receipt = client.submit_claim(claims).receipt
+        receipt = client.submit_claim(claim).receipt
         assert receipt.phdr[crypto.COSE_HEADER_PARAM_ISSUER] == service_identifier
         assert (
             receipt.phdr[pycose.headers.KID].decode("ascii") == parameters["serviceId"]

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -128,5 +128,6 @@ class TestServiceIdentifier:
         # "service identity" is used as a KID in the receipts.
         receipt = client.submit_claim(claims).receipt
         assert receipt.phdr[crypto.COSE_HEADER_PARAM_ISSUER] == service_identifier
-        assert receipt.phdr[pycose.headers.KID].decode("ascii") == parameters["serviceId"]
-
+        assert (
+            receipt.phdr[pycose.headers.KID].decode("ascii") == parameters["serviceId"]
+        )

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -114,12 +114,12 @@ def test_service_did(client, did_web, configure_service):
     assert crypto.COSE_HEADER_PARAM_ISSUER not in receipt.phdr
     assert cose.headers.KID not in receipt.phdr
 
-    service_identity = "did:web:ledger.example.com"
-    configure_service({"service_identity": service_identity})
+    service_identifier = "did:web:ledger.example.com"
+    configure_service({"service_identifier": service_identifier})
 
     # Get a new receipt. This time it should have the right issuer and kid.
     # Somewhat confusingly, what the old `/app/parameters` endpoint calls the
     # "service identity" is used as a KID in the receipts.
     receipt = client.submit_claim(claims).receipt
-    assert receipt.phdr[crypto.COSE_HEADER_PARAM_ISSUER] == service_identity
+    assert receipt.phdr[crypto.COSE_HEADER_PARAM_ISSUER] == service_identifier
     assert receipt.phdr[cose.headers.KID].decode("ascii") == parameters["serviceId"]


### PR DESCRIPTION
We're headed towards using a DID for the server's identity. This will require a few parts, but the first step is to add iss and kid fields to the receipt's protected headers.

The iss value is be copied from an optional field in the configuration file. If the field is missing, we omit the iss and kid altogether. The kid should represent the current service's certificate/public key and will change on disaster recovery. For now, we use the same value we use for service_identity, ie. the hash of the DER certificate, but may revisit this in the future (eg. a hash of just the public key).

The old service_identity field does not get removed just yet, so as to not break tooling that uses it while we are still transitioning to DIDs. In particular, pyscitt and our functional tests still depend on it.

Fixes #25 