### PR TITLE
Add latency perf test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv/
 workspace/
 *.egg-info/
 .vscode/settings.json
+perf.json

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -38,6 +38,8 @@ stages:
           Pool: 1es-dcv3
           Environment:
             ENABLE_PREFIX_TREE: OFF
+          FunctionalTestArguments: '--enable-perf'
+          PublishPerfResults: true
 
       - template: common.yml
         parameters:

--- a/.pipelines/common.yml
+++ b/.pipelines/common.yml
@@ -84,5 +84,5 @@ jobs:
       - ${{ if parameters.PublishPerfResults }}:
         - task: PublishPipelineArtifact@1
           inputs:
-            artifactName: "perf-results"
+            artifactName: "${{ parameters.Name }}-perf-results"
             targetPath: $(Build.SourcesDirectory)/perf.json

--- a/.pipelines/common.yml
+++ b/.pipelines/common.yml
@@ -22,6 +22,9 @@ parameters:
   - name: FunctionalTestArguments
     type: string
     default: ''
+  - name: PublishPerfResults
+    type: boolean
+    default: false
 jobs:
   - job: ${{ parameters.Name }}
     displayName: ${{ parameters.DisplayName }}
@@ -77,3 +80,9 @@ jobs:
 
       - script: ./run_functional_tests.sh ${{ parameters.FunctionalTestArguments }}
         displayName: Run Functional Tests
+
+      - ${{ if parameters.PublishPerfResults }}:
+        - task: PublishPipelineArtifact@1
+          inputs:
+            artifactName: "perf-results"
+            targetPath: $(Build.SourcesDirectory)/perf.json

--- a/.pipelines/common.yml
+++ b/.pipelines/common.yml
@@ -84,5 +84,5 @@ jobs:
       - ${{ if parameters.PublishPerfResults }}:
         - task: PublishPipelineArtifact@1
           inputs:
-            artifactName: "${{ parameters.Name }}-perf-results"
+            artifactName: "perf-results-${{ parameters.Name }}"
             targetPath: $(Build.SourcesDirectory)/perf.json

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -137,6 +137,7 @@ class BaseClient:
             self.member_http_sig = None
 
         if tcp_nodelay_patch:
+            # Work-around until https://github.com/encode/httpcore/pull/651 is merged.
             # This is necessary to set TCP_NODELAY on the sockets used by httpx.
             # Without it we get issues with Nagle + delayed ACK,
             # leading to 40ms pauses when sending requests.

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -319,13 +319,13 @@ class Client(BaseClient):
 
     @overload
     def submit_claim(
-        self, claim: bytes, *, skip_confirmation: Literal[False] = False
+        self, claim: bytes, *, skip_confirmation: Literal[False] = False, **kwargs
     ) -> Submission[bytes]:
         ...
 
     @overload
     def submit_claim(
-        self, claim: bytes, *, skip_confirmation: Literal[True]
+        self, claim: bytes, *, skip_confirmation: Literal[True], **kwargs
     ) -> Submission[None]:
         ...
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,11 +12,19 @@ def pytest_addoption(parser):
         action="store_true",
         help="Enable tests which depend on prefix tree support",
     )
+    parser.addoption(
+        "--enable-perf",
+        action="store_true",
+        help="Enable performance tests",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "needs_prefix_tree: only run test if prefix tree support is enabled."
+    )
+    config.addinivalue_line(
+        "markers", "perf: only run test if performance testing is enabled."
     )
 
 
@@ -29,3 +37,10 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "needs_prefix_tree" in item.keywords:
                 item.add_marker(needs_prefix_tree_skip)
+
+    if not config.getoption("--enable-perf"):
+        perf_skip = pytest.mark.skip(reason="performance testing was not enabled")
+
+        for item in items:
+            if "perf" in item.keywords:
+                item.add_marker(perf_skip)

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -6,10 +6,12 @@ import pytest
 from infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 from pyscitt import crypto, governance
 
+X5C_PARAMS = dict(alg="ES256", kty="ec", ec_curve="P-256")
+
 
 @pytest.fixture(scope="class")
 def x5c_ca(client):
