### PR TITLE
Remove /app prefix when making API calls.

### DIFF
--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -53,7 +53,7 @@ namespace scitt::did::web
         // typically something like 0.0.0.0, and hardcode localhost instead.
         auto [_host, port] =
           ccf::split_net_address(primary_interface.bind_address);
-        return fmt::format("https://localhost:{}/app/did/{}/doc", port, did);
+        return fmt::format("https://localhost:{}/did/{}/doc", port, did);
       }
       else
       {

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -520,7 +520,7 @@ namespace scitt
             // NB: This path tells the caller to continue to ask until the end
             // of the range, even if the next response is paginated
             out.next_link = fmt::format(
-              "/app/entries/txIds?from={}&to={}", next_page_start, to_seqno);
+              "/entries/txIds?from={}&to={}", next_page_start, to_seqno);
           }
 
           return out;

--- a/demo/github/1-scitt-setup.sh
+++ b/demo/github/1-scitt-setup.sh
@@ -26,4 +26,4 @@ scitt governance propose_configuration \
 TRUST_STORE=tmp/trust_store
 mkdir -p $TRUST_STORE
 
-curl -k -f $SCITT_URL/app/parameters > $TRUST_STORE/scitt.json
+curl -k -f $SCITT_URL/parameters > $TRUST_STORE/scitt.json

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -237,7 +237,7 @@ class BaseClient:
         In the latter case, an exception is raised.
         """
         response = self.get(
-            "/app/tx",
+            "/tx",
             params={"transaction_id": tx},
             retry_on=[lambda r: r.is_success and r.json()["status"] == "Pending"],
         )
@@ -293,7 +293,7 @@ class Client(BaseClient):
     """
 
     def get_parameters(self) -> dict:
-        return self.get("/app/parameters").json()
+        return self.get("/parameters").json()
 
     def get_trust_store(self) -> dict:
         params = self.get_parameters()
@@ -301,17 +301,17 @@ class Client(BaseClient):
         return {service_id: params}
 
     def get_constitution(self) -> str:
-        return self.get("/app/constitution").text
+        return self.get("/constitution").text
 
     def get_version(self) -> dict:
