### PR TITLE
Assorted Notary mark ups

### DIFF
--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -6,6 +6,7 @@
 #include "cbor.h"
 #include "openssl_wrappers.h"
 #include "public_key.h"
+#include "tracing.h"
 #include "util.h"
 
 #include <ccf/crypto/base64.h>
@@ -140,7 +141,7 @@ namespace scitt::cose
         // byte string, not an array.
         // But other implementations mistakenly serialise single certs as bstrs
         // in arrays, so we are not strict here.
-        CCF_APP_INFO("Single cert found in x5chain array in COSE header.");
+        SCITT_INFO("Single cert found in x5chain array in COSE header.");
       }
     }
     else if (x5chain.uDataType == QCBOR_TYPE_BYTE_STRING)
@@ -149,7 +150,7 @@ namespace scitt::cose
     }
     else
     {
-      CCF_APP_FAIL("Type: {}", x5chain.uDataType);
+      SCITT_FAIL("Type: {}", x5chain.uDataType);
       throw COSEDecodeError(
         "Value type of x5chain in COSE header is not array or byte "
         "string.");

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -426,7 +426,7 @@ namespace scitt::cose
     auto error = QCBORDecode_Finish(&ctx);
     if (error)
     {
-      throw std::runtime_error("Failed to decode COSE_Sign1");
+      throw COSEDecodeError("Failed to decode COSE_Sign1");
     }
     return std::make_tuple(phdr, uhdr);
   }

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -79,7 +79,7 @@ namespace scitt::verifier
       auto issuer = phdr.issuer;
       auto kid = phdr.kid;
 
-      if (!phdr.issuer.has_value())
+      if (!issuer.has_value())
       {
         throw cose::COSEDecodeError("Missing issuer in protected header");
       }
@@ -89,11 +89,6 @@ namespace scitt::verifier
       }
 
       std::optional<std::string> assertion_method_id;
-      if (!issuer.has_value())
-      {
-        throw VerificationError(
-          "Issuer was missing as a part of the decoded header.");
-      }
 
       if (kid.has_value())
       {
@@ -273,22 +268,35 @@ namespace scitt::verifier
       // Validate protected header
       validate_notary_protected_header(phdr, configuration);
 
-      // Validate unprotected header
-      // Unprotected header must contain x5chain else the notary claim cannot be
-      // verified.
-      if (!uhdr.x5chain.has_value())
+      std::vector<std::vector<uint8_t>> x5chain{};
+
+      if (phdr.x5chain.has_value() and uhdr.x5chain.has_value())
       {
         throw VerificationError(
-          "Notary claim's unprotected header is missing an x5chain (label 33) "
-          "parameter.");
+          "Notary claim has an x5chain (label 33) "
+          "parameter in both its protected and unprotected header.");
+      }
+      else if (phdr.x5chain.has_value())
+      {
+        SCITT_INFO("Notary x5chain in protected header.");
+        x5chain = phdr.x5chain.value();
+      }
+      else if (uhdr.x5chain.has_value())
+      {
+        SCITT_INFO("Notary x5chain in unprotected header.");
+        x5chain = uhdr.x5chain.value();
+      }
+      else
+      {
+        throw VerificationError(
+          "Notary claim is missing an x5chain (label 33) "
+          "parameter in its headers.");
       }
 
-      PublicKey key;
       // Verify the chain of certs against the x509 root store.
       auto roots = x509_root_store(tx);
-      auto cert = verify_chain(roots, uhdr.x5chain.value());
-      key = PublicKey(cert, std::nullopt);
-      return key;
+      auto cert = verify_chain(roots, x5chain);
+      return PublicKey(cert, std::nullopt);
     }
 
     ClaimProfile verify_claim(
@@ -358,14 +366,6 @@ namespace scitt::verifier
           }
 
           return ClaimProfile::X509;
-        }
-        else if (phdr.profile.has_value())
-        {
-          SCITT_INFO(
-            "Unknown COSE profile in protected header: {}",
-            phdr.profile.value());
-          throw cose::COSEDecodeError(
-            "Unknown COSE profile in protected header");
         }
         else
         {

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -270,7 +270,7 @@ namespace scitt::verifier
 
       std::vector<std::vector<uint8_t>> x5chain{};
 
-      if (phdr.x5chain.has_value() and uhdr.x5chain.has_value())
+      if (phdr.x5chain.has_value() && uhdr.x5chain.has_value())
       {
         throw VerificationError(
           "Notary claim has an x5chain (label 33) "

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -54,10 +54,6 @@ class TestNonCanonicalEncoding:
         """The ledger should accept claims even if not canonically encoded."""
         client.submit_claim(claim)
 
-    @pytest.mark.xfail(
-        reason="pycose does not preserve the original encoding (https://github.com/TimothyClaeys/pycose/pull/91)",
-        raises=InvalidSignature,
-    )
     def test_verify_receipt(self, client: Client, trust_store, claim):
         """We should be able to verify the produced receipt."""
         # Once the xfail is fixed, this test can be merged with test_submit_claim.


### PR DESCRIPTION
Implementing hangover review comments from https://github.com/microsoft/scitt-ccf-ledger/pull/73 addressing https://github.com/microsoft/scitt-ccf-ledger/issues/84

Featuring:
- x5chain (de)serialization 
- QCBOR tweaks
- Cleaning up redundant code  
- Notary spec allows x5chain in the protected header (but currently notation always puts it in the unprotected headers). We now check for the x5chain in the protected header of notary claims before the unprotected header. 