### PR TITLE
Fix a few decoding bugs, and increase test coverage.

### DIFF
--- a/app/unit-tests/verifier_test.cpp
+++ b/app/unit-tests/verifier_test.cpp
@@ -158,14 +158,24 @@ TEST(Verifier, EmptyChain)
 TEST(Verifier, GarbageCert)
 {
   auto root = create_cert("CN=root", true);
-  std::vector<uint8_t> leaf = {0xde, 0xad, 0xbe, 0xef};
+  auto leaf = create_cert("CN=leaf", false, &root);
+  std::vector<uint8_t> garbage = {0xde, 0xad, 0xbe, 0xef};
 
   EXPECT_THROW(
     Verifier::verify_chain(
       {{root.first}},
       {{
-        leaf,
+        garbage,
         crypto::cert_pem_to_der(root.first),
+      }}),
+    VerificationError);
+
+  EXPECT_THROW(
+    Verifier::verify_chain(
+      {{root.first}},
+      {{
+        crypto::cert_pem_to_der(leaf.first),
+        garbage,
       }}),
     VerificationError);
 }

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -119,21 +119,6 @@ def test_consistent_kid(client, did_web, trust_store):
     assert did_doc["assertionMethod"][0]["id"] == f"{identity.issuer}{kid}"
 
 
-def test_invalid_kid(client, did_web):
-    """
-    Submit a claim with an invalid kid and check that it is rejected.
-    """
-    identity = did_web.create_identity(kid="#key-1")
-    invalid_identity = crypto.Signer(
-        identity.private_key, issuer=identity.issuer, kid="key-1"
-    )
-
-    claim = crypto.sign_json_claimset(invalid_identity, {"foo": "bar"})
-
-    with pytest.raises(ServiceError, match="kid must start with '#'"):
-        client.submit_claim(claim)
-
-
 @pytest.mark.needs_cchost
 @pytest.mark.isolated_test
 def test_recovery(client, did_web, restart_service):

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -1,14 +1,135 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import struct
+from io import BytesIO
+
 import cbor2
+import pycose
 import pytest
-from pycose import algorithms, headers
 from pycose.messages import Sign1Message
 
-from pyscitt import crypto
-from pyscitt.client import Client
+from pyscitt import crypto, governance
+from pyscitt.client import Client, ServiceError
+from pyscitt.crypto import cert_pem_to_der
 from pyscitt.verify import verify_receipt
+
+from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
+
+
+class NonCanonicalEncoder(cbor2.encoder.CBOREncoder):
+    """
+    A variant of cbor2's encoder that introduces deliberate non-canonical
+    encodings.
+
+    For most payloads, even setting the canonical flag on cbor2's encoder to
+    False produces messages that are canonical anyway, simply as these are also
+    the most compact encoding.
+
+    This class goes out of its way to produce inefficiently encoded message.
+
+    Note that this derives from cbor2.encoder.CBOREncoder, which is different
+    than cbor2.CBOREncoder. The former is the Python implementation, whereas
+    the latter may be implemented in C, and we can't override its
+    implementation.
+    """
+
+    def __init__(self, fp):
+        super().__init__(fp, canonical=False)
+
+        # There are two definitions in the C and Python modules. Make sure we support either.
+        self._encoders[cbor2.CBORTag] = self._encoders[cbor2.encoder.CBORTag]
+        self._encoders[cbor2.CBORSimpleValue] = self._encoders[
+            cbor2.encoder.CBORSimpleValue
+        ]
+
+    def encode_length(self, major_tag, length):
+        # All lengths are encoded using 8 bytes, regardless of the value, for
+        # maximum inefficiency. This function gets called to encode integer
+        # values too, so the same applies.
+        self._fp_write(struct.pack(">BQ", (major_tag << 5) | 27, length))
+
+
+def cbor_encode(obj, *, canonical=True):
+    with BytesIO() as fp:
+        if canonical:
+            cbor2.CBOREncoder(fp, canonical=canonical).encode(obj)
+        else:
+            NonCanonicalEncoder(fp).encode(obj)
+        return fp.getvalue()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        0,
+        42,
+        [],
+        [42],
+        "Hello",
+        b"World",
+    ],
+)
+def test_cbor_encoder_hack(value):
+    """
+    Make sure our non-canonical encoding hack actually works.
+
+    It should produce a different encoding than the original encoder, yet still
+    roundtrip to the same value.
+    """
+    encoding = cbor_encode(value, canonical=False)
+    assert encoding != cbor_encode(value, canonical=True)
+    assert cbor2.loads(encoding) == value
+
+
+Algorithm = pycose.headers.Algorithm.identifier
+ContentType = pycose.headers.ContentType.identifier
+X5chain = pycose.headers.X5chain.identifier
+KID = pycose.headers.KID.identifier
+
+
+def sign(signer: crypto.Signer, payload: bytes, parameters: dict, *, canonical=True):
+    """
+    Sign a COSE Sign1 envelope.
+
+    This function is similar to `crypto.sign_claimset`, but it bypasses pycose
+    allowing us to encode invalid messages that pycose would refuse to encode.
+
+    Default values for common parameters will be added automatically if not
+    already part of `parameters`. If a parameter needs to be completely omitted
+    from the message, its value in the `parameters` dictionary can be set to
+    None.
+    """
+
+    algorithm = pycose.algorithms.CoseAlgorithm.from_id(signer.algorithm)
+    parameters.setdefault(Algorithm, algorithm.identifier)
+    parameters.setdefault(ContentType, "text/plain")
+
+    if signer.x5c is not None:
+        parameters.setdefault(
+            X5chain,
+            [cert_pem_to_der(x5) for x5 in signer.x5c],
+        )
+    if signer.kid is not None:
+        parameters.setdefault(KID, signer.kid.encode("utf-8"))
+    if signer.issuer is not None:
+        parameters.setdefault(crypto.COSE_HEADER_PARAM_ISSUER, signer.issuer)
+
+    # The caller can set a parameter to None to stop this function from adding
+    # defaults, but we don't want those None to be encoded, so we filter them
+    # out here.
+    parameters = {k: v for k, v in parameters.items() if v is not None}
+
+    encoded_headers = cbor_encode(parameters, canonical=canonical)
+
+    key = crypto.cose_private_key_from_pem(signer.private_key)
+
+    tbs = cbor_encode(["Signature1", encoded_headers, b"", payload], canonical=True)
+    signature = algorithm.sign(key, tbs)
+    message = [encoded_headers, dict(), payload, signature]
+    return cbor_encode(
+        cbor2.CBORTag(Sign1Message.cbor_tag, message), canonical=canonical
+    )
 
 
 class TestNonCanonicalEncoding:
