### PR TITLE
Add tracing adapter

### DIFF
--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -7,6 +7,7 @@
 #include "did/resolver.h"
 #include "did/web/syntax.h"
 #include "kv_types.h"
+#include "tracing.h"
 
 #include <algorithm>
 #include <ccf/crypto/entropy.h>
@@ -98,7 +99,7 @@ namespace scitt::did::web
 
       auto callback = format_callback_url(did, tx);
 
-      CCF_APP_INFO("Triggering fetch of DID document for {}", did);
+      SCITT_INFO(fmt::format("Triggering fetch of DID document for {}", did));
       CCF_APP_DEBUG("DID fetch callback url: {}", callback);
       host_processes->trigger_host_process_launch(
         {DID_WEB_RESOLVER_SCRIPT, url, nonce, callback});

--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -99,7 +99,7 @@ namespace scitt::did::web
 
       auto callback = format_callback_url(did, tx);
 
-      SCITT_INFO("Triggering fetch of DID document for {}", did);
+      SCITT_INFO("Fetching DID document for {}", did);
       CCF_APP_DEBUG("DID fetch callback url: {}", callback);
       host_processes->trigger_host_process_launch(
         {DID_WEB_RESOLVER_SCRIPT, url, nonce, callback});

--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -8,9 +8,9 @@
 #include "did/web/syntax.h"
 #include "kv_types.h"
 #include "tracing.h"
+#include "util.h"
 
 #include <algorithm>
-#include <ccf/crypto/entropy.h>
 #include <ccf/ds/hex.h>
 #include <ccf/node/host_processes_interface.h>
 #include <ccf/node_context.h>
@@ -21,8 +21,6 @@
 
 namespace scitt::did::web
 {
-  const static crypto::EntropyPtr entropy = crypto::create_entropy();
-
   class DidWebResolver : public MethodResolver
   {
   private:
@@ -68,7 +66,7 @@ namespace scitt::did::web
       check_did_is_did_web(did);
 
       auto now = current_time.tv_sec;
-      auto nonce = ds::to_hex(entropy->random(16));
+      auto nonce = ds::to_hex(ENTROPY->random(16));
       // add nonce to query param for cache busting
       // TODO validate if this is fine security-wise
       auto url = get_did_web_doc_url_from_did(did) + "?" + nonce;

--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -99,7 +99,7 @@ namespace scitt::did::web
 
       auto callback = format_callback_url(did, tx);
 
-      SCITT_INFO(fmt::format("Triggering fetch of DID document for {}", did));
+      SCITT_INFO("Triggering fetch of DID document for {}", did);
       CCF_APP_DEBUG("DID fetch callback url: {}", callback);
       host_processes->trigger_host_process_launch(
         {DID_WEB_RESOLVER_SCRIPT, url, nonce, callback});

--- a/app/src/http_error.h
+++ b/app/src/http_error.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "tracing.h"
+
 namespace scitt
 {
   struct HTTPError : public std::runtime_error
@@ -88,7 +90,7 @@ namespace scitt
       }
       catch (const HTTPError& e)
       {
-        CCF_APP_INFO("HTTPError: {}", e.what());
+        SCITT_INFO(fmt::format("HTTPError: {}", e.what()));
         ctx.rpc_ctx->set_error(e.status_code, e.code, e.what());
         for (const auto& [header_name, header_value] : e.headers)
         {
@@ -97,7 +99,8 @@ namespace scitt
       }
       catch (const std::exception& e)
       {
-        CCF_APP_FAIL("Unhandled exception in endpoint: {}", e.what());
+        SCITT_FAIL(
+          fmt::format("Unhandled exception in endpoint: {}", e.what()));
         throw;
       }
     };

--- a/app/src/http_error.h
+++ b/app/src/http_error.h
@@ -90,7 +90,10 @@ namespace scitt
       }
       catch (const HTTPError& e)
       {
-        SCITT_INFO("HTTPError: {}", e.what());
+        if (e.code == errors::InternalError)
+          SCITT_FAIL("Code={} {}", e.code, e.what());
+        else
+          SCITT_INFO("Code={}", e.code);
         ctx.rpc_ctx->set_error(e.status_code, e.code, e.what());
         for (const auto& [header_name, header_value] : e.headers)
         {

--- a/app/src/http_error.h
+++ b/app/src/http_error.h
@@ -90,7 +90,7 @@ namespace scitt
       }
       catch (const HTTPError& e)
       {
-        SCITT_INFO(fmt::format("HTTPError: {}", e.what()));
+        SCITT_INFO("HTTPError: {}", e.what());
         ctx.rpc_ctx->set_error(e.status_code, e.code, e.what());
         for (const auto& [header_name, header_value] : e.headers)
         {
@@ -99,8 +99,7 @@ namespace scitt
       }
       catch (const std::exception& e)
       {
-        SCITT_FAIL(
-          fmt::format("Unhandled exception in endpoint: {}", e.what()));
+        SCITT_FAIL("Unhandled exception in endpoint: {}", e.what());
         throw;
       }
     };

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -285,6 +285,9 @@ namespace scitt
         });
 
         ctx.rpc_ctx->set_response_status(HTTP_STATUS_CREATED);