-        return self.get("/app/version").json()
+        return self.get("/version").json()
 
     def submit_claim(
         self, claim: bytes, *, skip_confirmation=False, decode=True
     ) -> Submission:
         headers = {"Content-Type": "application/cose"}
         response = self.post(
-            "/app/entries",
+            "/entries",
             headers=headers,
             content=claim,
             retry_on=[
@@ -328,12 +328,12 @@ class Client(BaseClient):
 
     def get_claim(self, tx: str, *, embed_receipt=False) -> bytes:
         response = self.get_historical(
-            f"/app/entries/{tx}", params={"embedReceipt": embed_receipt}
+            f"/entries/{tx}", params={"embedReceipt": embed_receipt}
         )
         return response.content
 
     def get_receipt(self, tx: str, *, decode=True) -> Union[bytes, Receipt]:
-        response = self.get_historical(f"/app/entries/{tx}/receipt")
+        response = self.get_historical(f"/entries/{tx}/receipt")
         if decode:
             return Receipt.decode(response.content)
         else:
@@ -354,7 +354,7 @@ class Client(BaseClient):
         if end is not None:
             params["to"] = end
 
-        link = f"/app/entries/txIds?{urlencode(params)}"
+        link = f"/entries/txIds?{urlencode(params)}"
 
         while link:
             response = self.get(

--- a/pyscitt/pyscitt/prefix_tree.py
+++ b/pyscitt/pyscitt/prefix_tree.py
@@ -188,9 +188,7 @@ class PrefixTreeClient:
         def is_indexed(data: bytes, upper_bound_seqno: int) -> bool:
             return TreeReceipt.decode(data).upper_bound_seqno >= upper_bound_seqno
 
-        info = self.client.post(
-            "/app/prefix_tree/flush", wait_for_confirmation=True
-        ).json()
+        info = self.client.post("/prefix_tree/flush", wait_for_confirmation=True).json()
 
         # The confirmation we get from the flush is not quite enough for the
         # results to be visible, since it may take some time for the indexer to
@@ -200,7 +198,7 @@ class PrefixTreeClient:
         # we got when flushing. We also need to handle the NoPrefixTree 404 error,
         # which can happen on a fresh service.
         self.client.get_historical(
-            "/app/prefix_tree",
+            "/prefix_tree",
             retry_on=[
                 (HTTPStatus.NOT_FOUND, "NoPrefixTree"),
                 lambda r: r.is_success
@@ -210,10 +208,10 @@ class PrefixTreeClient:
         return info
 
     def debug(self) -> dict:
-        return self.client.get("/app/prefix_tree/debug").json()
+        return self.client.get("/prefix_tree/debug").json()
 
     def get_read_receipt(self, issuer: str, feed: str, *, decode=True):
-        response = self.client.get_historical(f"/app/read_receipt/{issuer}/{feed}")
+        response = self.client.get_historical(f"/read_receipt/{issuer}/{feed}")
         if decode:
             return ReadReceipt.decode(response.content)
         else:

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -25,7 +25,7 @@ if [ "$DOCKER" = "1" ]; then
 
     # wait until the network is ready
     timeout=120
-    while ! curl -s -f -k $CCF_URL/app/parameters > /dev/null; do
+    while ! curl -s -f -k $CCF_URL/parameters > /dev/null; do
         echo "Waiting for service to be ready..."
         sleep 1
         timeout=$((timeout - 1))

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -102,7 +102,7 @@ class ManagedCCHostFixtures:
                 )
                 client.governance.propose(proposal, must_pass=True)
                 client.get(
-                    "/app/parameters",
+                    "/parameters",
                     retry_on=[(HTTPStatus.NOT_FOUND, "FrontendNotOpen")],
                 )
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -124,7 +124,7 @@ class TestServiceIdentifier:
 
         # If a service identifier is configured, issued receipts include an issuer
         # and kid.
-        # Somewhat confusingly, what the old `/app/parameters` endpoint calls the
+        # Somewhat confusingly, what the old `/parameters` endpoint calls the
         # "service identity" is used as a KID in the receipts.
         receipt = client.submit_claim(claim).receipt
         assert receipt.phdr[crypto.COSE_HEADER_PARAM_ISSUER] == service_identifier

--- a/test/test_prefix_tree.py
+++ b/test/test_prefix_tree.py
@@ -20,9 +20,7 @@ def test_prefix_tree(did_web, client):
     pt = client.prefix_tree
 
     # Until we flush the prefix tree, the claim does not appear
-    with pytest.raises(
-        ServiceError, match="UnknownFeed: No claim found for given issuer and feed"
-    ):
+    with pytest.raises(ServiceError, match="UnknownFeed"):
         pt.get_read_receipt(identity.issuer, feed)
 
     pt.flush()
@@ -80,12 +78,10 @@ def test_prefix_tree(did_web, client):
 def test_empty_prefix_tree(client):
     """Before any flush has been committed, fetching the prefix tree receipt returns a graceful error."""
 
-    with pytest.raises(
-        ServiceError, match="NoPrefixTree: No prefix tree has been committed yet"
-    ):
-        client.get_historical("/app/prefix_tree")
+    with pytest.raises(ServiceError, match="NoPrefixTree"):
+        client.get_historical("/prefix_tree")
 
-        client.prefix_tree.flush()
+    client.prefix_tree.flush()
 
-        # Now we're okay since we have at least one PT root committed.
-        client.get_historical("/app/prefix_tree")
+    # Now we're okay since we have at least one PT root committed.
+    client.get_historical("/prefix_tree")


### PR DESCRIPTION
Since CCF 3.x, all application endpoints are available both under the /app prefix, or directly at the root. Using endpoints without prefix makes the client code more consitent with the server code.

Additionally, in the future, we'll want to use the /.well-known path to serve DID documents, which must be at the root.

Fixes #52