### PR TITLE
Python: pin `ccf` package & fix dependencies

### DIFF
--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,11 +13,11 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
+        "ccf==3.0.2",
+        "cryptography==38.*", # needs to match ccf
         "httpx",
-        "cryptography",
         "cbor2",
         "pycose>=1.0.1",
-        "ccf>=2.0.0",
         "pyjwt",
     ],
 )

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -14,7 +14,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "ccf==3.0.2",
-        "cryptography==38.*", # needs to match ccf
+        "cryptography==38.*",  # needs to match ccf
         "httpx",
         "cbor2",
         "pycose>=1.0.1",


### PR DESCRIPTION
The version of the Python package of CCF is in sync with the C++ package, so we should pin it like we do for the Docker images etc.

CI is currently broken because of a new release of `cryptography` (39.x) which conflicts with the `ccf` version requirements of `==38.*`. Pinning to the same requirements specifier avoids the issue.