+
+        // TODO log CoseProfile
+        SCITT_INFO("ClaimSizeKb={}", body.size() / 1024);
       };
 
       make_endpoint(
@@ -672,7 +675,7 @@ namespace scitt
           std::move(resolution.resolution_metadata);
 
         issuers->put(issuer, issuer_info.value());
-        SCITT_INFO("Updated DID document for issuer {}", issuer);
+        SCITT_INFO("Updated DID document for {}", issuer);
 
         return ccf::make_success();
       };

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -162,12 +162,10 @@ namespace scitt
           return this->get_untrusted_host_time_v1(time);
         };
 
-      return ccf::UserEndpointRegistry::make_endpoint_with_local_commit_handler(
-        method,
-        verb,
-        tracing_adapter(error_adapter(f), method, get_time),
-        tracing_local_commit_callback,
-        ap);
+      auto endpoint = ccf::UserEndpointRegistry::make_endpoint(
+        method, verb, tracing_adapter(error_adapter(f), method, get_time), ap);
+      endpoint.locally_committed_func = tracing_local_commit_callback;
+      return endpoint;
     }
 
   public:
@@ -827,7 +825,6 @@ namespace scitt
         .install();
 
 #ifdef ENABLE_PREFIX_TREE
-      // TODO local variant of make_endpoint in all endpoints
       PrefixTreeFrontend::init_handlers(context, *this);
 #endif
     }

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -672,7 +672,7 @@ namespace scitt
           std::move(resolution.resolution_metadata);
 
         issuers->put(issuer, issuer_info.value());
-        SCITT_INFO(fmt::format("Updated DID document for issuer {}", issuer));
+        SCITT_INFO("Updated DID document for issuer {}", issuer);
 
         return ccf::make_success();
       };

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -190,13 +190,6 @@ namespace scitt
 
       verifier = std::make_unique<verifier::Verifier>(std::move(resolver));
 
-      timespec untrusted_host_time;
-      const auto result = get_untrusted_host_time_v1(untrusted_host_time);
-      if (result == ccf::ApiResult::OK)
-      {
-        srand(untrusted_host_time.tv_sec);
-      }
-
       static constexpr auto post_entry_path = "/entries";
       auto post_entry = [this](EndpointContext& ctx) {
         auto& body = ctx.rpc_ctx->get_request_body();

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -290,10 +290,11 @@ namespace scitt
         SCITT_INFO("ClaimSizeKb={}", body.size() / 1024);
       };
 
-      make_endpoint(
+      make_endpoint_with_local_commit_handler(
         post_entry_path,
         HTTP_POST,
         tracing_adapter(error_adapter(post_entry), get_time),
+        tracing_local_commit_callback,
         authn_policy)
         .install();
 
@@ -680,11 +681,12 @@ namespace scitt
         return ccf::make_success();
       };
 
-      make_endpoint(
+      make_endpoint_with_local_commit_handler(
         update_did_doc_path,
         HTTP_POST,
         tracing_adapter(
           error_adapter(ccf::json_adapter(update_did_doc)), get_time),
+        tracing_local_commit_callback,
         no_authn_policy)
         .set_auto_schema<PostDidResolution::In, void>()
         .install();

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -100,6 +100,7 @@ namespace scitt
           "x-ms-client-request-id", client_request_id.value());
       }
 
