### PR TITLE
Remove the /constitution endpoint.

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -41,7 +41,6 @@
 #include <ccf/node/host_processes_interface.h>
 #include <ccf/node/quote.h>
 #include <ccf/service/tables/cert_bundles.h>
-#include <ccf/service/tables/constitution.h>
 #include <ccf/service/tables/members.h>
 #include <ccf/service/tables/nodes.h>
 #include <ccf/service/tables/service.h>
@@ -781,24 +780,6 @@ namespace scitt
         error_adapter(ccf::json_adapter(get_configuration)),
         no_authn_policy)
         .set_auto_schema<void, Configuration>()
-        .install();
-
-      static constexpr auto get_constitution_path = "/constitution";
-      auto get_constitution = [&](EndpointContext& ctx) {
-        auto constitution =
-          ctx.tx.template ro<ccf::Constitution>(ccf::Tables::CONSTITUTION)
-            ->get()
-            .value();
-
-        ctx.rpc_ctx->set_response_body(std::move(constitution));
-        ctx.rpc_ctx->set_response_header(
-          http::headers::CONTENT_TYPE, "application/javascript");
-      };
-      make_endpoint(
-        get_constitution_path,
-        HTTP_GET,
-        error_adapter(get_constitution),
-        no_authn_policy)
         .install();
 
       static constexpr auto get_version_path = "/version";

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -300,7 +300,9 @@ class Client(BaseClient):
         return {service_id: params}
 
     def get_constitution(self) -> str:
-        return self.get("/constitution").text
+        # The endpoint returns the value as a JSON-encoded string, ie. wrapped
+        # in double quotes and with all special characters escaped.
+        return self.get("/gov/kv/constitution").json()
 
     def get_version(self) -> dict:
         return self.get("/version").json()


### PR DESCRIPTION
As of CCF 3.0.2, there is a built-in endpoint for governance tables, including getting the current constitution. This can be used in place of our existing /constitution endpoint.

Fixes #46