### PR TITLE
Miscellaneous fixes

### DIFF
--- a/pyscitt/pyscitt/cli/create_did_web.py
+++ b/pyscitt/pyscitt/cli/create_did_web.py
@@ -25,7 +25,6 @@ def create_did_web(
     kty: str,
     alg: Optional[str],
 ):
-
     parsed = urlsplit(base_url)
     assert parsed.hostname
     did = format_did_web(

--- a/pyscitt/pyscitt/cli/prefix_tree.py
+++ b/pyscitt/pyscitt/cli/prefix_tree.py
@@ -32,7 +32,6 @@ def prefix_tree_get_receipt(
     output: Optional[Path],
     service_trust_store_path: Path,
 ):
-
     if claim_path:
         claim = CoseMessage.decode(claim_path.read_bytes())
 

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -17,7 +17,6 @@ def retrieve_signed_claimsets(
     to_seqno: Optional[int],
     service_trust_store_path: Optional[Path],
 ):
-
     base_path.mkdir(parents=True, exist_ok=True)
 
     if service_trust_store_path:

--- a/pyscitt/pyscitt/cli/submit_signed_claims.py
+++ b/pyscitt/pyscitt/cli/submit_signed_claims.py
@@ -17,7 +17,6 @@ def submit_signed_claimset(
     service_trust_store_path: Optional[Path],
     skip_confirmation: bool,
 ):
-
     if path.suffix != ".cose":
         raise ValueError("unsupported file extension")
 

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -566,7 +566,6 @@ def load_private_key(key_path: Path) -> Pem:
 def create_did_document(
     did: str, pub_key_pem: Pem, alg: Optional[str] = None, kid: Optional[str] = None
 ) -> dict:
-
     pub_key = load_pem_public_key(pub_key_pem.encode("ascii"))
     der = pub_key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
 

--- a/pyscitt/pyscitt/receipt.py
+++ b/pyscitt/pyscitt/receipt.py
@@ -28,8 +28,20 @@ def hdr_as_dict(phdr: dict) -> dict:
     Return a representation of a list of COSE header parameters that
     is amenable to pretty-printing.
     """
-    display = lambda v: v.__name__ if hasattr(v, "__name__") else v
-    return {display(k): display(v) for k, v in phdr.items()}
+
+    def display(item):
+        if hasattr(item, "__name__"):
+            return item.__name__
+        if type(item) is bytes:
+            return item.hex()
+        return item
+
+    # Decode KID into a 'readable' text string if present.
+    hdr_dict = {display(k): display(v) for k, v in phdr.items()}
+    if hdr_dict.get("KID"):
+        hdr_dict["KID"] = bytes.fromhex(hdr_dict["KID"]).decode()
+
+    return hdr_dict
 
 
 @dataclass

--- a/start.sh
+++ b/start.sh
@@ -27,7 +27,7 @@ source venv/bin/activate
 pip install --disable-pip-version-check -e ./pyscitt
 pip install --disable-pip-version-check -q -r test/requirements.txt
 
-exec python3.8 test/infra/cchost.py \
+exec python3.8 -m test.infra.cchost \
     --port 8000 \
     --cchost $CCF_DIR/bin/cchost \
     --package $SCITT_DIR/lib/libscitt \

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-pytest_plugins = "infra.fixtures"
+pytest_plugins = "test.infra.fixtures"
 
 
 def pytest_addoption(parser):

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -29,6 +29,7 @@ class UnexpectedExitException(Exception):
 LOG.level("FAIL", no=60, color="<red>")
 LOG.level("FATAL", no=60, color="<red>")
 
+
 # Python 3.11 would make this obsolete with 'except*'
 def match_taskgroup_error(group: aiotools.TaskGroupError, expected: type):
     errors = group.__errors__

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -5,9 +5,10 @@ from pathlib import Path
 
 import pytest
 
-from infra.jwt_issuer import JwtIssuer
 from pyscitt import crypto
 from pyscitt.client import Client, ServiceError
+
+from .infra.jwt_issuer import JwtIssuer
 
 
 class TestAuthentication:

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -11,11 +11,12 @@ import pycose.headers
 import pytest
 from pycose.messages import Sign1Message
 
-from infra.did_web_server import DIDWebServer
-from infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 from pyscitt import crypto, governance
 from pyscitt.client import Client, ServiceError
 from pyscitt.verify import verify_receipt
+
+from .infra.did_web_server import DIDWebServer
+from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 
 
 # Temporary monkey-patch for pycose until https://github.com/TimothyClaeys/pycose/pull/107

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -10,7 +10,6 @@ import pytest
 from loguru import logger as LOG
 from pycose.messages import CoseMessage
 
-from infra.did_web_server import DIDWebServer
 from pyscitt import crypto, did
 from pyscitt.cli.governance import (
     SCITT_CONSTITUTION_MARKER_END,
@@ -19,6 +18,8 @@ from pyscitt.cli.governance import (
 from pyscitt.cli.main import main
 from pyscitt.client import Client, ServiceError
 from pyscitt.governance import ProposalNotAccepted
+
+from .infra.did_web_server import DIDWebServer
 
 
 @pytest.fixture

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -7,12 +7,13 @@ import httpx
 import pycose
 import pytest
 
-from infra.did_web_server import DIDWebServer
 from pyscitt import crypto
 from pyscitt.client import Client, ServiceError
 from pyscitt.did import Resolver, did_web_document_url
 from pyscitt.receipt import Receipt
 from pyscitt.verify import DIDResolverTrustStore, verify_receipt
+
+from .infra.did_web_server import DIDWebServer
 
 
 class TestAcceptedAlgorithms:

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -6,8 +6,9 @@ import time
 
 import pytest
 
-from infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 from pyscitt import crypto, governance
+
+from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 
 X5C_PARAMS = dict(alg="ES256", kty="ec", ec_curve="P-256")
 


### PR DESCRIPTION
- Tweak imports to fix `start.sh` and keep mypy happy.
- Tweak receipt.py to fix the `pyscitt.sh pretty-receipt` command.
    - Adds special case to print `KID` as ascii rather than hexadecimal.