-    ca = X5ChainCertificateAuthority(alg="ES256", kty="ec", ec_curve="P-256")
+    ca = X5ChainCertificateAuthority(**X5C_PARAMS)
 
     client.governance.propose(
         governance.set_ca_bundle_proposal("x509_roots", ca.cert_bundle),
@@ -47,29 +49,21 @@ class TestPerf:
         client.submit_claim(claims)
 
         latency_did_web_submit_s = measure_latency(
-            lambda: client.submit_claim(
-                claims, skip_confirmation=True, wait_time=0
-            )
+            lambda: client.submit_claim(claims, skip_confirmation=True, wait_time=0)
         )
         latency_did_web_submit_and_receipt_s = measure_latency(
-            lambda: client.submit_claim(
-                claims, skip_confirmation=False, wait_time=0
-            )
+            lambda: client.submit_claim(claims, skip_confirmation=False, wait_time=0)
         )
 
         # Test x5c performance.
-        identity = x5c_ca.create_identity(1, alg="ES256")
+        identity = x5c_ca.create_identity(1, **X5C_PARAMS)
         claims = crypto.sign_json_claimset(identity, payload)
 
         latency_x5c_submit_s = measure_latency(
-            lambda: client.submit_claim(
-                claims, skip_confirmation=True, wait_time=0
-            )
+            lambda: client.submit_claim(claims, skip_confirmation=True, wait_time=0)
         )
         latency_x5c_submit_and_receipt_s = measure_latency(
-            lambda: client.submit_claim(
-                claims, skip_confirmation=False, wait_time=0
-            )
+            lambda: client.submit_claim(claims, skip_confirmation=False, wait_time=0)
         )
 
         # Note: Time-to-receipt depends on the configured signature interval of

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -26,8 +26,10 @@ def x5c_ca(client):
 
 def measure_latency(fn, arg_fn=None):
     if arg_fn is None:
+
         def arg_fn():
             return None
+
     times = []
     for _ in range(150):
         arg = arg_fn()
@@ -48,16 +50,16 @@ class TestPerf:
     def test_latency(self, client, did_web, x5c_ca):
         payload = {"foo": "bar"}
 
-        client = client.replace(wait_time=0)
+        client = client.replace(wait_time=0.01, tcp_nodelay_patch=True)
 
         # Test did:web performance (uncached resolution).
         latency_did_web_uncached_submit_s = measure_latency(
             lambda claim: client.submit_claim(claim, skip_confirmation=True),
-            lambda: crypto.sign_json_claimset(did_web.create_identity(), payload)
+            lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
         )
         latency_did_web_uncached_submit_and_receipt_s = measure_latency(
             lambda claim: client.submit_claim(claim, skip_confirmation=False),
-            lambda: crypto.sign_json_claimset(did_web.create_identity(), payload)
+            lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
         )
 
         # Test did:web performance (cached resolution).

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import json
 import time
 

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -24,11 +24,15 @@ def x5c_ca(client):
     return ca
 
 
-def measure_latency(f):
+def measure_latency(fn, arg_fn=None):
+    if arg_fn is None:
+        def arg_fn():
+            return None
     times = []
     for _ in range(150):
+        arg = arg_fn()
         t_start = time.perf_counter()
-        f()
+        fn(arg)
         t_end = time.perf_counter()
         times.append(t_end - t_start)
     return {
@@ -44,36 +48,52 @@ class TestPerf:
     def test_latency(self, client, did_web, x5c_ca):
         payload = {"foo": "bar"}
 
-        # Test did:web performance.
+        client = client.replace(wait_time=0)
+
+        # Test did:web performance (uncached resolution).
+        latency_did_web_uncached_submit_s = measure_latency(
+            lambda claim: client.submit_claim(claim, skip_confirmation=True),
+            lambda: crypto.sign_json_claimset(did_web.create_identity(), payload)
+        )
+        latency_did_web_uncached_submit_and_receipt_s = measure_latency(
+            lambda claim: client.submit_claim(claim, skip_confirmation=False),
+            lambda: crypto.sign_json_claimset(did_web.create_identity(), payload)
+        )
+
+        # Test did:web performance (cached resolution).
         identity = did_web.create_identity()
-        claims = crypto.sign_json_claimset(identity, payload)
+        claim = crypto.sign_json_claimset(identity, payload)
 
         # Make sure DID document is cached.
-        client.submit_claim(claims)
+        client.submit_claim(claim)
 
-        latency_did_web_submit_s = measure_latency(
-            lambda: client.submit_claim(claims, skip_confirmation=True, wait_time=0)
+        latency_did_web_cached_submit_s = measure_latency(
+            lambda _: client.submit_claim(claim, skip_confirmation=True)
         )
-        latency_did_web_submit_and_receipt_s = measure_latency(
-            lambda: client.submit_claim(claims, skip_confirmation=False, wait_time=0)
+        latency_did_web_cached_submit_and_receipt_s = measure_latency(
+            lambda _: client.submit_claim(claim, skip_confirmation=False)
         )
 
         # Test x5c performance.
         identity = x5c_ca.create_identity(1, **X5C_PARAMS)
-        claims = crypto.sign_json_claimset(identity, payload)
+        claim = crypto.sign_json_claimset(identity, payload)
 
         latency_x5c_submit_s = measure_latency(
-            lambda: client.submit_claim(claims, skip_confirmation=True, wait_time=0)
+            lambda _: client.submit_claim(claim, skip_confirmation=True)
         )
         latency_x5c_submit_and_receipt_s = measure_latency(
-            lambda: client.submit_claim(claims, skip_confirmation=False, wait_time=0)
+            lambda _: client.submit_claim(claim, skip_confirmation=False)
         )
 
-        # Note: Time-to-receipt depends on the configured signature interval of
+        # Time-to-receipt depends on the configured signature interval of
         # the CCF network and is hence just a rough estimate.
+        # Uncached did:web resolution uses a local server and is therefore
+        # faster than in a real-world scenario.
         stats = {
-            "latency_did_web_submit_s": latency_did_web_submit_s,
-            "latency_did_web_submit_and_receipt_s": latency_did_web_submit_and_receipt_s,
+            "latency_did_web_uncached_submit_s": latency_did_web_uncached_submit_s,
+            "latency_did_web_uncached_submit_and_receipt_s": latency_did_web_uncached_submit_and_receipt_s,
+            "latency_did_web_cached_submit_s": latency_did_web_cached_submit_s,
+            "latency_did_web_cached_submit_and_receipt_s": latency_did_web_cached_submit_and_receipt_s,
             "latency_x5c_submit_s": latency_x5c_submit_s,
             "latency_x5c_submit_and_receipt_s": latency_x5c_submit_and_receipt_s,
         }

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -24,14 +24,14 @@ def x5c_ca(client):
     return ca
 
 
-def measure_latency(fn, arg_fn=None):
+def measure_latency(fn, arg_fn=None, n=150):
     if arg_fn is None:
 
         def arg_fn():
             return None
 
     times = []
-    for _ in range(150):
+    for _ in range(n):
         arg = arg_fn()
         t_start = time.perf_counter()
         fn(arg)
@@ -53,13 +53,16 @@ class TestPerf:
         client = client.replace(wait_time=0.01, tcp_nodelay_patch=True)
 
         # Test did:web performance (uncached resolution).
+        uncached_repeat = 20
         latency_did_web_uncached_submit_s = measure_latency(
             lambda claim: client.submit_claim(claim, skip_confirmation=True),
             lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
+            n=uncached_repeat
         )
         latency_did_web_uncached_submit_and_receipt_s = measure_latency(
             lambda claim: client.submit_claim(claim, skip_confirmation=False),
             lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
+            n=uncached_repeat
         )
 
         # Test did:web performance (cached resolution).

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -57,12 +57,12 @@ class TestPerf:
         latency_did_web_uncached_submit_s = measure_latency(
             lambda claim: client.submit_claim(claim, skip_confirmation=True),
             lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
-            n=uncached_repeat
+            n=uncached_repeat,
         )
         latency_did_web_uncached_submit_and_receipt_s = measure_latency(
             lambda claim: client.submit_claim(claim, skip_confirmation=False),
             lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
-            n=uncached_repeat
+            n=uncached_repeat,
         )
 
         # Test did:web performance (cached resolution).

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -48,12 +48,12 @@ class TestPerf:
 
         latency_did_web_submit_s = measure_latency(
             lambda: client.submit_claim(
-                claims, skip_confirmation=True, decode=False, wait_time=0
+                claims, skip_confirmation=True, wait_time=0
             )
         )
         latency_did_web_submit_and_receipt_s = measure_latency(
             lambda: client.submit_claim(
-                claims, skip_confirmation=False, decode=False, wait_time=0
+                claims, skip_confirmation=False, wait_time=0
             )
         )
 
@@ -63,12 +63,12 @@ class TestPerf:
 
         latency_x5c_submit_s = measure_latency(
             lambda: client.submit_claim(
-                claims, skip_confirmation=True, decode=False, wait_time=0
+                claims, skip_confirmation=True, wait_time=0
             )
         )
         latency_x5c_submit_and_receipt_s = measure_latency(
             lambda: client.submit_claim(
-                claims, skip_confirmation=False, decode=False, wait_time=0
+                claims, skip_confirmation=False, wait_time=0
             )
         )
 

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -1,0 +1,86 @@
+import json
+import time
+
+import pytest
+
+from infra.x5chain_certificate_authority import X5ChainCertificateAuthority
+from pyscitt import crypto, governance
+
+
+@pytest.fixture(scope="class")
+def x5c_ca(client):
+    ca = X5ChainCertificateAuthority(alg="ES256", kty="ec", ec_curve="P-256")
+
+    client.governance.propose(
+        governance.set_ca_bundle_proposal("x509_roots", ca.cert_bundle),
+        must_pass=True,
+    )
+
+    return ca
+
+
+def measure_latency(f):
+    times = []
+    for _ in range(150):
+        t_start = time.perf_counter()
+        f()
+        t_end = time.perf_counter()
+        times.append(t_end - t_start)
+    return {
+        "avg": sum(times) / len(times),
+        "p99": sorted(times)[int(len(times) * 0.99)],
+        "min": min(times),
+        "max": max(times),
+    }
+
+
+@pytest.mark.perf
+class TestPerf:
+    def test_latency(self, client, did_web, x5c_ca):
+        payload = {"foo": "bar"}
+
+        # Test did:web performance.
+        identity = did_web.create_identity()
+        claims = crypto.sign_json_claimset(identity, payload)
+
+        # Make sure DID document is cached.
+        client.submit_claim(claims)
+
+        latency_did_web_submit_s = measure_latency(
+            lambda: client.submit_claim(
+                claims, skip_confirmation=True, decode=False, wait_time=0
+            )
+        )
+        latency_did_web_submit_and_receipt_s = measure_latency(
+            lambda: client.submit_claim(
+                claims, skip_confirmation=False, decode=False, wait_time=0
+            )
+        )
+
+        # Test x5c performance.
+        identity = x5c_ca.create_identity(1, alg="ES256")
+        claims = crypto.sign_json_claimset(identity, payload)
+
+        latency_x5c_submit_s = measure_latency(
+            lambda: client.submit_claim(
+                claims, skip_confirmation=True, decode=False, wait_time=0
+            )
+        )
+        latency_x5c_submit_and_receipt_s = measure_latency(
+            lambda: client.submit_claim(
+                claims, skip_confirmation=False, decode=False, wait_time=0
+            )
+        )
+
+        # Note: Time-to-receipt depends on the configured signature interval of
+        # the CCF network and is hence just a rough estimate.
+        stats = {
+            "latency_did_web_submit_s": latency_did_web_submit_s,
+            "latency_did_web_submit_and_receipt_s": latency_did_web_submit_and_receipt_s,
+            "latency_x5c_submit_s": latency_x5c_submit_s,
+            "latency_x5c_submit_and_receipt_s": latency_x5c_submit_and_receipt_s,
+        }
+
+        # Write stats to file for further analysis.
+        with open("perf.json", "w", encoding="utf-8") as fp:
+            json.dump(stats, fp, indent=2)


### PR DESCRIPTION
This implements some of #50, in particular the latency for `POST /entries` as well as time-to-receipt which involves further GET calls. It is implemented as a pytest that's disabled by default. It writes a `perf.json` to the current folder (added to `.gitignore`) which gets uploaded as pipeline artifact in CI.