+      // The user data is used to propagate the request IDs to the local commit callback
       ctx.rpc_ctx->set_user_data(
         std::make_shared<AppData>(AppData{request_id, client_request_id}));
 

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "constants.h"
+#include "util.h"
 
 #include <ccf/base_endpoint_registry.h>
 #include <ccf/endpoint_context.h>
@@ -44,7 +45,7 @@ namespace scitt
 
   std::string create_request_id()
   {
-    return fmt::format("{:x}", rand());
+    return fmt::format("{:x}", ENTROPY->random64());
   }
 
 #define SCITT_INFO(s, ...) \

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -44,9 +44,7 @@ namespace scitt
 
   std::string create_request_id()
   {
-    std::stringstream stream;
-    stream << std::hex << rand();
-    return stream.str();
+      return fmt::format("{:x}", rand());
   }
 
 #define SCITT_INFO(s, ...) \

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -37,23 +37,19 @@ namespace scitt
     return stream.str();
   }
 
-  inline void SCITT_INFO(const std::string& msg)
-  {
-    CCF_APP_INFO(
-      "ClientRequestId={} RequestId={} {}",
-      client_request_id.value_or(""),
-      request_id,
-      msg);
-  }
+#define SCITT_INFO(s, ...) \
+  CCF_APP_INFO( \
+    "ClientRequestId={} RequestId={} " s, \
+    client_request_id.value_or(""), \
+    request_id, \
+    ##__VA_ARGS__)
 
-  inline void SCITT_FAIL(const std::string& msg)
-  {
-    CCF_APP_FAIL(
-      "ClientRequestId={} RequestId={} {}",
-      client_request_id.value_or(""),
-      request_id,
-      msg);
-  }
+#define SCITT_FAIL(s, ...) \
+  CCF_APP_FAIL( \
+    "ClientRequestId={} RequestId={} " s, \
+    client_request_id.value_or(""), \
+    request_id, \
+    ##__VA_ARGS__)
 
   template <typename Fn, typename Ctx>
   Fn generic_tracing_adapter(
@@ -91,11 +87,11 @@ namespace scitt
           "x-ms-client-request-id", client_request_id.value());
       }
 
-      SCITT_INFO(fmt::format(
+      SCITT_INFO(
         "Verb={} Path={} Query={}",
         ctx.rpc_ctx->get_request_verb().c_str(),
         ctx.rpc_ctx->get_request_path(),
-        ctx.rpc_ctx->get_request_query()));
+        ctx.rpc_ctx->get_request_query());
 
       ::timespec start;
       ccf::ApiResult result = get_time(start);
@@ -125,13 +121,13 @@ namespace scitt
 
       auto duration_ms = diff_timespec_ms(start, end);
 
-      SCITT_INFO(fmt::format(
+      SCITT_INFO(
         "Verb={} Path={} Query={} Status={} TimeMs={}",
         ctx.rpc_ctx->get_request_verb().c_str(),
         ctx.rpc_ctx->get_request_path(),
         ctx.rpc_ctx->get_request_query(),
         ctx.rpc_ctx->get_response_status(),
-        duration_ms));
+        duration_ms);
     };
   }
 

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -86,9 +86,8 @@ namespace scitt
       {
         // Validate client request id to avoid misinterpretation of the log,
         // e.g. if it contains a space.
-        std::smatch match;
         if (!std::regex_match(
-              client_request_id.value(), match, CLIENT_REQUEST_ID_REGEX))
+              client_request_id.value(), CLIENT_REQUEST_ID_REGEX))
         {
           client_request_id = std::nullopt;
           SCITT_INFO("Code=InvalidInput Invalid client request id");

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -14,10 +14,10 @@
 
 namespace scitt
 {
-  std::string REQUEST_ID_HEADER = "x-ms-request-id";
-  std::string CLIENT_REQUEST_ID_HEADER = "x-ms-client-request-id";
+  constexpr std::string_view REQUEST_ID_HEADER = "x-ms-request-id";
+  constexpr std::string_view CLIENT_REQUEST_ID_HEADER = "x-ms-client-request-id";
 
-  std::regex CLIENT_REQUEST_ID_REGEX("^[0-9a-zA-Z-]+");
+  const std::regex CLIENT_REQUEST_ID_REGEX("^[0-9a-zA-Z-]+");
 
   thread_local std::string request_id;
   thread_local std::optional<std::string> client_request_id;
@@ -56,6 +56,11 @@ namespace scitt
     Fn fn, const std::function<ccf::ApiResult(::timespec& time)>& get_time)
   {
     return [fn, get_time](Ctx& ctx) {
+      auto cleanup = finally([] {
+        request_id = "";
+        client_request_id = std::nullopt;
+      });
+
       request_id = create_request_id();
       ctx.rpc_ctx->set_response_header(REQUEST_ID_HEADER, request_id);
 

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "constants.h"
+
+#include <time.h>
+#include <regex>
+#include <sstream>
+#include <functional>
+#include <ccf/endpoint_context.h>
+#include <ccf/base_endpoint_registry.h>
+
+namespace scitt
+{
+  std::string REQUEST_ID_HEADER = "x-ms-request-id";
+  std::string CLIENT_REQUEST_ID_HEADER = "x-ms-client-request-id";
+
+  std::regex CLIENT_REQUEST_ID_REGEX("^[0-9a-zA-Z-]+");
+
+  thread_local std::string request_id;
+  thread_local std::optional<std::string> client_request_id;
+
+  int diff_timespec_ms(const struct timespec& time0, const struct timespec& time1) {
+    return (time1.tv_sec - time0.tv_sec) * 1000
+        + (time1.tv_nsec - time0.tv_nsec) / 1000000;
+  }
+
+  std::string create_request_id() {
+    std::stringstream stream;
+    stream << std::hex << rand();
+    return stream.str();
+  }
+
+  inline void SCITT_INFO(const std::string& msg)
+  {
+    CCF_APP_INFO("ClientRequestId={} RequestId={} {}",
+        client_request_id.value_or(""),
+        request_id,
+        msg
+        );
+  }
+
+  inline void SCITT_FAIL(const std::string& msg)
+  {
+    CCF_APP_FAIL("ClientRequestId={} RequestId={} {}",
+        client_request_id.value_or(""),
+        request_id,
+        msg
+        );
+  }
+
+  template <typename Fn, typename Ctx>
+  Fn generic_tracing_adapter(
+    Fn fn, const std::function<ccf::ApiResult(::timespec& time)>& get_time)
+  {
+    return [fn, get_time](Ctx& ctx) {
+      request_id = create_request_id();
+      ctx.rpc_ctx->set_response_header(REQUEST_ID_HEADER, request_id);
+
+      client_request_id = ctx.rpc_ctx->get_request_header(CLIENT_REQUEST_ID_HEADER);
+
+      if (client_request_id.has_value())
+      {
+        std::smatch match;
+        if (!std::regex_match(client_request_id.value(), match, CLIENT_REQUEST_ID_REGEX))
+        {
+          client_request_id = std::nullopt;
+          SCITT_INFO("Invalid client request id");
+          ctx.rpc_ctx->set_error(HTTP_STATUS_BAD_REQUEST, errors::InvalidInput, "Invalid client request id.");
+          return;
+        }
+        ctx.rpc_ctx->set_response_header("x-ms-client-request-id", client_request_id.value());
+      }
+
+      SCITT_INFO(fmt::format("Verb={} Path={} Query={}",
+        ctx.rpc_ctx->get_request_verb().c_str(),
+        ctx.rpc_ctx->get_request_path(),
+        ctx.rpc_ctx->get_request_query()
+        ));
+
+      ::timespec start;
+      ccf::ApiResult result = get_time(start);
+      if (result != ccf::ApiResult::OK)
+      {
+        SCITT_FAIL("get_untrusted_host_time_v1 failed");
+        ctx.rpc_ctx->set_error(HTTP_STATUS_INTERNAL_SERVER_ERROR, errors::InternalError, "Failed to get time.");
+        return;
+      }
+
+      fn(ctx);
+
+      ::timespec end;
+      result = get_time(end);
+      if (result != ccf::ApiResult::OK)
+      {
+        SCITT_FAIL("get_untrusted_host_time_v1 failed");
+        ctx.rpc_ctx->set_error(HTTP_STATUS_INTERNAL_SERVER_ERROR, errors::InternalError, "Failed to get time.");
+        return;
+      }
+
+      auto duration_ms = diff_timespec_ms(start, end);
+      
+      SCITT_INFO(fmt::format("Verb={} Path={} Query={} Status={} TimeMs={}",
+        ctx.rpc_ctx->get_request_verb().c_str(),
+        ctx.rpc_ctx->get_request_path(),
+        ctx.rpc_ctx->get_request_query(),
+        ctx.rpc_ctx->get_response_status(),
+        duration_ms
+        ));
+    };
+  }
+
+  /**
+   * Create an adapter around an existing EndpointFunction to handle tracing.
+   */
+  ccf::endpoints::EndpointFunction tracing_adapter(
+    ccf::endpoints::EndpointFunction fn, const std::function<ccf::ApiResult(::timespec& time)>& get_time)
+  {
+    return generic_tracing_adapter<
+      ccf::endpoints::EndpointFunction,
+      ccf::endpoints::EndpointContext>(fn, get_time);
+  }
+
+  ccf::endpoints::ReadOnlyEndpointFunction tracing_read_only_adapter(
+    ccf::endpoints::ReadOnlyEndpointFunction fn, const std::function<ccf::ApiResult(::timespec& time)>& get_time)
+  {
+    return generic_tracing_adapter<
+      ccf::endpoints::ReadOnlyEndpointFunction,
+      ccf::endpoints::ReadOnlyEndpointContext>(fn, get_time);
+  }
+
+  ccf::endpoints::CommandEndpointFunction tracing_command_adapter(
+    ccf::endpoints::CommandEndpointFunction fn, const std::function<ccf::ApiResult(::timespec& time)>& get_time)
+  {
+    return generic_tracing_adapter<
+      ccf::endpoints::CommandEndpointFunction,
+      ccf::endpoints::CommandEndpointContext>(fn, get_time);
+  }
+}

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -61,7 +61,7 @@ namespace scitt
   if (client_request_id.has_value()) \
     CCF_APP_FAIL( \
       "ClientRequestId={} RequestId={} " s, \
-      client_request_id.value_or(""), \
+      client_request_id.value(), \
       request_id, \
       ##__VA_ARGS__); \
   else \

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -68,6 +68,8 @@ namespace scitt
 
       if (client_request_id.has_value())
       {
+        // Validate client request id to avoid misinterpretation of the log,
+        // e.g. if it contains a space.
         std::smatch match;
         if (!std::regex_match(client_request_id.value(), match, CLIENT_REQUEST_ID_REGEX))
         {

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <ccf/crypto/entropy.h>
 #include <ccf/crypto/pem.h>
 #include <string>
 #include <string_view>
@@ -11,6 +12,8 @@
 
 namespace scitt
 {
+  const static crypto::EntropyPtr ENTROPY = crypto::create_entropy();
+
   static std::vector<crypto::Pem> split_x509_cert_bundle(
     const std::string_view& pem)
   {

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -45,27 +45,32 @@ namespace scitt
   class final_action
   {
   public:
-      explicit final_action(const F& ff) noexcept : f{ff} { }
-      explicit final_action(F&& ff) noexcept : f{std::move(ff)} { }
+    explicit final_action(const F& ff) noexcept : f{ff} {}
+    explicit final_action(F&& ff) noexcept : f{std::move(ff)} {}
 
-      ~final_action() noexcept { if (invoke) f(); }
+    ~final_action() noexcept
+    {
+      if (invoke)
+        f();
+    }
 
-      final_action(final_action&& other) noexcept
-          : f(std::move(other.f)), invoke(std::exchange(other.invoke, false))
-      { }
+    final_action(final_action&& other) noexcept :
+      f(std::move(other.f)),
+      invoke(std::exchange(other.invoke, false))
+    {}
 
-      final_action(const final_action&)   = delete;
-      void operator=(const final_action&) = delete;
-      void operator=(final_action&&)      = delete;
+    final_action(const final_action&) = delete;
+    void operator=(const final_action&) = delete;
+    void operator=(final_action&&) = delete;
 
   private:
-      F f;
-      bool invoke = true;
+    F f;
+    bool invoke = true;
   };
 
   template <class F>
   [[nodiscard]] auto finally(F&& f) noexcept
   {
-      return final_action<std::decay_t<F>>{std::forward<F>(f)};
+    return final_action<std::decay_t<F>>{std::forward<F>(f)};
   }
 }

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -39,4 +39,33 @@ namespace scitt
   {
     return v.find(e) != v.end();
   }
+
+  // From Microsoft's GSL utilities.
+  template <class F>
+  class final_action
+  {
+  public:
+      explicit final_action(const F& ff) noexcept : f{ff} { }
+      explicit final_action(F&& ff) noexcept : f{std::move(ff)} { }
+
+      ~final_action() noexcept { if (invoke) f(); }
+
+      final_action(final_action&& other) noexcept
+          : f(std::move(other.f)), invoke(std::exchange(other.invoke, false))
+      { }
+
+      final_action(const final_action&)   = delete;
+      void operator=(const final_action&) = delete;
+      void operator=(final_action&&)      = delete;
+
+  private:
+      F f;
+      bool invoke = true;
+  };
+
+  template <class F>
+  [[nodiscard]] auto finally(F&& f) noexcept
+  {
+      return final_action<std::decay_t<F>>{std::forward<F>(f)};
+  }
 }

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -59,6 +59,7 @@ class HttpSig(httpx.Auth):
 
 @dataclass
 class ServiceError(Exception):
+    headers: dict
     code: str
     message: str
 
@@ -265,7 +266,7 @@ class BaseClient:
 
         if not response.is_success:
             error = response.json()["error"]
-            raise ServiceError(error["code"], error["message"])
+            raise ServiceError(response.headers, error["code"], error["message"])
 
         if wait_for_confirmation:
             self.wait_for_confirmation(response.headers[CCF_TX_ID_HEADER])

--- a/test/test_tracing.py
+++ b/test/test_tracing.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import re
+
+import pytest
+
+from pyscitt.client import Client, ServiceError
+
+REQUEST_ID_HEADER = "x-ms-request-id"
+CLIENT_REQUEST_ID_HEADER = "x-ms-client-request-id"
+REQUEST_ID_REGEX = re.compile(r"[0-9a-f]+")
+
+def test_tracing_headers(client: Client):
+    response = client.get("/version")
+    assert CLIENT_REQUEST_ID_HEADER not in response.headers
+    assert REQUEST_ID_REGEX.match(response.headers[REQUEST_ID_HEADER])
+
+    response = client.get("/version", headers={CLIENT_REQUEST_ID_HEADER: "123"})
+    assert response.headers[CLIENT_REQUEST_ID_HEADER] == "123"
+    assert REQUEST_ID_REGEX.match(response.headers[REQUEST_ID_HEADER])
+
+    with pytest.raises(ServiceError, match="InvalidInput") as exc_info:
+        client.get("/version", headers={CLIENT_REQUEST_ID_HEADER: "123 456"})
+    error = exc_info.value
+    assert CLIENT_REQUEST_ID_HEADER not in error.headers
+    assert REQUEST_ID_REGEX.match(error.headers[REQUEST_ID_HEADER])

--- a/test/test_tracing.py
+++ b/test/test_tracing.py
@@ -11,6 +11,7 @@ REQUEST_ID_HEADER = "x-ms-request-id"
 CLIENT_REQUEST_ID_HEADER = "x-ms-client-request-id"
 REQUEST_ID_REGEX = re.compile(r"[0-9a-f]+")
 
+
 def test_tracing_headers(client: Client):
     response = client.get("/version")
     assert CLIENT_REQUEST_ID_HEADER not in response.headers


### PR DESCRIPTION
Closes #74 and #72.

TODO:
- Create issue to allow extending tracing adapter log messages (e.g. for attaching error code instead of logging a separate message; similarly for logging the TxId)