### PR TITLE
Unset SGX_AESM_ADDR env variable when starting cchost process

### DIFF
--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -192,6 +192,10 @@ class CCHost:
                 raise
 
     async def _start_process(self):
+        # Ensure SGX_AESM_ADDR is not set when starting cchost.
+        cchost_env = os.environ.copy()
+        cchost_env.pop("SGX_AESM_ADDR", None)
+        
         LOG.debug("Starting cchost process...")
         process = await asyncio.create_subprocess_exec(
             self.binary,
@@ -202,6 +206,7 @@ class CCHost:
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=cchost_env,
         )
 
         # We use two nested task groups. The reason for this is we want the log

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -195,7 +195,7 @@ class CCHost:
         # Ensure SGX_AESM_ADDR is not set when starting cchost.
         cchost_env = os.environ.copy()
         cchost_env.pop("SGX_AESM_ADDR", None)
-        
+
         LOG.debug("Starting cchost process...")
         process = await asyncio.create_subprocess_exec(
             self.binary,


### PR DESCRIPTION
Open Enclave fails to start when SGX_AESM_ADDR is set. This PR ensures it is not set when starting SCITT. 

SGX_AESM_ADDR not required for CCF SCITT and is described here https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-addon#overview