### PR TITLE
Add a DID-based service identifier to the ledger.

### DIFF
--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -37,6 +37,7 @@ namespace scitt
     const std::string PayloadTooLarge = "PayloadTooLarge";
     const std::string UnknownFeed = "UnknownFeed";
     const std::string NoPrefixTree = "NoPrefixTree";
+    const std::string NotFound = "NotFound";
   } // namespace errors
 
 } // namespace scitt

--- a/app/src/did/document.h
+++ b/app/src/did/document.h
@@ -12,6 +12,9 @@
 
 namespace scitt::did
 {
+  static constexpr std::string_view VERIFICATION_METHOD_TYPE_JWK =
+    "JsonWebKey2020";
+
   struct Jwk
   {
     std::string kty;
@@ -21,12 +24,13 @@ namespace scitt::did
     std::optional<std::string> crv;
     std::optional<std::string> x;
     std::optional<std::string> y;
+    std::optional<std::vector<std::string>> x5c;
 
     bool operator==(const Jwk&) const = default;
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Jwk);
   DECLARE_JSON_REQUIRED_FIELDS(Jwk, kty);
-  DECLARE_JSON_OPTIONAL_FIELDS(Jwk, alg, n, e, crv, x, y);
+  DECLARE_JSON_OPTIONAL_FIELDS(Jwk, alg, n, e, crv, x, y, x5c);
 
   struct DidVerificationMethod
   {

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -13,6 +13,7 @@
 #include "http_error.h"
 #include "kv_types.h"
 #include "receipt.h"
+#include "service_endpoints.h"
 #include "util.h"
 #include "verifier.h"
 
@@ -229,23 +230,19 @@ namespace scitt
         auto service_cert_digest =
           crypto::Sha256Hash(service_cert_der).hex_str();
 
-        // Take the service's DID from the configuration, if present. For the
-        // time being, the kid is the same as the service certificate hash.
-        // Eventually, this may change to become eg. an RFC7638 JWK thumbprint.
+        // Take the service's DID from the configuration, if present.
         std::vector<uint8_t> sign_protected;
         if (cfg.service_identifier.has_value())
         {
-          // TODO: clarify the format of KID. We currently use the hex digest,
-          // encoded in ASCII. Since the COSE field is a bstr, we could skip the
-          // hex/ASCII encoding part of it and embed the digest directly, but
-          // this would not be valid as-is in the corresponding JWK.
-          std::span<const uint8_t> kid = {
-            reinterpret_cast<const uint8_t*>(service_cert_digest.data()),
-            service_cert_digest.size(),
-          };
+          // The kid is the same as the service certificate hash (prefixed with
+          // a # to make it a relative DID-url). Eventually, this may change to
+          // become eg. an RFC7638 JWK thumbprint.
+          std::string kid = fmt::format("#{}", service_cert_digest);
+          std::span<const uint8_t> kid_bytes(
+            reinterpret_cast<const uint8_t*>(kid.data()), kid.size());
 
           sign_protected = create_countersign_protected_header(
-            time, *cfg.service_identifier, kid, service_cert_digest);
+            time, *cfg.service_identifier, kid_bytes, service_cert_digest);
         }
         else
         {
@@ -799,6 +796,8 @@ namespace scitt
         .set_auto_schema<void, GetVersion::Out>()
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
+
+      register_service_endpoints(*this);
 
 #ifdef ENABLE_PREFIX_TREE
       PrefixTreeFrontend::init_handlers(context, *this);

--- a/app/src/service_endpoints.h
+++ b/app/src/service_endpoints.h
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "did/document.h"
+
+#include <ccf/base_endpoint_registry.h>
+#include <ccf/crypto/verifier.h>
+#include <ccf/endpoint.h>
+#include <ccf/json_handler.h>
+#include <ccf/service/tables/service.h>
+
+namespace scitt
+{
+  did::DidDocument service_info_to_did_document(
+    std::string_view service_identifier, const ccf::ServiceInfo& service_info)
+  {
+    auto verifier = crypto::make_unique_verifier(service_info.cert);
+    auto service_cert_der = verifier->cert_der();
+    auto key_id = crypto::Sha256Hash(service_cert_der).hex_str();
+
+    // We roundtrip via JSON to convert from CCF's JWK type to our own.
+    did::Jwk jwk = nlohmann::json(verifier->public_key_jwk());
+    jwk.x5c = {{
+      crypto::b64_from_raw(service_cert_der),
+    }};
+
+    did::DidDocument doc;
+    doc.id = std::string(service_identifier);
+    doc.assertion_method.push_back(did::DidVerificationMethod{
+      .id = fmt::format("{}#{}", service_identifier, key_id),
+      .type = std::string(did::VERIFICATION_METHOD_TYPE_JWK),
+      .controller = std::string(service_identifier),
+      .public_key_jwk = jwk,
+    });
+    return doc;
+  }
+
+  did::DidDocument get_did_document(
+    ccf::endpoints::EndpointContext& ctx, nlohmann::json&& params)
+  {
+    auto cfg = ctx.tx.template ro<ConfigurationTable>(CONFIGURATION_TABLE)
+                 ->get()
+                 .value_or(Configuration{});
+
+    if (!cfg.service_identifier.has_value())
+    {
+      throw NotFoundError(errors::NotFound, "DID is not enabled");
+    }
+
+    auto service = ctx.tx.template ro<ccf::Service>(ccf::Tables::SERVICE);
+    auto service_info = service->get().value();
+
+    return service_info_to_did_document(*cfg.service_identifier, service_info);
+  }
+
+  void register_service_endpoints(ccf::BaseEndpointRegistry& registry)
+  {
+    // A top-level DID (eg. did:web:example.com) would require serving the DID
+    // document at `/.well-known/did.json`, which CCF does not yet support:
+    // https://github.com/microsoft/CCF/issues/4810
+    //
+    // As a workaround, we currently use `did:web:example.com:scitt` as the DID.
+    registry
+      .make_endpoint(
+        "/scitt/did.json",
+        HTTP_GET,
+        error_adapter(ccf::json_adapter(get_did_document)),
+        {ccf::empty_auth_policy})
+      .install();
+  }
+}

--- a/pyscitt/pyscitt/cli/prefix_tree.py
+++ b/pyscitt/pyscitt/cli/prefix_tree.py
@@ -10,6 +10,7 @@ from pycose.messages import CoseMessage
 from .. import crypto, prefix_tree
 from ..client import Client
 from ..crypto import COSE_HEADER_PARAM_FEED, COSE_HEADER_PARAM_ISSUER
+from ..verify import StaticTrustStore
 from .client_arguments import add_client_arguments, create_client
 
 
@@ -49,10 +50,8 @@ def prefix_tree_get_receipt(
     print(json.dumps(receipt.as_dict(), indent=2))
 
     if claim_path and service_trust_store_path:
-        service_trust_store = crypto.read_service_trust_store(service_trust_store_path)
-        service_params = crypto.get_service_parameters(
-            receipt.tree_headers["service_id"], service_trust_store
-        )
+        service_trust_store = StaticTrustStore.load(service_trust_store_path)
+        service_params = service_trust_store.lookup(receipt.tree_headers)
         receipt.verify(claim, service_params)
 
 

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -5,8 +5,8 @@ import argparse
 from pathlib import Path
 from typing import Optional
 
-from .. import crypto
 from ..client import Client
+from ..verify import StaticTrustStore, verify_receipt
 from .client_arguments import add_client_arguments, create_client
 
 
@@ -21,7 +21,7 @@ def retrieve_signed_claimsets(
     base_path.mkdir(parents=True, exist_ok=True)
 
     if service_trust_store_path:
-        service_trust_store = crypto.read_service_trust_store(service_trust_store_path)
+        service_trust_store = StaticTrustStore.load(service_trust_store_path)
     else:
         service_trust_store = None
 
@@ -30,9 +30,7 @@ def retrieve_signed_claimsets(
         path = base_path / f"{tx}.cose"
 
         if service_trust_store:
-            crypto.verify_cose_with_receipt(
-                claim, service_trust_store=service_trust_store
-            )
+            verify_receipt(claim, service_trust_store=service_trust_store)
 
         with open(path, "wb") as f:
             f.write(claim)

--- a/pyscitt/pyscitt/cli/submit_signed_claims.py
+++ b/pyscitt/pyscitt/cli/submit_signed_claims.py
@@ -5,8 +5,8 @@ import argparse
 from pathlib import Path
 from typing import Optional
 
-from .. import crypto
 from ..client import Client
+from ..verify import StaticTrustStore, verify_receipt
 from .client_arguments import add_client_arguments, create_client
 
 
@@ -39,8 +39,8 @@ def submit_signed_claimset(
         print(f"Received {receipt_path}")
 
     if service_trust_store_path:
-        service_trust_store = crypto.read_service_trust_store(service_trust_store_path)
-        crypto.verify_cose_with_receipt(
+        service_trust_store = StaticTrustStore.load(service_trust_store_path)
+        verify_receipt(
             signed_claimset,
             receipt=submission.receipt,
             service_trust_store=service_trust_store,

--- a/pyscitt/pyscitt/cli/validate_cose.py
+++ b/pyscitt/pyscitt/cli/validate_cose.py
@@ -5,22 +5,22 @@ from pathlib import Path
 from typing import Optional
 
 from .. import crypto
+from ..verify import StaticTrustStore, verify_receipt
 
 
 def validate_cose_with_receipt(
     cose_path: Path, receipt_path: Optional[Path], service_trust_store_path: Path
 ):
-    service_trust_store = crypto.read_service_trust_store(service_trust_store_path)
-    with open(cose_path, "rb") as f:
-        cose = f.read()
+    service_trust_store = StaticTrustStore.load(service_trust_store_path)
+
+    cose = cose_path.read_bytes()
+
     if receipt_path is None:
         receipt = None
     else:
-        with open(receipt_path, "rb") as f:
-            receipt = f.read()
-    crypto.verify_cose_with_receipt(
-        cose, service_trust_store=service_trust_store, receipt=receipt
-    )
+        receipt = receipt_path.read_bytes()
+
+    verify_receipt(cose, service_trust_store, receipt)
     print(f"COSE document is valid: {cose_path}")
 
 

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -19,6 +19,7 @@ from . import crypto
 from .governance import GovernanceClient
 from .prefix_tree import PrefixTreeClient
 from .receipt import Receipt
+from .verify import ServiceParameters
 
 CCF_TX_ID_HEADER = "x-ms-ccf-transaction-id"
 
@@ -337,13 +338,8 @@ class Client(BaseClient):
     Specialization of the BaseClient, aimed at interacting with a SCITT CCF ledger instance.
     """
 
-    def get_parameters(self) -> dict:
-        return self.get("/parameters").json()
-
-    def get_trust_store(self) -> dict:
-        params = self.get_parameters()
-        service_id = params.get("serviceId")
-        return {service_id: params}
+    def get_parameters(self) -> ServiceParameters:
+        return ServiceParameters.from_dict(self.get("/parameters").json())
 
     def get_constitution(self) -> str:
         # The endpoint returns the value as a JSON-encoded string, ie. wrapped

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -22,6 +22,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePrivateKey,
     EllipticCurvePublicKey,
+    EllipticCurvePublicNumbers,
 )
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
@@ -62,9 +63,7 @@ from pycose.keys.keyparam import (
 )
 from pycose.keys.okp import OKPKey
 from pycose.keys.rsa import RSAKey
-from pycose.messages import CoseMessage, Sign1Message
-
-from .receipt import Receipt
+from pycose.messages import Sign1Message
 
 RECOMMENDED_RSA_PUBLIC_EXPONENT = 65537
 
@@ -248,6 +247,14 @@ def get_cert_info(pem: str) -> dict:
     return {"cn": cn}
 
 
+def get_cert_public_key(pem: Pem) -> Pem:
+    cert = load_pem_x509_certificate(pem.encode("ascii"))
+    key = cert.public_key()
+    return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode(
+        "ascii"
+    )
+
+
 def get_cert_fingerprint(pem: Pem) -> str:
     cert = load_pem_x509_certificate(pem.encode("ascii"))
     return cert.fingerprint(hashes.SHA256()).hex()
@@ -319,22 +326,6 @@ def default_algorithm_for_key(key) -> str:
 def default_algorithm_for_private_key(key_pem: Pem) -> str:
     key = load_pem_private_key(key_pem.encode("ascii"), None)
     return default_algorithm_for_key(key)
-
-
-def verify_cose_sign1(buf: bytes, cert_pem: str):
-    cert = load_pem_x509_certificate(cert_pem.encode("ascii"))
-    key = cert.public_key()
-    if isinstance(key, RSAPublicKey):
-        cose_key = from_cryptography_rsakey_obj(key)
-    elif isinstance(key, EllipticCurvePublicKey):
-        cose_key = from_cryptography_eckey_obj(key)
-    else:
-        raise NotImplementedError("unsupported key type")
-
-    msg = Sign1Message.decode(buf)
-    msg.key = cose_key
-    if not msg.verify_signature():
-        raise ValueError("signature is invalid")
 
 
 def cose_header_to_jws_header(cose_header: dict) -> dict:
@@ -545,27 +536,6 @@ def embed_receipt_in_cose(buf: bytes, receipt: bytes) -> bytes:
     return cbor2.dumps(outer)
 
 
-def verify_cose_with_receipt(
-    buf: bytes, service_trust_store: dict, receipt: Optional[bytes] = None
-) -> None:
-    msg = CoseMessage.decode(buf)
-    assert isinstance(msg, Sign1Message)
-
-    if receipt is None:
-        parsed_receipts = msg.uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS]
-        # For now, assume there is only one receipt
-        assert len(parsed_receipts) == 1
-        parsed_receipt = parsed_receipts[0]
-    else:
-        parsed_receipt = cbor2.loads(receipt)
-
-    decoded_receipt = Receipt.from_cose_obj(parsed_receipt)
-
-    service_id = decoded_receipt.phdr["service_id"]
-    service_params = get_service_parameters(service_id, service_trust_store)
-    decoded_receipt.verify(msg, service_params)
-
-
 def load_private_key(key_path: Path) -> Pem:
     with open(key_path) as f:
         key_priv_pem = f.read()
@@ -724,30 +694,6 @@ def sign_json_claimset(
     )
 
 
-def read_service_trust_store(path: Path) -> dict:
-    store = {}
-    for path in path.glob("**/*.json"):
-        with open(path) as f:
-            params = json.load(f)
-
-        service_id = params.get("serviceId")
-        if not isinstance(service_id, str) or not service_id:
-            raise ValueError("serviceId must be a non-empty string")
-        if service_id in store:
-            raise ValueError(
-                f"Duplicate service ID while reading trust store: {service_id}"
-            )
-
-        store[service_id] = params
-    return store
-
-
-def get_service_parameters(service_id: str, service_trust_store: dict) -> dict:
-    if service_id not in service_trust_store:
-        raise ValueError(f"Service ID not found in trust store: {service_id}")
-    return service_trust_store[service_id]
-
-
 def decode_p1363_signature(signature: bytes) -> Tuple[int, int]:
     """
     Decode an ECDSA signature from its IEEE P1363 encoding into its r and s
@@ -776,3 +722,17 @@ def convert_p1363_signature_to_dss(signature: bytes) -> bytes:
     """
     r, s = decode_p1363_signature(signature)
     return encode_dss_signature(r, s)
+
+
+def convert_jwk_to_pem(jwk: dict) -> Pem:
+    if jwk.get("kty") == "EC":
+        x = int.from_bytes(base64.urlsafe_b64decode(jwk["x"]), "big")
+        y = int.from_bytes(base64.urlsafe_b64decode(jwk["y"]), "big")
+        crv = REGISTERED_EC_CURVES[jwk["crv"]].curve_obj()
+        key = EllipticCurvePublicNumbers(x, y, crv).public_key()
+    else:
+        raise NotImplementedError("Unsupported JWK type")
+
+    return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode(
+        "ascii"
+    )

--- a/pyscitt/pyscitt/prefix_tree.py
+++ b/pyscitt/pyscitt/prefix_tree.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from .crypto import COSE_HEADER_PARAM_FEED, COSE_HEADER_PARAM_ISSUER
 from .receipt import ReceiptContents, hdr_as_dict
+from .verify import ServiceParameters
 
 
 class bitvector:
@@ -105,7 +106,9 @@ class ReadReceipt:
     def decode(cls, data: bytes):
         return cls.from_cose_obj(cbor2.loads(data))
 
-    def verify(self, claim: Union[Sign1Message, bytes], service_params: dict):
+    def verify(
+        self, claim: Union[Sign1Message, bytes], service_params: ServiceParameters
+    ):
         if isinstance(claim, bytes):
             claim = CoseMessage.decode(claim)
         assert isinstance(claim, Sign1Message)

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -1,0 +1,212 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import base64
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+import cbor2
+import pycose
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+from cryptography.x509 import load_pem_x509_certificate
+from pycose.messages import Sign1Message
+
+from . import crypto, did
+from .crypto import (
+    COSE_HEADER_PARAM_ISSUER,
+    COSE_HEADER_PARAM_SCITT_RECEIPTS,
+    Pem,
+    cert_der_to_pem,
+    convert_jwk_to_pem,
+    get_cert_public_key,
+)
+from .receipt import Receipt
+
+
+@dataclass
+class ServiceParameters:
+    tree_algorithm: str
+    signature_algorithm: str
+    certificate: bytes
+    service_id: Optional[str] = None
+
+    @staticmethod
+    def from_dict(data) -> "ServiceParameters":
+        """
+        Decode service parameters as returned by the /parameters endpoint.
+        """
+        return ServiceParameters(
+            tree_algorithm=data["treeAlgorithm"],
+            signature_algorithm=data["signatureAlgorithm"],
+            certificate=base64.b64decode(data["serviceCertificate"]),
+            service_id=data["serviceId"],
+        )
+
+    def as_dict(self) -> Dict[str, str]:
+        result = {
+            "treeAlgorithm": self.tree_algorithm,
+            "signatureAlgorithm": self.signature_algorithm,
+            "serviceCertificate": base64.b64encode(self.certificate).decode("ascii"),
+        }
+        if self.service_id is not None:
+            result["serviceId"] = self.service_id
+        return result
+
+
+class TrustStore(ABC):
+    @abstractmethod
+    def lookup(self, phdr) -> ServiceParameters:
+        """
+        Look up a service's parameters based on the protected headers from a
+        receipt. Raises an exception if not matching service is found.
+        """
+        raise NotImplementedError()
+
+
+def verify_cose_sign1(buf: bytes, cert_pem: str):
+    cert = load_pem_x509_certificate(cert_pem.encode("ascii"))
+    key = cert.public_key()
+
+    if isinstance(key, RSAPublicKey):
+        cose_key = crypto.from_cryptography_rsakey_obj(key)
+    elif isinstance(key, EllipticCurvePublicKey):
+        cose_key = crypto.from_cryptography_eckey_obj(key)
+    else:
+        raise NotImplementedError("unsupported key type")
+
+    msg = Sign1Message.decode(buf)
+    msg.key = cose_key
+    if not msg.verify_signature():
+        raise ValueError("signature is invalid")
+
+
+def verify_receipt(
+    buf: bytes,
+    service_trust_store: TrustStore,
+    receipt: Union[Receipt, bytes, None] = None,
+) -> None:
+    msg = Sign1Message.decode(buf)
+
+    if isinstance(receipt, Receipt):
+        decoded_receipt = receipt
+    else:
+        if receipt is None:
+            parsed_receipts = msg.uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS]
+            # For now, assume there is only one receipt
+            assert len(parsed_receipts) == 1
+            parsed_receipt = parsed_receipts[0]
+        else:
+            parsed_receipt = cbor2.loads(receipt)
+
+        decoded_receipt = Receipt.from_cose_obj(parsed_receipt)
+
+    service_params = service_trust_store.lookup(decoded_receipt.phdr)
+    decoded_receipt.verify(msg, service_params)
+
+
+class StaticTrustStore(TrustStore):
+    """
+    A static trust store, based on a list of trusted service certificates.
+    """
+
+    services: Dict[str, ServiceParameters]
+
+    def __init__(self, services: Dict[str, ServiceParameters]):
+        self.services = services
+
+    @staticmethod
+    def load(path: Path) -> "StaticTrustStore":
+        """
+        Populate a static trust store from a directory. Each JSON file in the
+        directory corresponds to a trusted service identity.
+        """
+        store = {}
+        for path in path.glob("**/*.json"):
+            with open(path) as f:
+                data = json.load(f)
+
+            service_id = data.get("serviceId")
+            if not isinstance(service_id, str) or not service_id:
+                raise ValueError("serviceId must be a non-empty string")
+
+            if service_id in store:
+                raise ValueError(
+                    f"Duplicate service ID while reading trust store: {service_id}"
+                )
+
+            store[service_id] = ServiceParameters.from_dict(data)
+
+        return StaticTrustStore(store)
+
+    def lookup(self, phdr) -> ServiceParameters:
+        if "service_id" not in phdr:
+            raise ValueError("Receipt does not have a service identity.")
+
+        service_id = phdr["service_id"]
+        if service_id in self.services:
+            return self.services[service_id]
+        else:
+            raise ValueError(f"Unknown service identity {service_id!r}")
+
+
+class DIDDocumentTrustStore(TrustStore):
+    """
+    A trust store backed by a single DID-document.
+
+    The trust store will use the KID found in the protected headers to select
+    the appropriate assertion method from the document.
+    """
+
+    document: dict
+
+    def __init__(self, document: dict):
+        self.document = document
+
+    def lookup(self, phdr) -> ServiceParameters:
+        issuer = phdr.get(COSE_HEADER_PARAM_ISSUER)
+        if issuer != self.document.get("id"):
+            raise ValueError(
+                f"Incorrect issuer {issuer!r}, expected {self.document['id']}"
+            )
+
+        if pycose.headers.KID in phdr:
+            kid = phdr[pycose.headers.KID].decode("ascii")
+        else:
+            kid = None
+
+        method = did.find_assertion_method(self.document, kid)
+        jwk = method["publicKeyJwk"]
+        if len(jwk.get("x5c", [])) < 1:
+            raise ValueError("Missing x5c parameter in service JWK")
+        certificate = base64.b64decode(jwk["x5c"][0])
+
+        return ServiceParameters("CCF", "ES256", certificate)
+
+
+class DIDResolverTrustStore(TrustStore):
+    """
+    A trust store which uses the issuer found in receipts to dynamically
+    resolve the service parameters.
+
+    The trust store does not restrict which issuers are allowed, only that the
+    receipt signature matches the identifier.
+    """
+
+    def __init__(self, resolver: Optional[did.Resolver] = None):
+        if resolver is not None:
+            self.resolver = resolver
+        else:
+            self.resolver = did.Resolver()
+
+    def lookup(self, phdr) -> ServiceParameters:
+        if COSE_HEADER_PARAM_ISSUER not in phdr:
+            raise ValueError("Receipt does not have an issuer")
+
+        issuer = phdr[COSE_HEADER_PARAM_ISSUER]
+        document = self.resolver.resolve(issuer)
+
+        return DIDDocumentTrustStore(document).lookup(phdr)

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -7,12 +7,15 @@ import time
 from contextlib import contextmanager
 from http import HTTPStatus
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 from loguru import logger as LOG
 
 from pyscitt import governance
 from pyscitt.client import Client
+from pyscitt.did import format_did_web
+from pyscitt.verify import ServiceParameters, StaticTrustStore
 
 from .cchost import CCHost, get_default_cchost_path, get_enclave_path
 from .did_web_server import DIDWebServer
@@ -245,6 +248,23 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="class")
+def service_identifier(service_url: str) -> str:
+    """
+    Get the long term service identifier, under the form of a DID.
+
+    The service is configured to include this identifier in receipts.
+    """
+
+    result = urlparse(service_url)
+    assert result.hostname is not None
+
+    # CCF currently won't let us host the DID document under `/.well-known`,
+    # which prevents us from using a top-level DID. The `scitt` path is a
+    # temporary workaround.
+    return format_did_web(result.hostname, result.port, "scitt")
+
+
+@pytest.fixture(scope="class")
 def base_client(service_url, member_auth):
     """
     Create a Client instance to connect to the test SCITT service.
@@ -256,7 +276,7 @@ def base_client(service_url, member_auth):
 
 
 @pytest.fixture(scope="class")
-def configure_service(base_client: Client):
+def configure_service(base_client: Client, service_identifier: str):
     """
     Change the service configuration.
 
@@ -266,11 +286,9 @@ def configure_service(base_client: Client):
     """
 
     def f(configuration):
-        if "authentication" not in configuration:
-            configuration = {
-                "authentication": {"allow_unauthenticated": True},
-                **configuration,
-            }
+        configuration = configuration.copy()
+        configuration.setdefault("authentication", {"allow_unauthenticated": True})
+        configuration.setdefault("service_identifier", service_identifier)
 
         proposal = governance.set_scitt_configuration_proposal(configuration)
         base_client.governance.propose(proposal, must_pass=True)
@@ -308,8 +326,9 @@ def did_web(client, tmp_path_factory):
 
 
 @pytest.fixture(scope="class")
-def trust_store(client) -> dict:
+def trust_store(client) -> StaticTrustStore:
     """
-    Get the trust store associated with the service.
+    Get the static trust store associated with the service.
     """
-    return client.get_trust_store()
+    params = client.get_parameters()
+    return StaticTrustStore({params.service_id: params})

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -9,6 +9,7 @@ from infra.did_web_server import DIDWebServer
 from infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 from pyscitt import crypto, governance
 from pyscitt.client import Client, ServiceError
+from pyscitt.verify import verify_receipt
 
 
 @pytest.mark.parametrize(
@@ -34,11 +35,10 @@ def test_submit_claim(client: Client, did_web, trust_store, params):
     # Sign and submit a dummy claim using our new identity
     claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
     receipt = client.submit_claim(claims).receipt
-
-    crypto.verify_cose_with_receipt(claims, trust_store, receipt)
+    verify_receipt(claims, trust_store, receipt)
 
     embedded = crypto.embed_receipt_in_cose(claims, receipt)
-    crypto.verify_cose_with_receipt(embedded, trust_store, None)
+    verify_receipt(embedded, trust_store, None)
 
 
 @pytest.mark.parametrize(
@@ -68,7 +68,7 @@ def test_submit_claim_x5c(client: Client, trust_store, params: dict, x5c_len: in
     # Sign and submit a dummy claim using our new identity
     claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
     receipt = client.submit_claim(claims).receipt
-    crypto.verify_cose_with_receipt(claims, trust_store, receipt)
+    verify_receipt(claims, trust_store, receipt)
 
 
 def test_invalid_x5c(client: Client, trust_store):
@@ -119,7 +119,7 @@ def test_default_did_port(client: Client, trust_store, tmp_path):
         # Sign and submit a dummy claim using our new identity
         claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
         receipt = client.submit_claim(claims).receipt
-        crypto.verify_cose_with_receipt(claims, trust_store, receipt)
+        verify_receipt(claims, trust_store, receipt)
 
 
 def test_consistent_kid(client, did_web, trust_store):
@@ -139,7 +139,7 @@ def test_consistent_kid(client, did_web, trust_store):
 
     # Submit the claim and verify the resulting receipt.
     receipt = client.submit_claim(claim).receipt
-    crypto.verify_cose_with_receipt(claim, trust_store, receipt)
+    verify_receipt(claims, trust_store, receipt)
 
     # Check that the resolved DID document contains the expected assertion
     # method id.

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -139,7 +139,7 @@ def test_consistent_kid(client, did_web, trust_store):
 
     # Submit the claim and verify the resulting receipt.
     receipt = client.submit_claim(claim).receipt
-    verify_receipt(claims, trust_store, receipt)
+    verify_receipt(claim, trust_store, receipt)
 
     # Check that the resolved DID document contains the expected assertion
     # method id.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -48,7 +48,9 @@ def run(request):
 def test_smoke_test(run, client, tmp_path: Path):
     trust_store_path = tmp_path / "store"
     trust_store_path.mkdir()
-    (trust_store_path / "service.json").write_text(json.dumps(client.get_parameters()))
+    (trust_store_path / "service.json").write_text(
+        json.dumps(client.get_parameters().as_dict())
+    )
 
     (tmp_path / "claims.json").write_text(json.dumps({"foo": "bar"}))
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -9,6 +9,7 @@ from pycose.messages import Sign1Message
 
 from pyscitt import crypto
 from pyscitt.client import Client
+from pyscitt.verify import verify_receipt
 
 
 class TestNonCanonicalEncoding:
@@ -61,7 +62,7 @@ class TestNonCanonicalEncoding:
         """We should be able to verify the produced receipt."""
         # Once the xfail is fixed, this test can be merged with test_submit_claim.
         receipt = client.submit_claim(claim).receipt
-        crypto.verify_cose_with_receipt(claim, trust_store, receipt)
+        verify_receipt(claim, trust_store, receipt)
 
     def test_embed_receipt(self, client: Client, trust_store, claim):
         """When embedding a receipt in a claim, the ledger should not affect the original encoding."""

--- a/test/test_historical.py
+++ b/test/test_historical.py
@@ -7,6 +7,7 @@ import pytest
 
 from pyscitt import crypto
 from pyscitt.client import Client
+from pyscitt.verify import verify_receipt
 
 
 class TestHistorical:
@@ -42,20 +43,20 @@ class TestHistorical:
     def test_get_receipt(self, client: Client, trust_store, submissions):
         for s in submissions:
             receipt = client.get_receipt(s.tx, decode=False)
-            crypto.verify_cose_with_receipt(s.claim, trust_store, receipt)
+            verify_receipt(s.claim, trust_store, receipt)
 
     def test_get_claim(self, client: Client, trust_store, submissions):
         for s in submissions:
             claim = client.get_claim(s.tx)
-            crypto.verify_cose_with_receipt(claim, trust_store, s.receipt)
+            verify_receipt(claim, trust_store, s.receipt)
 
     def test_get_claim_with_embedded_receipt(
         self, client: Client, trust_store, submissions
     ):
         for s in submissions:
             claim = client.get_claim(s.tx, embed_receipt=True)
-            crypto.verify_cose_with_receipt(claim, trust_store)
+            verify_receipt(claim, trust_store)
 
             # The original receipt can still be used on the claim, even after
             # the ledger has embedded a new copy of it.
-            crypto.verify_cose_with_receipt(claim, trust_store, s.receipt)
+            verify_receipt(claim, trust_store, s.receipt)


### PR DESCRIPTION
A DID document is hosted at /scitt/did.json, allowing the service identifier to be resolved through did:web.

For now, the document only includes the current service certificate, but in the future this will be included to include past certificates too, allowing historical receipts to be verified.

Related to #53