@@ -17,50 +138,18 @@ class TestNonCanonicalEncoding:
         """Create a signed claim, with protected headers encoded non-canonically."""
 
         identity = did_web.create_identity()
-
-        attributes = {
-            headers.Algorithm.identifier: algorithms.Es256.identifier,
-            headers.ContentType.identifier: "text/plain",
-            crypto.COSE_HEADER_PARAM_ISSUER: identity.issuer,
-        }
-
-        # pycose and cbor2 use canonical encoding, which we explicitly want to avoid here.
-        # We encode the protected header manually, using inefficient encodings:
-        # - 0xba marks the start of a map, with a uint32 length
-        # - 0x1a marks a uint32, which we use to encode the keys of the map.
-        # For simplicity we defer to cbor2 to encode values. We have enough non-canonicity already.
-        protected = bytes([0xBA]) + len(attributes).to_bytes(4, "big")
-        protected += b"".join(
-            bytes([0x1A]) + k.to_bytes(4, "big") + cbor2.dumps(v)
-            for k, v in attributes.items()
-        )
-        print(protected.hex(), attributes, cbor2.loads(protected))
-        assert cbor2.loads(protected) == attributes
-        assert protected != cbor2.dumps(attributes)
-
-        payload = b"Hello World"
-        key = crypto.cose_private_key_from_pem(identity.private_key)
-
-        # The rest is pretty standard COSE signing: create the TBS, sign it,
-        # piece everything together to create the message. The following line
-        # is the only step that must really be canonically encoded by every party.
-        tbs = cbor2.dumps(["Signature1", protected, b"", payload])
-        signature = algorithms.Es256.sign(key, tbs)
-        message = [protected, dict(), payload, signature]
-        return cbor2.dumps(cbor2.CBORTag(Sign1Message.cbor_tag, message))
+        return sign(identity, b"Hello World", {}, canonical=False)
 
     def test_submit_claim(self, client: Client, trust_store, claim):
         """The ledger should accept claims even if not canonically encoded."""
-        client.submit_claim(claim)
-
-    def test_verify_receipt(self, client: Client, trust_store, claim):
-        """We should be able to verify the produced receipt."""
-        # Once the xfail is fixed, this test can be merged with test_submit_claim.
         receipt = client.submit_claim(claim).receipt
         verify_receipt(claim, trust_store, receipt)
 
     def test_embed_receipt(self, client: Client, trust_store, claim):
-        """When embedding a receipt in a claim, the ledger should not affect the original encoding."""
+        """
+        When embedding a receipt in a claim, the ledger should not affect the
+        encoding of byte-string pieces.
+        """
         tx = client.submit_claim(claim).tx
         embedded = client.get_claim(tx, embed_receipt=True)
 
@@ -72,3 +161,121 @@ class TestNonCanonicalEncoding:
         assert original_pieces[0] == updated_pieces[0]
         assert original_pieces[2] == updated_pieces[2]
         assert original_pieces[3] == updated_pieces[3]
