### PR TITLE
Miscellaneous tidying

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,7 +15,6 @@ project(scitt
 )
 
 set(COMPILE_TARGET "sgx" CACHE STRING "Target compilation platform, either 'sgx' or 'virtual'")
-option(ENABLE_DEBUG_MALLOC "Enable Open Enclave's debug malloc for enclave builds" OFF)
 set(ATTESTED_FETCH_MRENCLAVE_HEX "" CACHE STRING "attested-fetch MRENCLAVE (hex)")
 message(STATUS "ATTESTED_FETCH_MRENCLAVE_HEX=${ATTESTED_FETCH_MRENCLAVE_HEX}")
 option(CCF_UNSAFE "Use CCF's unsafe variant (must be separately installed)" OFF)
@@ -93,7 +92,7 @@ if (BUILD_TESTS)
     message(FATAL_ERROR "Unit tests are not supported on SGX builds. Set BUILD_TESTS=OFF to disable them.")
   endif()
 
-  # Avoid Gtest files ending up in the scitt install directory   
+  # Avoid Gtest files ending up in the scitt install directory
   set(INSTALL_GTEST OFF)
   include(FetchContent)
   FetchContent_Declare(

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,6 @@ CC="$CC" CXX="$CXX" \
     -DENABLE_PREFIX_TREE="${ENABLE_PREFIX_TREE}" \
     -DBUILD_TESTS="${BUILD_TESTS}" \
     -DLVI_MITIGATIONS=OFF \
-    -DENABLE_DEBUG_MALLOC=OFF \
     -DCMAKE_INSTALL_PREFIX=$install_dir \
     "$root_dir/app"
 

--- a/pyscitt/pyscitt/cli/governance.py
+++ b/pyscitt/pyscitt/cli/governance.py
@@ -5,7 +5,6 @@ import argparse
 import json
 import sys
 from dataclasses import dataclass
-from functools import partial
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, Union

--- a/pyscitt/pyscitt/cli/prefix_tree.py
+++ b/pyscitt/pyscitt/cli/prefix_tree.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from pycose.messages import CoseMessage
 
-from .. import crypto, prefix_tree
+from .. import prefix_tree
 from ..client import Client
 from ..crypto import COSE_HEADER_PARAM_FEED, COSE_HEADER_PARAM_ISSUER
 from ..verify import StaticTrustStore

--- a/pyscitt/pyscitt/cli/validate_cose.py
+++ b/pyscitt/pyscitt/cli/validate_cose.py
@@ -4,7 +4,6 @@ import argparse
 from pathlib import Path
 from typing import Optional
 
-from .. import crypto
 from ..verify import StaticTrustStore, verify_receipt
 
 

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -7,13 +7,10 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Generic, Iterable, Literal, Optional, Tuple, TypeVar, Union, overload
+from typing import Iterable, Literal, Optional, TypeVar, Union, overload
 from urllib.parse import urlencode
 
 import httpx
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from loguru import logger as LOG
 
 from . import crypto

--- a/pyscitt/pyscitt/local_key_sign_client.py
+++ b/pyscitt/pyscitt/local_key_sign_client.py
@@ -5,7 +5,6 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from loguru import logger as LOG
 
 from pyscitt.client import MemberAuthenticationMethod
 

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -6,26 +6,19 @@ import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Dict, Optional, Union
 
 import cbor2
 import pycose
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.x509 import load_pem_x509_certificate
 from pycose.keys.ec2 import EC2Key
 from pycose.keys.rsa import RSAKey
 from pycose.messages import Sign1Message
 
 from . import crypto, did
-from .crypto import (
-    COSE_HEADER_PARAM_ISSUER,
-    COSE_HEADER_PARAM_SCITT_RECEIPTS,
-    Pem,
-    cert_der_to_pem,
-    convert_jwk_to_pem,
-    get_cert_public_key,
-)
+from .crypto import COSE_HEADER_PARAM_ISSUER, COSE_HEADER_PARAM_SCITT_RECEIPTS
 from .receipt import Receipt
 
 

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -47,7 +47,8 @@ echo "Setting up python virtual environment."
 if [ ! -f "venv/bin/activate" ]; then
     python3.8 -m venv "venv"
 fi
-source venv/bin/activate 
+source venv/bin/activate
+pip install --disable-pip-version-check -q wheel
 pip install --disable-pip-version-check -q -e ./pyscitt
 pip install --disable-pip-version-check -q -r test/requirements.txt
 

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -48,8 +48,8 @@ if [ ! -f "venv/bin/activate" ]; then
     python3.8 -m venv "venv"
 fi
 source venv/bin/activate
-pip install --disable-pip-version-check -q wheel
 pip install --disable-pip-version-check -q -e ./pyscitt
+pip install --disable-pip-version-check -q wheel
 pip install --disable-pip-version-check -q -r test/requirements.txt
 
 echo "Running functional tests..."

--- a/start.sh
+++ b/start.sh
@@ -24,7 +24,8 @@ if [ ! -f "venv/bin/activate" ]; then
     python3.8 -m venv "venv"
 fi
 source venv/bin/activate
-pip install --disable-pip-version-check -e ./pyscitt
+pip install --disable-pip-version-check -q -e ./pyscitt
+pip install --disable-pip-version-check -q wheel
 pip install --disable-pip-version-check -q -r test/requirements.txt
 
 exec python3.8 -m test.infra.cchost \

--- a/test/infra/async_utils.py
+++ b/test/infra/async_utils.py
@@ -4,7 +4,7 @@
 import asyncio
 import threading
 from abc import ABC, abstractmethod
-from typing import Any, Awaitable, List, Optional
+from typing import Any, Awaitable, Optional
 
 import aiotools
 

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -1,9 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import itertools
 import os
-import time
 from contextlib import contextmanager
 from http import HTTPStatus
 from pathlib import Path
@@ -16,7 +14,7 @@ from pyscitt import governance
 from pyscitt.client import Client
 from pyscitt.did import format_did_web
 from pyscitt.local_key_sign_client import LocalKeySignClient
-from pyscitt.verify import ServiceParameters, StaticTrustStore
+from pyscitt.verify import StaticTrustStore
 
 from .cchost import CCHost, get_default_cchost_path, get_enclave_path
 from .did_web_server import DIDWebServer

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from pathlib import Path
-
 import pytest
 
 from pyscitt import crypto

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 import json
-import os
 import shlex
 from pathlib import Path
 
@@ -16,7 +15,7 @@ from pyscitt.cli.governance import (
     SCITT_CONSTITUTION_MARKER_START,
 )
 from pyscitt.cli.main import main
-from pyscitt.client import Client, ServiceError
+from pyscitt.client import ServiceError
 from pyscitt.governance import ProposalNotAccepted
 
 from .infra.did_web_server import DIDWebServer

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -10,7 +10,6 @@ import pytest
 from pyscitt import crypto
 from pyscitt.client import Client, ServiceError
 from pyscitt.did import Resolver, did_web_document_url
-from pyscitt.receipt import Receipt
 from pyscitt.verify import DIDResolverTrustStore, verify_receipt
 
 from .infra.did_web_server import DIDWebServer

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -3,7 +3,6 @@
 
 import cbor2
 import pytest
-from cryptography.exceptions import InvalidSignature
 from pycose import algorithms, headers
 from pycose.messages import Sign1Message
 


### PR DESCRIPTION
- Removes ENABLE_DEBUG_MALLOC as it did nothing.
- Pip install wheel when creating a venv before installing test requirements to avoid the `error: invalid command 'bdist_wheel'` error we've been seeing in CI. 
- Cleans up unnecessary python imports.