+
+
+def service_error(match):
+    return pytest.raises(ServiceError, match=match)
+
+
+class TestHeaderParameters:
+    @pytest.fixture(scope="class")
+    def identity(self, did_web):
+        return did_web.create_identity()
+
+    @pytest.fixture(scope="class")
+    def submit(self, client, identity):
+        def f(parameters, *, signer=identity):
+            return client.submit_claim(sign(signer, b"Hello", parameters))
+
+        return f
+
+    def test_algorithm(self, submit):
+        # We only support integer algorithm identifiers
+        with service_error("Failed to decode protected header"):
+            submit({Algorithm: "foo"})
+
+        with service_error("Missing algorithm in protected header"):
+            submit({Algorithm: None})
+
+    def test_kid(self, submit, identity):
+        # This works because our DID document only has a single key.
+        submit({KID: None})
+        submit({KID: identity.kid.encode("utf-8")})
+
+        with service_error("Failed to decode protected header"):
+            # The KID needs to be a byte string.
+            submit({KID: identity.kid})
+
+        with service_error("kid must start with '#'"):
+            assert identity.kid.startswith("#")
+            submit({KID: identity.kid[1:].encode("utf-8")})
+
+    def test_content_type(self, submit):
+        # This comes from the CoAP Content-Format registry, and is defined as
+        # `text/plain; charset=utf-8` (not that it matters, since the ledger
+        # doesn't use the value).
+        submit({ContentType: 0})
+
+        submit({ContentType: "text/plain"})
+
+        with service_error("Missing cty in protected header"):
+            submit({ContentType: None})
+
+        with service_error("Content-type must be of type text string or int64"):
+            # Note this is a byte string, not text string
+            submit({ContentType: b"text/plain"})
+
+    def test_x5chain(
+        self, submit, client: Client, trusted_ca: X5ChainCertificateAuthority
+    ):
+        signer = trusted_ca.create_identity(length=1, kty="ec", alg="ES256")
+        assert signer.x5c is not None and len(signer.x5c) == 2
+
+        with service_error("x5chain array length was 0"):
+            submit({X5chain: []}, signer=signer)
+
+        # Unfortunately, this throws an error during validation because the
+        # service requires full chains (including the root CA), and doesn't
+        # support self-signed EE certs either. This means we have no way of
+        # testing the full submission flow with an x5chain of length 1.
+        # We still test that we can at least make it past decoding.
+        with service_error("chain must include at least one CA certificate"):
+            submit(
+                {X5chain: cert_pem_to_der(signer.x5c[0])},
+                signer=signer,
+            )
+
+        # Technically, the standard disallows this, as chains of length 1
+        # should be encoded as a plain bstr, not wrapped in a list. A number of
+        # implementations get this wrong though (including Notary), so we
+        # explicitly allow it.
+        with service_error("chain must include at least one CA certificate"):
+            submit(
+                {X5chain: [cert_pem_to_der(signer.x5c[0])]},
+                signer=signer,
+            )
+
+        submit(
+            {X5chain: [cert_pem_to_der(c) for c in signer.x5c]},
+            signer=signer,
+        )
+
+        with service_error("x5chain in COSE header is not array or byte string"):
+            submit(
+                {X5chain: "Not a bstr"},
+                signer=signer,
+            )
+
+        with service_error("Next item in x5chain was not of type byte string"):
+            submit(
+                {X5chain: ["Not a bstr"]},
+                signer=signer,
+            )
+
+        with service_error("Next item in x5chain was not of type byte string"):
+            submit(
+                {X5chain: [cert_pem_to_der(signer.x5c[0]), "Not a bstr"]},
+                signer=signer,
+            )
+
+        with service_error("Could not parse certificate"):
+            submit(
+                {X5chain: [b"Garbage leaf", cert_pem_to_der(signer.x5c[1])]},
+                signer=signer,
+            )
+
+        with service_error("Could not parse certificate"):
+            submit(
+                {X5chain: [cert_pem_to_der(signer.x5c[0]), b"Garbage root"]},
+                signer=signer,
+            )


### PR DESCRIPTION
- The content-type parameter was decoded as QCBOR_TYPE_ANY, but then
  assumed to always be a string. This could cause a type confusion and
  lead to crashes. It is now changed to be accept strings on integers
  only.

- The handling of a missing alg header parameter was creating an
  exception but not throwing it. This didn't weaken validation, since a
  bad_optional exception would be thrown two lines further down instead,
  but produced confusing and unexpected error responses.

- Added tests for various encoding and invalid messages edge cases. We
  cannot rely on pycose for many of these as it refuses malformed
  messages, so we use cbor2 directly.

- When embedding a receipt in a Sign1 enveloppe, which contained a
  single unprotected X509 certificate x5chain, the wrong QCBOR function
  was used, producing incorrectly formatted outputs.

- Check the return value when decoding X509 certificates and throw a
  ValidationError. Previously this could cause NULL pointer
  dereferencing.