### PR TITLE
Implement the new REST API

### DIFF
--- a/app/src/app_data.h
+++ b/app/src/app_data.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#include <ccf/rpc_context.h>
+#include <functional>
+#include <string>
+
+namespace scitt
+{
+  using TriggerAsynchronousOperation =
+    std::function<void(std::string callback_url)>;
+  struct AsynchronousOperation
+  {
+    TriggerAsynchronousOperation trigger;
+    std::string bind_address;
+  };
+
+  struct AppData
+  {
+    std::optional<std::string> request_id;
+    std::optional<std::string> client_request_id;
+    std::optional<AsynchronousOperation> asynchronous_operation;
+  };
+
+  AppData& get_app_data(std::shared_ptr<ccf::RpcContext>& ctx)
+  {
+    auto user_data = static_cast<AppData*>(ctx->get_user_data());
+    if (user_data != nullptr)
+    {
+      return *user_data;
+    }
+
+    auto data = std::make_shared<AppData>();
+    ctx->set_user_data(data);
+    return *data;
+  }
+}

--- a/app/src/call_types.h
+++ b/app/src/call_types.h
@@ -2,11 +2,6 @@
 // Licensed under the MIT License.
 
 #pragma once
-#ifdef VIRTUAL_ENCLAVE
-#  include "did/unattested.h"
-#else
-#  include "did/attested.h"
-#endif
 #include "kv_types.h"
 
 #include <ccf/ds/json.h>
@@ -16,15 +11,6 @@
 
 namespace scitt
 {
-  struct PostDidResolution
-  {
-#ifdef VIRTUAL_ENCLAVE
-    using In = did::UnattestedResolution;
-#else
-    using In = did::AttestedResolution;
-#endif
-  };
-
   struct GetIssuerInfo
   {
     using Out = IssuerInfo;
@@ -100,5 +86,43 @@ namespace scitt
 
   DECLARE_JSON_TYPE(GetVersion::Out);
   DECLARE_JSON_REQUIRED_FIELDS(GetVersion::Out, scitt_version);
+
+  struct GetEntry
+  {
+    struct Out
+    {
+      ccf::TxID entry_id;
+    };
+  };
+
+  DECLARE_JSON_TYPE(GetEntry::Out);
+  DECLARE_JSON_REQUIRED_FIELDS_WITH_RENAMES(GetEntry::Out, entry_id, "entryId");
+
+  struct GetOperation
+  {
+    struct Out
+    {
+      ccf::TxID operation_id;
+      OperationStatus status;
+      std::optional<ccf::TxID> entry_id;
+      std::optional<nlohmann::json> error;
+    };
+  };
+
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(GetOperation::Out);
+  DECLARE_JSON_REQUIRED_FIELDS_WITH_RENAMES(
+    GetOperation::Out, operation_id, "operationId", status, "status");
+  DECLARE_JSON_OPTIONAL_FIELDS_WITH_RENAMES(
+    GetOperation::Out, entry_id, "entryId", error, "error");
+
+  struct GetAllOperations
+  {
+    struct Out
+    {
+      std::vector<GetOperation::Out> operations;
+    };
+  };
+  DECLARE_JSON_TYPE(GetAllOperations::Out);
+  DECLARE_JSON_REQUIRED_FIELDS(GetAllOperations::Out, operations);
 
 } // namespace scitt

--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -13,7 +13,8 @@ namespace scitt
 {
   const uint64_t MAX_ENTRY_SIZE_BYTES = 1024 * 1024;
 
-  const std::chrono::seconds DID_RESOLUTION_REQUEST_EXPIRY{60 * 5};
+  const std::chrono::seconds OPERATION_EXPIRY{60 * 60};
+
   const std::chrono::seconds DID_RESOLUTION_CACHE_EXPIRY{60 * 30};
 
 #ifdef VIRTUAL_ENCLAVE
@@ -26,18 +27,19 @@ namespace scitt
 
   namespace errors
   {
-    const std::string DIDResolutionInProgressRetryLater =
-      "DIDResolutionInProgressRetryLater";
     const std::string DIDMethodNotSupported = "DIDMethodNotSupported";
+    const std::string DIDResolutionError = "DIDResolutionError";
     const std::string IndexingInProgressRetryLater =
       "IndexingInProgressRetryLater";
     const std::string InternalError = "InternalError";
     const std::string InvalidInput = "InvalidInput";
+    const std::string TransactionNotCached = "TransactionNotCached";
     const std::string QueryParameterError = "QueryParameterError";
     const std::string PayloadTooLarge = "PayloadTooLarge";
     const std::string UnknownFeed = "UnknownFeed";
     const std::string NoPrefixTree = "NoPrefixTree";
     const std::string NotFound = "NotFound";
+    const std::string OperationExpired = "OperationExpired";
   } // namespace errors
 
 } // namespace scitt

--- a/app/src/did/resolver.h
+++ b/app/src/did/resolver.h
@@ -31,16 +31,9 @@ namespace scitt::did
     {}
   };
 
-  struct AsyncResolutionInProgress : public DIDResolutionError
-  {
-    AsyncResolutionInProgress() :
-      DIDResolutionError("DID resolution in progress, try again soon")
-    {}
-  };
-
   struct DidWebOptions
   {
-    kv::Tx& tx;
+    kv::ReadOnlyTx& tx;
     std::optional<std::chrono::seconds> max_age;
     std::optional<std::string> if_assertion_method_id_match;
   };

--- a/app/src/did/unattested.h
+++ b/app/src/did/unattested.h
@@ -5,7 +5,7 @@
 
 #include "constants.h"
 #include "did/resolver.h"
-#include "did/web/method.h"
+#include "did/web/syntax.h"
 #include "util.h"
 
 #include <algorithm>

--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -3,155 +3,61 @@
 
 #pragma once
 
+#ifdef VIRTUAL_ENCLAVE
+#  include "did/unattested.h"
+#else
+#  include "did/attested.h"
+#endif
 #include "constants.h"
 #include "did/resolver.h"
 #include "did/web/syntax.h"
+#include "http_error.h"
 #include "kv_types.h"
 #include "tracing.h"
 #include "util.h"
 
 #include <algorithm>
-#include <ccf/ds/hex.h>
 #include <ccf/node/host_processes_interface.h>
-#include <ccf/node_context.h>
-#include <ccf/service/tables/nodes.h>
-#include <ccf/tx.h>
 #include <fmt/format.h>
 #include <string>
 
 namespace scitt::did::web
 {
-  class DidWebResolver : public MethodResolver
+#ifdef VIRTUAL_ENCLAVE
+  using ResolutionCallbackData = UnattestedResolution;
+  using ResolutionValidationError = UnattestedResolutionError;
+#else
+  using ResolutionCallbackData = AttestedResolution;
+  using ResolutionValidationError = AttestedResolutionError;
+#endif
+
+  /**
+   * This exception is used to interrupt processing of a claim and ask the
+   * caller to schedule an asynchronous resolution, using
+   * DidWebResolver::trigger_asynchronous_resolution.
+   *
+   * If this exception is thrown during the callback of an asynchronous
+   * resolution, then the resolution result was unsatisfactory and the operation
+   * is marked as failed with the message contained in the exception.
+   */
+  struct AsyncResolutionNeeded : public BadRequestError
   {
-  private:
-    ccfapp::AbstractNodeContext& context;
-    std::shared_ptr<ccf::AbstractHostProcesses> host_processes;
-
-    /**
-     * Return the callback URL used by the external fetch process to submit
-     * results.
-     *
-     * We use the node table to determine what port the service is listening on.
-     * This works even if cchost was given port 0 in its configuration, as it
-     * will updated the node information after
-     */
-    std::string format_callback_url(std::string_view did, kv::Tx& tx) const
-    {
-      auto nodes = tx.ro<ccf::Nodes>(ccf::Tables::NODES);
-      ccf::NodeId node_id = context.get_node_id();
-      std::optional<ccf::NodeInfo> node_info = nodes->get(node_id);
-
-      if (node_info.has_value() && !node_info->rpc_interfaces.empty())
-      {
-        // cchost can listen on multiple interfaces. This arbitrarily uses the
-        // first one, in alphabetical order.
-        const auto& primary_interface =
-          node_info->rpc_interfaces.begin()->second;
-
-        // Note that bind_address can be 0.0.0.0. This is fine here
-        // as Linux routes that address to localhost.
-        return fmt::format(
-          "https://{}/did/{}/doc", primary_interface.bind_address, did);
-      }
-      else
-      {
-        throw DIDResolutionError("Could not determine did:web call back URL");
-      }
-    }
-
-    void trigger_fetch_did_web_doc(
-      const std::string& did, ::timespec current_time, kv::Tx& tx) const
-    {
-      check_did_is_did_web(did);
-
-      auto now = current_time.tv_sec;
-      auto nonce = ds::to_hex(ENTROPY->random(16));
-      // add nonce to query param for cache busting
-      // TODO validate if this is fine security-wise
-      auto url = get_did_web_doc_url_from_did(did) + "?" + nonce;
-
-      auto issuers = tx.template rw<IssuersTable>(ISSUERS_TABLE);
-
-      auto issuer_info = issuers->get(did);
-      if (issuer_info.has_value())
-      {
-        auto last_requested = issuer_info->resolution_requested;
-        if (last_requested.has_value())
-        {
-          // TODO: move the expiry constant to a parameter
-          if (now - *last_requested < DID_RESOLUTION_REQUEST_EXPIRY.count())
-            return;
-        }
-        issuer_info->resolution_requested = now;
-        issuer_info->resolution_nonce = nonce;
-        issuers->put(did, *issuer_info);
-      }
-      else
-      {
-        IssuerInfo issuer_info;
-        issuer_info.resolution_requested = now;
-        issuer_info.resolution_nonce = nonce;
-        issuers->put(did, issuer_info);
-      }
-
-      auto callback = format_callback_url(did, tx);
-
-      SCITT_INFO("Fetching DID document for {}", did);
-      CCF_APP_DEBUG("DID fetch callback url: {}", callback);
-      host_processes->trigger_host_process_launch(
-        {DID_WEB_RESOLVER_SCRIPT, url, nonce, callback});
-    }
-
-    std::optional<DidResolutionResult> lookup(
-      const Did& did,
-      ::timespec current_time,
-      const DidWebOptions& options) const
-    {
-      auto issuers = options.tx.template rw<IssuersTable>(ISSUERS_TABLE);
-      auto issuer_info = issuers->get(did);
-      if (!issuer_info.has_value())
-      {
-        return std::nullopt;
-      }
-
-      auto& did_doc = issuer_info->did_document;
-      if (!did_doc.has_value())
-      {
-        return std::nullopt;
-      }
-
-      auto& resolution_metadata = issuer_info->did_resolution_metadata.value();
-      if (options.max_age.has_value())
-      {
-        auto last_updated = resolution_metadata.updated;
-        if (current_time.tv_sec - last_updated > options.max_age->count())
-        {
-          return std::nullopt;
-        }
-      }
-
-      if (options.if_assertion_method_id_match.has_value())
-      {
-        try
-        {
-          find_assertion_method_in_did_document(
-            did_doc.value(), options.if_assertion_method_id_match.value());
-        }
-        catch (const DIDAssertionMethodNotFoundError&)
-        {
-          return std::nullopt;
-        }
-      }
-
-      return {{did_doc.value(), resolution_metadata}};
-    }
-
-  public:
-    DidWebResolver(ccfapp::AbstractNodeContext& context) :
-      context(context),
-      host_processes(context.get_subsystem<ccf::AbstractHostProcesses>())
+    AsyncResolutionNeeded(std::string did, std::string msg) :
+      BadRequestError(errors::DIDResolutionError, msg),
+      did(did)
     {}
 
+    AsyncResolutionNeeded(std::string did, std::string code, std::string msg) :
+      BadRequestError(code, msg),
+      did(did)
+    {}
+
+    std::string did;
+  };
+
+  class DidWebResolver : public MethodResolver
+  {
+  public:
     std::string_view get_method_prefix() const
     {
       return DID_WEB_PREFIX;
@@ -165,15 +71,131 @@ namespace scitt::did::web
         throw DIDResolutionError("did:web resolver is not enabled");
       }
 
-      auto result = lookup(did, options.current_time, *options.did_web_options);
-      if (result)
+      auto issuers =
+        options.did_web_options->tx.template ro<IssuersTable>(ISSUERS_TABLE);
+
+      auto issuer_info = issuers->get(did);
+      if (!issuer_info.has_value())
       {
-        return *result;
+        throw AsyncResolutionNeeded(did, "Unknown issuer");
       }
 
-      trigger_fetch_did_web_doc(
-        did, options.current_time, options.did_web_options->tx);
-      throw AsyncResolutionInProgress();
+      if (issuer_info->error.has_value())
+      {
+        throw AsyncResolutionNeeded(
+          did, issuer_info->error->code, issuer_info->error->message);
+      }
+
+      if (
+        !issuer_info->did_document.has_value() ||
+        !issuer_info->did_resolution_metadata.has_value())
+      {
+        throw AsyncResolutionNeeded(errors::InternalError, "Empty issuer");
+      }
+
+      auto& did_doc = issuer_info->did_document.value();
+      auto& resolution_metadata = issuer_info->did_resolution_metadata.value();
+      if (options.did_web_options->max_age.has_value())
+      {
+        auto last_updated = resolution_metadata.updated;
+        if (
+          options.current_time.tv_sec - last_updated >
+          options.did_web_options->max_age->count())
+        {
+          throw AsyncResolutionNeeded(
+            did, "DID document for issuer has expired");
+        }
+      }
+
+      if (options.did_web_options->if_assertion_method_id_match.has_value())
+      {
+        try
+        {
+          find_assertion_method_in_did_document(
+            did_doc,
+            options.did_web_options->if_assertion_method_id_match.value());
+        }
+        catch (const DIDAssertionMethodNotFoundError&)
+        {
+          throw AsyncResolutionNeeded(
+            did, "Missing assertion method in DID document");
+        }
+      }
+
+      return {did_doc, resolution_metadata};
+    }
+
+    static void trigger_asynchronous_resolution(
+      ccfapp::AbstractNodeContext& context,
+      const std::string& callback_url,
+      const std::string& did,
+      const std::string& nonce)
+    {
+      // add nonce to query param for cache busting
+      auto url = get_did_web_doc_url_from_did(did) + "?" + nonce;
+
+      auto host_processes = context.get_subsystem<ccf::AbstractHostProcesses>();
+      host_processes->trigger_host_process_launch(
+        {DID_WEB_RESOLVER_SCRIPT, url, nonce, callback_url});
+    }
+
+    /**
+     * Write a resolution result to the issuers table in the KV.
+     *
+     * This performs validation of the results, eg. it checks the attestation
+     * and TLS certificate chain of the resolution.
+     */
+    static void update_did_document(
+      ::timespec host_time,
+      kv::Tx& tx,
+      const ResolutionCallbackData& result,
+      const std::string& issuer,
+      const std::string& expected_nonce)
+    {
+      DidResolutionResult resolution;
+      try
+      {
+#ifdef VIRTUAL_ENCLAVE
+        resolution =
+          verify_unattested_resolution(issuer, expected_nonce, result);
+#else
+        auto ca_cert_bundles = tx.template ro<ccf::CACertBundlePEMs>(
+          ccf::Tables::CA_CERT_BUNDLE_PEMS);
+        resolution = verify_attested_resolution(
+          issuer, expected_nonce, ca_cert_bundles, result);
+#endif
+      }
+      catch (const ResolutionValidationError& e)
+      {
+        // Generally, the error we write into the KV won't be used: the next
+        // time the same issuer is requested we will ignore the error and send
+        // out a new request.
+        //
+        // However, in the case of an aggregated resolution (multiple claims
+        // submitted concurrently for the same issuer), we'll get multiple
+        // callbacks but only the first one contains the resolution payload.
+        // In this case, no re-resolution happens and we'll return the error
+        // again.
+        auto issuers = tx.template rw<IssuersTable>(ISSUERS_TABLE);
+        issuers->put(
+          issuer,
+          IssuerInfo{
+            .error = {{
+              .code = errors::DIDResolutionError,
+              .message = e.what(),
+            }},
+          });
+        throw BadRequestError(errors::DIDResolutionError, e.what());
+      }
+
+      resolution.resolution_metadata.updated = host_time.tv_sec;
+
+      auto issuers = tx.template rw<IssuersTable>(ISSUERS_TABLE);
+      IssuerInfo issuer_info{
+        .did_document = std::move(resolution.did_doc),
+        .did_resolution_metadata = std::move(resolution.resolution_metadata),
+      };
+      issuers->put(issuer, issuer_info);
     }
   };
 } // namespace scitt

--- a/app/src/historical/historical_queries_adapter.h
+++ b/app/src/historical/historical_queries_adapter.h
@@ -82,7 +82,7 @@ namespace scitt::historical
         }
         case HistoricalTxStatus::PendingOrUnknown:
         {
-          throw NotFoundError(
+          throw ServiceUnavailableError(
             ccf::errors::TransactionPendingOrUnknown, std::move(error_reason));
         }
         case HistoricalTxStatus::Invalid:

--- a/app/src/historical/historical_queries_adapter.h
+++ b/app/src/historical/historical_queries_adapter.h
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma once
 
+#include "http_error.h"
 #include "lru.h"
 #include "tracing.h"
 
 #include <ccf/endpoint_context.h>
 #include <ccf/historical_queries_adapter.h>
 #include <ccf/http_consts.h>
+#include <ccf/json_handler.h>
 #include <ccf/odata_error.h>
 #include <ccf/rpc_context.h>
 #include <ccf/tx_id.h>
@@ -16,6 +19,9 @@
 // states to avoid memory exhaustion using a simple LRU cache. See
 // https://github.com/microsoft/CCF/blob/main/src/node/historical_queries_adapter.cpp
 // for the original.
+//
+// It is also adapted to match the rest of the SCITT code base, eg. uses
+// exceptions to return HTTP errors.
 
 namespace scitt::historical
 {
@@ -25,8 +31,11 @@ namespace scitt::historical
   using ccf::historical::CheckHistoricalTxStatus;
   using ccf::historical::HandleHistoricalQuery;
   using ccf::historical::HistoricalTxStatus;
-  using ccf::historical::TxIDExtractor;
+  using ccf::historical::StatePtr;
 
+  // CCF defines a version, but makes it return std::optional instead of using
+  // exceptions.
+  using TxIDExtractor = std::function<ccf::TxID(EndpointContext& args)>;
   using ActiveHandlesLRU = LRU<ccf::SeqNo, bool>;
 
   // TODO: move this to constants.h and describe how it influences memory
@@ -35,112 +44,126 @@ namespace scitt::historical
   static ActiveHandlesLRU ACTIVE_HANDLES_LRU(MAX_ACTIVE_HANDLES);
   static std::mutex ACTIVE_HANDLES_MUTEX;
 
+  ccf::TxID get_tx_id_from_request_path(EndpointContext& ctx)
+  {
+    auto tx_id_str = ctx.rpc_ctx->get_request_path_params().at("txid");
+
+    const auto tx_id = ccf::TxID::from_str(tx_id_str);
+    if (!tx_id.has_value())
+    {
+      throw BadRequestError(
+        errors::InvalidInput,
+        fmt::format("Invalid transaction ID: {}", tx_id_str));
+    }
+    return tx_id.value();
+  }
+
+  StatePtr get_historical_state(
+    AbstractStateCache& state_cache,
+    const CheckHistoricalTxStatus& available,
+    const TxIDExtractor& extractor,
+    EndpointContext& ctx)
+  {
+    // Extract the requested transaction ID
+    ccf::TxID target_tx_id = extractor(ctx);
+
+    // Check that the requested transaction ID is available
+    {
+      auto error_reason =
+        fmt::format("Transaction {} is not available.", target_tx_id.to_str());
+      auto is_available =
+        available(target_tx_id.view, target_tx_id.seqno, error_reason);
+      switch (is_available)
+      {
+        case HistoricalTxStatus::Error:
+        {
+          throw InternalServerError(
+            ccf::errors::InternalError, std::move(error_reason));
+        }
+        case HistoricalTxStatus::PendingOrUnknown:
+        {
+          throw NotFoundError(
+            ccf::errors::TransactionPendingOrUnknown, std::move(error_reason));
+        }
+        case HistoricalTxStatus::Invalid:
+        {
+          throw NotFoundError(
+            ccf::errors::TransactionInvalid, std::move(error_reason));
+        }
+        case HistoricalTxStatus::Valid:
+        {
+        }
+      }
+    }
+
+    // We need a handle to determine whether this request is the 'same' as a
+    // previous one. For simplicity we use target_tx_id.seqno. This means we
+    // keep a lot of state around for old requests! It should be cleaned up
+    // manually
+    const auto historic_request_handle = target_tx_id.seqno;
+
+    StatePtr historical_state;
+    {
+      std::unique_lock<std::mutex> guard(ACTIVE_HANDLES_MUTEX);
+      ACTIVE_HANDLES_LRU.set_cull_callback(
+        [&state_cache](ccf::SeqNo key, bool) {
+          SCITT_INFO("Dropping cached transaction {}", key);
+          state_cache.drop_cached_states(key);
+        });
+      ACTIVE_HANDLES_LRU.insert(historic_request_handle, true);
+
+      // Get a state at the target version from the cache, if it is present.
+      // Note that this must be within the mutex lock, otherwise in busy
+      // situations state may be dropped before it was requested.
+      historical_state =
+        state_cache.get_state_at(historic_request_handle, target_tx_id.seqno);
+    }
+
+    if (historical_state == nullptr)
+    {
+      constexpr uint32_t retry_after_seconds = 1;
+      throw ServiceUnavailableError(
+        errors::TransactionNotCached,
+        fmt::format(
+          "Historical transaction {} is not cached.", target_tx_id.to_str()),
+        retry_after_seconds);
+    }
+
+    return historical_state;
+  }
+
   EndpointFunction adapter(
     const HandleHistoricalQuery& f,
     AbstractStateCache& state_cache,
     const CheckHistoricalTxStatus& available,
-    const TxIDExtractor& extractor)
+    const TxIDExtractor& extractor = get_tx_id_from_request_path)
   {
-    return [f, &state_cache, available, extractor](EndpointContext& args) {
-      // Extract the requested transaction ID
-      ccf::TxID target_tx_id;
-      {
-        const auto tx_id_opt = extractor(args);
-        if (tx_id_opt.has_value())
-        {
-          target_tx_id = tx_id_opt.value();
-        }
-        else
-        {
-          return;
-        }
-      }
-
-      // Check that the requested transaction ID is available
-      {
-        auto error_reason = fmt::format(
-          "Transaction {} is not available.", target_tx_id.to_str());
-        auto is_available =
-          available(target_tx_id.view, target_tx_id.seqno, error_reason);
-        switch (is_available)
-        {
-          case HistoricalTxStatus::Error:
-          {
-            SCITT_FAIL("Code=InternalError {}", error_reason);
-            args.rpc_ctx->set_error(
-              HTTP_STATUS_INTERNAL_SERVER_ERROR,
-              ccf::errors::InternalError,
-              std::move(error_reason));
-            return;
-          }
-          case HistoricalTxStatus::PendingOrUnknown:
-          {
-            SCITT_INFO("Code=TransactionPendingOrUnknown");
-            args.rpc_ctx->set_response_header(
-              http::headers::CACHE_CONTROL, "no-cache");
-            args.rpc_ctx->set_error(
-              HTTP_STATUS_NOT_FOUND,
-              ccf::errors::TransactionPendingOrUnknown,
-              std::move(error_reason));
-            return;
-          }
-          case HistoricalTxStatus::Invalid:
-          {
-            SCITT_INFO("Code=TransactionInvalid");
-            args.rpc_ctx->set_error(
-              HTTP_STATUS_NOT_FOUND,
-              ccf::errors::TransactionInvalid,
-              std::move(error_reason));
-            return;
-          }
-          case HistoricalTxStatus::Valid:
-          {
-          }
-        }
-      }
-
-      // We need a handle to determine whether this request is the 'same' as a
-      // previous one. For simplicity we use target_tx_id.seqno. This means we
-      // keep a lot of state around for old requests! It should be cleaned up
-      // manually
-      const auto historic_request_handle = target_tx_id.seqno;
-
-      ccf::historical::StatePtr historical_state;
-
-      {
-        std::unique_lock<std::mutex> guard(ACTIVE_HANDLES_MUTEX);
-        ACTIVE_HANDLES_LRU.set_cull_callback(
-          [&state_cache](ccf::SeqNo key, bool) {
-            SCITT_INFO("Dropping cached transaction {}", key);
-            state_cache.drop_cached_states(key);
-          });
-        ACTIVE_HANDLES_LRU.insert(historic_request_handle, true);
-
-        // Get a state at the target version from the cache, if it is present.
-        // Note that this must be within the mutex lock, otherwise in busy
-        // situations state may be dropped before it was requested.
-        historical_state =
-          state_cache.get_state_at(historic_request_handle, target_tx_id.seqno);
-      }
-
-      if (historical_state == nullptr)
-      {
-        args.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
-        constexpr size_t retry_after_seconds = 1;
-        args.rpc_ctx->set_response_header(
-          http::headers::RETRY_AFTER, retry_after_seconds);
-        args.rpc_ctx->set_response_header(
-          http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
-        args.rpc_ctx->set_response_body(fmt::format(
-          "Historical transaction {} is not currently available.",
-          target_tx_id.to_str()));
-        SCITT_INFO("Code=TransactionNotCached");
-        return;
-      }
-
-      // Call the provided handler
-      f(args, historical_state);
+    return [f, &state_cache, available, extractor](EndpointContext& ctx) {
+      auto state = get_historical_state(state_cache, available, extractor, ctx);
+      f(ctx, state);
     };
   }
 
+  using HandleJsonHistoricalQuery =
+    std::function<ccf::jsonhandler::JsonAdapterResponse(
+      EndpointContext& args, StatePtr state, nlohmann::json&& params)>;
+
+  /**
+   * A combination of ccf::json_adapter and historical::adapter.
+   *
+   * Because the signatures are incompatible, the two adapaters don't natively
+   * compose. This combined adapter may be used instead.
+   */
+  EndpointFunction json_adapter(
+    const HandleJsonHistoricalQuery& f,
+    AbstractStateCache& state_cache,
+    const CheckHistoricalTxStatus& available,
+    const TxIDExtractor& extractor = get_tx_id_from_request_path)
+  {
+    return ccf::json_adapter([f, &state_cache, available, extractor](
+                               EndpointContext& ctx, nlohmann::json&& params) {
+      auto state = get_historical_state(state_cache, available, extractor, ctx);
+      return f(ctx, state, std::move(params));
+    });
+  }
 }

--- a/app/src/odata_error.h
+++ b/app/src/odata_error.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "ccf/ds/json.h"
+
+namespace scitt
+{
+  // CCF already defines an equivalent definition, but unfortunately it lacks a
+  // operator==, which makes it impossible to use in an optional field.
+  struct ODataError
+  {
+    std::string code;
+    std::string message;
+
+    bool operator==(const ODataError&) const = default;
+  };
+
+  DECLARE_JSON_TYPE(ODataError);
+  DECLARE_JSON_REQUIRED_FIELDS(ODataError, code, message);
+}

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -575,7 +575,7 @@ namespace scitt
    *
    * Asynchronous operations are useful for tasks which depend on an external
    * process to execute. This transaction will record the start of the operation
-   * and set its status to "pending". When the external process completes, it
+   * and set its status to "running". When the external process completes, it
    * must invoke a callback URL, at which point more processing will happen
    * inside the ledger.
    *

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -1,0 +1,681 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "app_data.h"
+#include "historical/historical_queries_adapter.h"
+#include "odata_error.h"
+#include "visit_each_entry_in_value.h"
+
+#include <ccf/json_handler.h>
+#include <ccf/node_context.h>
+#include <ccf/service/tables/nodes.h>
+
+namespace scitt
+{
+  using OperationCallback = std::function<void(
+    ccf::endpoints::EndpointContext&, const nlohmann::json&, nlohmann::json&&)>;
+
+  /**
+   * An indexing strategy which maintains a map from Operation ID to state.
+   *
+   * The state can be one of "running", "failed" or "succeeded". In the last
+   * case, the transaction ID which completed the operation is recorded.
+   */
+  class OperationsIndexingStrategy
+    : public VisitEachEntryInValueTyped<OperationsTable>
+  {
+  public:
+    OperationsIndexingStrategy(ccf::BaseEndpointRegistry& registry) :
+      OperationsIndexingStrategy(
+        [&registry](timespec& time) {
+          return registry.get_untrusted_host_time_v1(time);
+        },
+        [&registry](
+          ccf::View view, ccf::SeqNo seqno, ccf::TxStatus& tx_status) {
+          return registry.get_status_for_txid_v1(view, seqno, tx_status);
+        })
+    {}
+
+    OperationsIndexingStrategy(
+      std::function<ccf::ApiResult(timespec& time)> get_time,
+      std::function<ccf::ApiResult(
+        ccf::View view, ccf::SeqNo seqno, ccf::TxStatus& tx_status)>
+        get_status_for_txid) :
+      VisitEachEntryInValueTyped(OPERATIONS_TABLE),
+      get_time(get_time),
+      get_status_for_txid(get_status_for_txid)
+    {}
+
+    /**
+     * Get the list of all operations whose state is known by the indexing
+     * strategy.
+     *
+     * The function isn't intended to be used in normal situations, but can
+     * serve as a convenient debugging endpoint into the state of the indexing
+     * strategy.
+     */
+    std::vector<GetOperation::Out> operations() const
+    {
+      std::lock_guard guard(lock);
+      std::vector<GetOperation::Out> result;
+      for (const auto& it : operations_)
+      {
+        result.push_back(GetOperation::Out{
+          .operation_id = ccf::TxID{it.second.view, it.first},
+          .status = it.second.status,
+          .entry_id = it.second.completion_tx,
+          .error = it.second.error,
+        });
+      }
+      return result;
+    }
+
+    /**
+     * Look up an operation by its transaction ID.
+     *
+     * If the transaction ID is unknown, this function generally returns an
+     * operation in the "running" state anyway, since it would not be possible
+     * to distinguish between whether this is an invalid transaction ID or if
+     * the transaction that created the operation has not been globally
+     * committed and indexed yet.
+     *
+     * In some cases however, we can be confident that this transaction ID is
+     * invalid now and forever in the future. In these cases, an appropriate
+     * HTTPError exception is thrown.
+     */
+    GetOperation::Out lookup(const ccf::TxID& operation_id) const
+    {
+      std::lock_guard guard(lock);
+
+      ccf::TxStatus tx_status;
+      auto result =
+        get_status_for_txid(operation_id.view, operation_id.seqno, tx_status);
+      if (result != ccf::ApiResult::OK)
+      {
+        throw InternalError(fmt::format(
+          "Failed to get transaction status: {}",
+          ccf::api_result_to_str(result)));
+      }
+
+      switch (tx_status)
+      {
+        case ccf::TxStatus::Unknown:
+        case ccf::TxStatus::Pending:
+          return {
+            .operation_id = operation_id,
+            .status = OperationStatus::Running,
+          };
+
+        case ccf::TxStatus::Invalid:
+          // This state can arise even in a well-behaved client if the view
+          // changed (eg. because of a Raft election), and the operation's
+          // transaction got dropped. It could also be a client giving us
+          // garbage txids, but we can't tell the difference so we remain polite
+          // and assume the former and say the operation has failed.
+          return {
+            .operation_id = operation_id,
+            .status = OperationStatus::Failed,
+            .error =
+              ODataError{
+                .code = ccf::errors::TransactionInvalid,
+                .message = "Transaction is invalid",
+              },
+          };
+
+        case ccf::TxStatus::Committed:
+          // This is the main case, when the client is referring to a
+          // transaction that has been committed to the ledger. From now on, it
+          // is safe to consider the SeqNo only and compare it to what has been
+          // indexed.
+          break;
+      }
+
+      if (operation_id.seqno < lower_bound)
+      {
+        throw HTTPError(
+          HTTP_STATUS_GONE,
+          errors::OperationExpired,
+          "Operation ID is too old");
+      }
+      else if (operation_id.seqno >= upper_bound)
+      {
+        // This is a SeqNo we have not indexed yet, so we can't yet tell if such
+        // an operation with that sequence number will exist or not yet, so
+        // pretend like it does and it is "running".
+        //
+        // This is possible even though the TxStatus is Committed, because the
+        // indexer could be behind the consensus.
+        return {
+          .operation_id = operation_id,
+          .status = OperationStatus::Running,
+        };
+      }
+      else if (auto it = operations_.find(operation_id.seqno);
+               it != operations_.end())
+      {
+        CCF_ASSERT(
+          operation_id.view == it->second.view,
+          "Operation ID has inconsistent view");
+        return {
+          .operation_id = operation_id,
+          .status = it->second.status,
+          .entry_id = it->second.completion_tx,
+          .error = it->second.error,
+        };
+      }
+      else
+      {
+        // The transaction number is within our indexing range, yet doesn't
+        // match any valid operation. The client must have sent us a transaction
+        // ID for something completely different.
+        throw HTTPError(
+          HTTP_STATUS_NOT_FOUND, errors::NotFound, "Invalid operation ID");
+      }
+    }
+
+  protected:
+    void visit_entry(const ccf::TxID& tx_id, const OperationLog& log) override
+    {
+      std::lock_guard guard(lock);
+
+      handle_transition(tx_id, log);
+      purge_operations();
+
+      upper_bound = tx_id.seqno + 1;
+    }
+
+  private:
+    void handle_transition(const ccf::TxID& tx_id, const OperationLog& log)
+    {
+      ccf::TxID operation_id = log.operation_id.value_or(tx_id);
+      if (operation_id.seqno < lower_bound)
+      {
+        return;
+      }
+
+      auto it = operations_.find(operation_id.seqno);
+      CCF_ASSERT(
+        (it == operations_.end()) || (operation_id.view == it->second.view),
+        "Operation ID has inconsistent view");
+
+      auto current_status = it != operations_.end() ?
+        std::optional(it->second.status) :
+        std::nullopt;
+      if (!check_transition(tx_id, operation_id, current_status, log))
+      {
+        return;
+      }
+
+      if (it == operations_.end())
+      {
+        it = operations_.emplace(operation_id.seqno, OperationState{}).first;
+        it->second.view = operation_id.view;
+        it->second.created_at = log.created_at.value();
+      }
+
+      it->second.status = log.status;
+      switch (log.status)
+      {
+        case OperationStatus::Running:
+          break;
+        case OperationStatus::Failed:
+          it->second.error = log.error;
+          break;
+        case OperationStatus::Succeeded:
+          it->second.completion_tx = tx_id;
+          break;
+      }
+    }
+
+    /**
+     * Each operation can be modelled as a state machine, with transactions in
+     * the operations table representing state transitions.
+     *
+     * Not all transitions are valid. The valid ones are summarised in the
+     * diagram below:
+     *
+     * Non existent -> Running -> Failed
+     *      |             |
+     *      |             v
+     *      |-------> Succeeded
+     *
+     * This function compares a current and future state and returns true if the
+     * transition is allowed. Some of the invalid transactions are logic errors
+     * in the implementations. Others (ie. completing an operation twice) are
+     * just undesirable but unavoidable, and shouldn't be treated as hard
+     * errors.
+     */
+    bool check_transition(
+      const ccf::TxID& tx_id,
+      const ccf::TxID& operation_id,
+      std::optional<OperationStatus> current_status,
+      const OperationLog& log)
+    {
+      constexpr auto Running = OperationStatus::Running;
+      constexpr auto Succeeded = OperationStatus::Succeeded;
+      constexpr auto Failed = OperationStatus::Failed;
+
+      bool valid = false;
+      if (!current_status.has_value())
+      {
+        valid = ((log.status == Running) || (log.status == Succeeded)) &&
+          log.created_at.has_value();
+      }
+      else if (current_status == Running)
+      {
+        valid = (log.status == Succeeded || log.status == Failed);
+      }
+      else if (current_status == Succeeded || current_status == Failed)
+      {
+        if (log.status == Succeeded || log.status == Failed)
+        {
+          // This is a less severe invalid transition. We just log it as INFO
+          // and don't abort. We still return false, to stop the indexing
+          // strategy from proceeding further.
+          SCITT_INFO(
+            "Repeated completion of operation {} at {}, from {} to {}",
+            operation_id.to_str(),
+            tx_id.to_str(),
+            nlohmann::json(current_status).dump(),
+            nlohmann::json(log.status).dump());
+          return false;
+        }
+        valid = false;
+      }
+
+      if (!valid)
+      {
+        if (current_status.has_value())
+        {
+          SCITT_FAIL(
+            "Got unexpected event {} at {} for existing operation {} in state",
+            nlohmann::json(log.status).dump(),
+            tx_id.to_str(),
+            operation_id.to_str(),
+            nlohmann::json(*current_status));
+        }
+        else
+        {
+          SCITT_FAIL(
+            "Got unexpected event {} at {} for unknown operation {}",
+            nlohmann::json(log.status).dump(),
+            tx_id.to_str(),
+            operation_id.to_str());
+        }
+      }
+      CCF_ASSERT(valid, "Invalid operation transition");
+      return valid;
+    }
+
+    /**
+     * Remove operations that are past their expiration.
+     *
+     * This helps limit the memory consumption of the indexing strategy, by
+     * keeping a bound on how many operations we keep around.
+     *
+     * Because operation IDs are monotonically increasing, and we keep them
+     * ordered in an std::map, we can scan from the front and stop as soon as a
+     * non-expired entry is found.
+     */
+    void purge_operations()
+    {
+      timespec current_time;
+      auto result = get_time(current_time);
+      if (result != ccf::ApiResult::OK)
+      {
+        SCITT_FAIL(
+          "Failed to get host time: {}", ccf::api_result_to_str(result));
+      }
+
+      auto it = operations_.begin();
+      while (it != operations_.end())
+      {
+        double age = difftime(current_time.tv_sec, it->second.created_at);
+        if (age > OPERATION_EXPIRY.count())
+        {
+          it++;
+        }
+        else
+        {
+          break;
+        }
+      }
+
+      if (it != operations_.begin())
+      {
+        SCITT_INFO(
+          "Removing {} operations from indexing strategy",
+          std::distance(operations_.begin(), it));
+
+        lower_bound = std::prev(it)->first + 1;
+        operations_.erase(operations_.begin(), it);
+      }
+    }
+
+    const std::function<ccf::ApiResult(timespec& time)> get_time;
+    const std::function<ccf::ApiResult(
+      ccf::View view, ccf::SeqNo seqno, ccf::TxStatus& tx_status)>
+      get_status_for_txid;
+
+    struct OperationState
+    {
+      // The std::map uses SeqNo as its key because TxIDs aren't totally
+      // ordered.
+      ccf::View view;
+      OperationStatus status;
+      time_t created_at;
+      std::optional<ccf::TxID> completion_tx;
+      std::optional<ODataError> error;
+    };
+
+    // It might be worth replacing this with a deque. Entries are only ever
+    // inserted in monotonically increasing sequence numbers, which would
+    // make them sorted and amenable to binary searches.
+    std::map<ccf::SeqNo, OperationState> operations_;
+
+    // These represent the ranges covered by the indexing strategy.
+    // The lower bound is inclusive and the upper bound exclusive.
+    //
+    // Anything lower than the lower bound has been purged from the indexing
+    // strategy. Anything greater or equal to the upper bound has not yet been
+    // indexed.
+    ccf::SeqNo lower_bound = 0;
+    ccf::SeqNo upper_bound = 0;
+
+    mutable std::mutex lock;
+  };
+
+  namespace endpoints
+  {
+    GetAllOperations::Out get_all_operations(
+      const std::shared_ptr<OperationsIndexingStrategy>& index,
+      ccf::endpoints::EndpointContext& ctx,
+      nlohmann::json&& params)
+    {
+      return {
+        .operations = index->operations(),
+      };
+    }
+
+    GetOperation::Out get_operation(
+      const std::shared_ptr<OperationsIndexingStrategy>& index,
+      ccf::endpoints::EndpointContext& ctx,
+      nlohmann::json&& params)
+    {
+      auto id = historical::get_tx_id_from_request_path(ctx);
+      return index->lookup(id);
+    }
+
+    /**
+     * This is the request handler for when an external process completes and
+     * invokes an operation's callback URL. It uses a historical query to get
+     * the operation's original metadata.
+     *
+     * This function will invoke the operation callback function, passing it
+     * both the original context and the callback payload.
+     *
+     * If the callback function completes successfully, we mark the operation as
+     * complete. The callback function should write its results to other tables
+     * of the KV. At a later point, the operation indexing strategy can be used
+     * to map from the operation ID to the transaction that completed it.
+     *
+     * If the callback function throws an HTTPError exception, details of the
+     * error are recorded in the operations table. The error details will be
+     * returned to future clients polling for the operation's status.
+     */
+    auto post_operation_callback(
+      OperationCallback& callback,
+      ccf::endpoints::EndpointContext& ctx,
+      ccf::historical::StatePtr state,
+      nlohmann::json&& params)
+    {
+      auto txid = state->transaction_id;
+      auto tx = state->store->create_read_only_tx();
+      auto operation = tx.ro<OperationsTable>(OPERATIONS_TABLE)->get();
+      if (!operation.has_value())
+      {
+        throw BadRequestError(
+          errors::InvalidInput,
+          fmt::format(
+            "Transaction ID {} does not correspond to an operation.",
+            txid.to_str()));
+      }
+
+      try
+      {
+        callback(ctx, operation->context, std::move(params));
+      }
+      catch (const HTTPError& e)
+      {
+        if (e.code == errors::InternalError)
+          SCITT_FAIL("Callback error code={} {}", e.code, e.what());
+        else
+          SCITT_INFO("Callback error code={}", e.code);
+
+        auto operations_table =
+          ctx.tx.template rw<OperationsTable>(OPERATIONS_TABLE);
+        operations_table->put(OperationLog{
+          .status = OperationStatus::Failed,
+          .operation_id = txid,
+          .error =
+            ODataError{
+              .code = e.code,
+              .message = e.what(),
+            },
+        });
+
+        // We consider any errors that are raised as part of the callback as
+        // being errors of the entire operation, not of the sole callback.
+        //
+        // Because of this, we return a success to the process that invoked the
+        // callback to stop it from retrying the callback.
+        return ccf::make_success();
+      }
+
+      auto operations_table =
+        ctx.tx.template rw<OperationsTable>(OPERATIONS_TABLE);
+      operations_table->put(OperationLog{
+        .status = OperationStatus::Succeeded,
+        .operation_id = txid,
+      });
+
+      return ccf::make_success();
+    }
+  }
+
+  void register_operations_endpoints(
+    ccfapp::AbstractNodeContext& context,
+    ccf::BaseEndpointRegistry& registry,
+    ccf::historical::CheckHistoricalTxStatus is_tx_committed,
+    const ccf::AuthnPolicies& authn_policy,
+    OperationCallback callback)
+  {
+    using namespace std::placeholders;
+
+    auto& state_cache = context.get_historical_state();
+
+    auto operations_index =
+      std::make_shared<OperationsIndexingStrategy>(registry);
+    context.get_indexing_strategies().install_strategy(operations_index);
+
+    registry
+      .make_endpoint(
+        "/operations",
+        HTTP_GET,
+        ccf::json_adapter(
+          std::bind(endpoints::get_all_operations, operations_index, _1, _2)),
+        authn_policy)
+      .set_auto_schema<void, GetAllOperations::Out>()
+      .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
+      .install();
+
+    registry
+      .make_endpoint(
+        "/operations/{txid}",
+        HTTP_GET,
+        ccf::json_adapter(
+          std::bind(endpoints::get_operation, operations_index, _1, _2)),
+        authn_policy)
+      .set_auto_schema<void, GetOperation::Out>()
+      .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
+      .install();
+
+    // The callback endpoint is specifically left open because it is called by
+    // the attested fetch script. The use of a nonce and checking the
+    // attestation on the payload make this ok.
+    const ccf::AuthnPolicies no_authn_policy = {ccf::empty_auth_policy};
+    registry
+      .make_endpoint(
+        "/operations/{txid}/callback",
+        HTTP_POST,
+        scitt::historical::json_adapter(
+          std::bind(endpoints::post_operation_callback, callback, _1, _2, _3),
+          state_cache,
+          is_tx_committed),
+        no_authn_policy)
+      .install();
+  }
+
+  /**
+   * Get the address and port number on which the RPC interface is listening.
+   * This forms the base of the callback URL used by the external process to
+   * submit asynchronous operations' results.
+   *
+   * We use the node table to determine what port the service is listening on.
+   * This works even if cchost was given port 0 in its configuration, as it
+   * will have updated the node information after the port is bound.
+   */
+  std::string get_bind_address(
+    ccfapp::AbstractNodeContext& context, kv::ReadOnlyTx& tx)
+  {
+    auto nodes = tx.ro<ccf::Nodes>(ccf::Tables::NODES);
+    ccf::NodeId node_id = context.get_node_id();
+    std::optional<ccf::NodeInfo> node_info = nodes->get(node_id);
+
+    if (node_info.has_value() && !node_info->rpc_interfaces.empty())
+    {
+      // cchost can listen on multiple interfaces. This arbitrarily uses the
+      // first one, in alphabetical order.
+      const auto& primary_interface = node_info->rpc_interfaces.begin()->second;
+
+      // Note that bind_address can be 0.0.0.0. This is fine here
+      // as Linux routes that address to localhost.
+      return primary_interface.bind_address;
+    }
+    else
+    {
+      throw std::runtime_error("Could not callback URL");
+    }
+  }
+
+  /**
+   * Mark the start of an asynchronous operation.
+   *
+   * Asynchronous operations are useful for tasks which depend on an external
+   * process to execute. This transaction will record the start of the operation
+   * and set its status to "pending". When the external process completes, it
+   * must invoke a callback URL, at which point more processing will happen
+   * inside the ledger.
+   *
+   * Ideally we'd kick-off the background process here, but we need access
+   * to the operation ID to construct the callback URL, and we don't know it
+   * yet. We use a local commit handler (operation_locally_committed_func)
+   * to run code after the transaction has been committed. The trigger argument
+   * is saved and will be called from the commit handler.
+   *
+   * The callback_context object may be used to preserve information about the
+   * asynchronous operation, and will be available to the handler when the
+   * background process completes and invokes the callback URL.
+   */
+  void start_asynchronous_operation(
+    timespec current_time,
+    ccfapp::AbstractNodeContext& node_context,
+    ccf::endpoints::EndpointContext& endpoint_context,
+    nlohmann::json callback_context,
+    TriggerAsynchronousOperation trigger)
+  {
+    auto table =
+      endpoint_context.tx.template rw<OperationsTable>(OPERATIONS_TABLE);
+    table->put(OperationLog{
+      .status = OperationStatus::Running,
+      .created_at = current_time.tv_sec,
+      .context = std::move(callback_context),
+    });
+
+    // The AppData allows us to propagate data to the handler. We use it to keep
+    // a reference to the trigger lambda and the bind address. The latter is
+    // needed to build the callback URL, but needs read access to the KV, which
+    // we won't have later on in the commit handler.
+    get_app_data(endpoint_context.rpc_ctx).asynchronous_operation =
+      AsynchronousOperation{
+        .trigger = trigger,
+        .bind_address = get_bind_address(node_context, endpoint_context.tx),
+      };
+  }
+
+  /**
+   * Mark this transaction as having executed a synchronous operation.
+   */
+  void record_synchronous_operation(timespec current_time, kv::Tx& tx)
+  {
+    auto operations_table = tx.template rw<OperationsTable>(OPERATIONS_TABLE);
+    operations_table->put(OperationLog{
+      .status = OperationStatus::Succeeded,
+      .created_at = current_time.tv_sec,
+    });
+  }
+
+  /**
+   * Local commit handler for endpoints which create new operations.
+   *
+   * The endpoint handlers don't have access to their transaction ID, and
+   * therefore cannot generate useful responses. This function is therefore
+   * necessary to inform the client of the operation ID.
+   *
+   * This is called for both synchronous and asynchronous operations. In the
+   * case of synchronous operations, the operation's status has already been set
+   * to "succeeded" in the KV, and once signed, globally committed and
+   * witnessed by the indexing strategy, will be available to the client.
+   *
+   * For asynchronous operations, we must trigger the external process, as
+   * recorded as a lambda in the AppData. Again, we can only do this now that we
+   * know the operation ID, since we need it for the callback URL.
+   *
+   * Note that if the endpoint handlers failed and set a non-2xx HTTP status
+   * code, CCF doesn't apply any of the writes and doesn't call this function.
+   * In this case, it is assumed the handler has set a response body when it set
+   * the erroneous status code.
+   *
+   */
+  void operation_locally_committed_func(
+    ccf::endpoints::CommandEndpointContext& ctx, const ccf::TxID& tx_id)
+  {
+    std::string tx_str = tx_id.to_str();
+    SCITT_DEBUG("New operation was locally committed with tx={}", tx_str);
+
+    // Even though synchronous operations are set to "Succeeded" in the KV,
+    // they still need to go through consensus, so we tell the client it is
+    // still "running".
+    GetOperation::Out operation{
+      .operation_id = tx_id,
+      .status = OperationStatus::Running,
+    };
+
+    ctx.rpc_ctx->set_response_header(http::headers::CCF_TX_ID, tx_str);
+    ctx.rpc_ctx->set_response_header(
+      http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
+    ctx.rpc_ctx->set_response_header(
+      http::headers::LOCATION, fmt::format("/operations/{}", tx_str));
+    ctx.rpc_ctx->set_response_body(serdes::pack(operation, serdes::Pack::Text));
+    ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
+
+    AppData& app_data = get_app_data(ctx.rpc_ctx);
+    if (app_data.asynchronous_operation.has_value())
+    {
+      app_data.asynchronous_operation->trigger(fmt::format(
+        "https://{}/operations/{}/callback",
+        app_data.asynchronous_operation->bind_address,
+        tx_str));
+    }
+  }
+}

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -132,8 +132,7 @@ namespace scitt
 
       if (operation_id.seqno < lower_bound)
       {
-        throw HTTPError(
-          HTTP_STATUS_GONE,
+        throw NotFoundError(
           errors::OperationExpired,
           "Operation ID is too old");
       }

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -666,10 +666,15 @@ namespace scitt
     ctx.rpc_ctx->set_response_header(http::headers::CCF_TX_ID, tx_str);
     ctx.rpc_ctx->set_response_header(
       http::headers::CONTENT_TYPE, http::headervalues::contenttype::JSON);
-    ctx.rpc_ctx->set_response_header(
-      http::headers::LOCATION, fmt::format("/operations/{}", tx_str));
     ctx.rpc_ctx->set_response_body(serdes::pack(operation, serdes::Pack::Text));
     ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
+
+    if (auto host = ctx.rpc_ctx->get_request_header(http::headers::HOST))
+    {
+      ctx.rpc_ctx->set_response_header(
+        http::headers::LOCATION,
+        fmt::format("https://{}/operations/{}", *host, tx_str));
+    }
 
     AppData& app_data = get_app_data(ctx.rpc_ctx);
     if (app_data.asynchronous_operation.has_value())

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -133,8 +133,7 @@ namespace scitt
       if (operation_id.seqno < lower_bound)
       {
         throw NotFoundError(
-          errors::OperationExpired,
-          "Operation ID is too old");
+          errors::OperationExpired, "Operation ID is too old");
       }
       else if (operation_id.seqno >= upper_bound)
       {

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -241,7 +241,7 @@ namespace scitt
      *
      * This function compares a current and future state and returns true if the
      * transition is allowed. Some of the invalid transactions are logic errors
-     * in the implementations. Others (ie. completing an operation twice) are
+     * in the implementation. Others (ie. completing an operation twice) are
      * just undesirable but unavoidable, and shouldn't be treated as hard
      * errors.
      */
@@ -258,12 +258,14 @@ namespace scitt
       bool valid = false;
       if (!current_status.has_value())
       {
-        valid = ((log.status == Running) || (log.status == Succeeded)) &&
-          log.created_at.has_value();
+        // This is a new operation. They can only be created in the Running or
+        // Succeeded states.
+        valid = (log.status == Running) || (log.status == Succeeded);
+        valid = valid && log.created_at.has_value();
       }
       else if (current_status == Running)
       {
-        valid = (log.status == Succeeded || log.status == Failed);
+        valid = (log.status == Succeeded) || (log.status == Failed);
       }
       else if (current_status == Succeeded || current_status == Failed)
       {
@@ -292,7 +294,7 @@ namespace scitt
             nlohmann::json(log.status).dump(),
             tx_id.to_str(),
             operation_id.to_str(),
-            nlohmann::json(*current_status));
+            nlohmann::json(*current_status).dump());
         }
         else
         {

--- a/app/src/prefix_tree/frontend.h
+++ b/app/src/prefix_tree/frontend.h
@@ -225,8 +225,7 @@ namespace scitt
         constexpr uint32_t retry_after_seconds = 1;
         throw ServiceUnavailableError(
           errors::TransactionNotCached,
-          fmt::format(
-            "Historical transaction {} is not cached.", seqno),
+          fmt::format("Historical transaction {} is not cached.", seqno),
           retry_after_seconds);
       }
 

--- a/app/src/prefix_tree/frontend.h
+++ b/app/src/prefix_tree/frontend.h
@@ -101,13 +101,8 @@ namespace scitt
           errors::UnknownFeed, "No claim found for given issuer and feed");
       }
 
-      auto info = fetch_tree_receipt(*ctx.rpc_ctx, entry->prefix_tree_seqno);
-      if (!info)
-      {
-        return;
-      }
-
-      const auto& [protected_headers, receipt] = *info;
+      const auto& [protected_headers, receipt] =
+        fetch_tree_receipt(*ctx.rpc_ctx, entry->prefix_tree_seqno);
       auto body = create_read_receipt(
         protected_headers, entry->headers, entry->proof, receipt);
 
@@ -127,13 +122,8 @@ namespace scitt
 
       auto [seqno, tree] = *current;
 
-      auto info = fetch_tree_receipt(*ctx.rpc_ctx, seqno);
-      if (!info)
-      {
-        return;
-      }
-
-      const auto& [protected_headers, receipt] = *info;
+      const auto& [protected_headers, receipt] =
+        fetch_tree_receipt(*ctx.rpc_ctx, seqno);
       auto body = create_tree_receipt(protected_headers, tree.hash, receipt);
 
       ctx.rpc_ctx->set_response_body(body);
@@ -216,10 +206,7 @@ namespace scitt
      * number.
      *
      * If found, returns a pair with the tree's protected headers and the
-     * corresponding CCF receipt. The function may return std::nullopt if the
-     * historical query is not available yet. In this cases, the RpcContext will
-     * be updated with a status code and headers informing the client to retry
-     * later.
+     * corresponding CCF receipt, otherwise it throws a ServiceUnavailableError.
      *
      * Note, because this accepts a SeqNo rather than a TxID, the caller must
      * ensure the relevant transaction has been committed globally first.
@@ -229,21 +216,18 @@ namespace scitt
      * have to perform a historical query every time.
      * https://github.com/microsoft/CCF/issues/4247
      */
-    std::optional<std::pair<std::vector<uint8_t>, ccf::ReceiptPtr>>
-    fetch_tree_receipt(ccf::RpcContext& ctx, ccf::SeqNo seqno)
+    std::pair<std::vector<uint8_t>, ccf::ReceiptPtr> fetch_tree_receipt(
+      ccf::RpcContext& ctx, ccf::SeqNo seqno)
     {
       auto state = context.get_historical_state().get_state_at(0, seqno);
       if (!state)
       {
-        ctx.set_response_status(HTTP_STATUS_ACCEPTED);
-        constexpr size_t retry_after_seconds = 3;
-        ctx.set_response_header(
-          http::headers::RETRY_AFTER, retry_after_seconds);
-        ctx.set_response_header(
-          http::headers::CONTENT_TYPE, http::headervalues::contenttype::TEXT);
-        ctx.set_response_body(fmt::format(
-          "Historical transaction {} is not currently available.", seqno));
-        return std::nullopt;
+        constexpr uint32_t retry_after_seconds = 1;
+        throw ServiceUnavailableError(
+          errors::TransactionNotCached,
+          fmt::format(
+            "Historical transaction {} is not cached.", seqno),
+          retry_after_seconds);
       }
 
       auto tx = state->store->create_read_only_tx();
@@ -259,7 +243,7 @@ namespace scitt
       }
 
       auto receipt = ccf::describe_receipt_v2(*state->receipt);
-      return {{info->protected_headers, receipt}};
+      return {info->protected_headers, receipt};
     }
 
     ccfapp::AbstractNodeContext& context;

--- a/app/src/service_endpoints.h
+++ b/app/src/service_endpoints.h
@@ -4,40 +4,16 @@
 #pragma once
 
 #include "did/document.h"
+#include "visit_each_entry_in_value.h"
 
 #include <ccf/base_endpoint_registry.h>
 #include <ccf/crypto/verifier.h>
 #include <ccf/endpoint.h>
-#include <ccf/indexing/strategies/visit_each_entry_in_map.h>
 #include <ccf/json_handler.h>
 #include <ccf/service/tables/service.h>
 
 namespace scitt
 {
-  /**
-   * A wrapper around VisitEachEntryInMap that works with any kv::TypedValue,
-   * providing access to the deserialized value.
-   */
-  template <typename M>
-  class VisitEachEntryInValueTyped
-    : public ccf::indexing::strategies::VisitEachEntryInMap
-  {
-  public:
-    using VisitEachEntryInMap::VisitEachEntryInMap;
-
-  protected:
-    void visit_entry(
-      const ccf::TxID& tx_id,
-      const ccf::ByteVector& k,
-      const ccf::ByteVector& v) final
-    {
-      visit_entry(tx_id, M::ValueSerialiser::from_serialised(v));
-    }
-
-    virtual void visit_entry(
-      const ccf::TxID& tx_id, const typename M::Value& value) = 0;
-  };
-
   GetServiceParameters::Out certificate_to_service_parameters(
     const std::vector<uint8_t>& certificate_der)
   {
@@ -210,8 +186,9 @@ namespace scitt
   void register_service_endpoints(
     ccfapp::AbstractNodeContext& context, ccf::BaseEndpointRegistry& registry)
   {
-    const ccf::AuthnPolicies no_authn_policy = {ccf::empty_auth_policy};
     using namespace std::placeholders;
+
+    const ccf::AuthnPolicies no_authn_policy = {ccf::empty_auth_policy};
 
     auto service_certificate_index =
       std::make_shared<ServiceCertificateIndexingStrategy>();

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -62,7 +62,7 @@ namespace scitt::verifier
 
     PublicKey process_ietf_profile(
       const cose::ProtectedHeader& phdr,
-      kv::Tx& tx,
+      kv::ReadOnlyTx& tx,
       ::timespec current_time,
       std::chrono::seconds resolution_cache_expiry,
       const Configuration& configuration)
@@ -130,7 +130,7 @@ namespace scitt::verifier
 
     PublicKey process_x509_profile(
       const cose::ProtectedHeader& phdr,
-      kv::Tx& tx,
+      kv::ReadOnlyTx& tx,
       const Configuration& configuration)
     {
       // X.509 SCITT profile validation.
@@ -265,7 +265,7 @@ namespace scitt::verifier
     PublicKey process_notary_profile(
       const cose::ProtectedHeader& phdr,
       const cose::UnprotectedHeader& uhdr,
-      kv::Tx& tx,
+      kv::ReadOnlyTx& tx,
       const Configuration& configuration)
     {
       // Validate protected header
@@ -304,7 +304,7 @@ namespace scitt::verifier
 
     ClaimProfile verify_claim(
       const std::vector<uint8_t>& data,
-      kv::Tx& tx,
+      kv::ReadOnlyTx& tx,
       ::timespec current_time,
       std::chrono::seconds resolution_cache_expiry,
       const Configuration& configuration)
@@ -468,7 +468,7 @@ namespace scitt::verifier
     /**
      * Get the set of trusted x509 CAs from the KV.
      */
-    static std::vector<crypto::Pem> x509_root_store(kv::Tx& tx)
+    static std::vector<crypto::Pem> x509_root_store(kv::ReadOnlyTx& tx)
     {
       // TODO: move bundle name to constants and make more specific.
       auto ca_certs =

--- a/app/src/visit_each_entry_in_value.h
+++ b/app/src/visit_each_entry_in_value.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <ccf/indexing/strategies/visit_each_entry_in_map.h>
+
+namespace scitt
+{
+  /**
+   * A wrapper around VisitEachEntryInMap that works with any kv::TypedValue,
+   * providing access to the deserialized value.
+   */
+  template <typename M>
+  class VisitEachEntryInValueTyped
+    : public ccf::indexing::strategies::VisitEachEntryInMap
+  {
+  public:
+    using VisitEachEntryInMap::VisitEachEntryInMap;
+
+  protected:
+    void visit_entry(
+      const ccf::TxID& tx_id,
+      const ccf::ByteVector& k,
+      const ccf::ByteVector& v) final
+    {
+      visit_entry(tx_id, M::ValueSerialiser::from_serialised(v));
+    }
+
+    virtual void visit_entry(
+      const ccf::TxID& tx_id, const typename M::Value& value) = 0;
+  };
+}

--- a/pyscitt/pyscitt/cli/submit_signed_claims.py
+++ b/pyscitt/pyscitt/cli/submit_signed_claims.py
@@ -24,8 +24,8 @@ def submit_signed_claimset(
         signed_claimset = f.read()
 
     if skip_confirmation:
-        tx = client.submit_claim(signed_claimset, skip_confirmation=True).tx
-        print(f"Submitted {path} as transaction {tx}")
+        pending = client.submit_claim(signed_claimset, skip_confirmation=True)
+        print(f"Submitted {path} as operation {pending.operation_tx}")
         print("Confirmation of submission was skipped! Claim may not be registered.")
         return
 

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -311,8 +311,6 @@ class BaseClient:
             *args,
             **kwargs,
             retry_on=[
-                HTTPStatus.ACCEPTED,
-                (HTTPStatus.NOT_FOUND, "TransactionPendingOrUnknown"),
                 (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
             ]
             + retry_on,

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -313,28 +313,30 @@ class BaseClient:
             retry_on=[
                 HTTPStatus.ACCEPTED,
                 (HTTPStatus.NOT_FOUND, "TransactionPendingOrUnknown"),
+                (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
             ]
             + retry_on,
         )
 
 
 @dataclass
-class Submission:
+class PendingSubmission:
     """
     The result of submitting a claim to the service.
     """
 
+    operation_tx: str
+
+
+@dataclass
+class Submission(PendingSubmission):
     tx: str
+    raw_receipt: bytes
 
     @property
     def seqno(self) -> int:
         view, seqno = self.tx.split(".")
         return int(seqno)
-
-
-@dataclass
-class SubmissionReceipt(Submission):
-    raw_receipt: bytes
 
     @property
     def receipt(self) -> Receipt:
@@ -363,65 +365,86 @@ class Client(BaseClient):
 
     @overload
     def submit_claim(
-        self,
-        claim: bytes,
-        *,
-        skip_confirmation: Literal[False] = False,
-        allow_retries: bool = True,
-    ) -> SubmissionReceipt:
+        self, claim: bytes, *, skip_confirmation: Literal[False] = False
+    ) -> Submission:
         ...
 
     @overload
     def submit_claim(
-        self,
-        claim: bytes,
-        *,
-        skip_confirmation: Literal[True],
-        allow_retries: bool = True,
-    ) -> Submission:
+        self, claim: bytes, *, skip_confirmation: Literal[True]
+    ) -> PendingSubmission:
         ...
 
     def submit_claim(
-        self,
-        claim: bytes,
-        *,
-        skip_confirmation: bool = False,
-        allow_retries: bool = True,
-    ) -> Union[SubmissionReceipt, Submission]:
+        self, claim: bytes, *, skip_confirmation=False
+    ) -> Union[Submission, PendingSubmission]:
         headers = {"Content-Type": "application/cose"}
         response = self.post(
             "/entries",
             headers=headers,
             content=claim,
-            retry_on=[
-                (HTTPStatus.SERVICE_UNAVAILABLE, "DIDResolutionInProgressRetryLater")
-            ]
-            if allow_retries
-            else [],
-        )
+        ).json()
 
-        tx = response.headers[CCF_TX_ID_HEADER]
+        operation_id = response["operationId"]
         if skip_confirmation:
-            return Submission(tx)
+            return PendingSubmission(operation_id)
         else:
+            tx = self.wait_for_operation(operation_id)
             receipt = self.get_receipt(tx, decode=False)
-            return SubmissionReceipt(tx, receipt)
+            return Submission(operation_id, tx, receipt)
+
+    def wait_for_operation(self, operation: str) -> str:
+        response = self.get(
+            f"/operations/{operation}",
+            retry_on=[lambda r: r.is_success and r.json()["status"] == "running"],
+        )
+        payload = response.json()
+
+        if payload["status"] == "succeeded":
+            return payload["entryId"]
+        elif payload["status"] == "failed":
+            error = payload["error"]
+            raise ServiceError(response.headers, error["code"], error["message"])
+        else:
+            raise ValueError("Invalid status {}".format(payload["status"]))
+
+    def get_operations(self):
+        return self.get("/operations").json()["operations"]
 
     def get_claim(self, tx: str, *, embed_receipt=False) -> bytes:
         response = self.get_historical(
-            f"/entries/{tx}", params={"embedReceipt": embed_receipt}
+            f"/entries/{tx}/claim", params={"embedReceipt": embed_receipt}
         )
         return response.content
 
     @overload
-    def get_receipt(self, tx: str, *, decode: Literal[True] = True) -> Receipt:
+    def get_receipt(
+        self,
+        tx: str,
+        *,
+        operation: bool = False,
+        decode: Literal[True] = True,
+    ) -> Receipt:
         ...
 
     @overload
-    def get_receipt(self, tx: str, *, decode: Literal[False]) -> bytes:
+    def get_receipt(
+        self, tx: str, *, operation: bool = False, decode: Literal[False]
+    ) -> bytes:
         ...
 
-    def get_receipt(self, tx: str, *, decode=True) -> Union[bytes, Receipt]:
+    def get_receipt(
+        self, tx: str, *, operation: bool = False, decode: bool = True
+    ) -> Union[bytes, Receipt]:
+        """
+        Get a receipt from the ledger.
+
+        If `operation` is true, the tx is treated as an operation ID and is
+        first waited on in order to obtain the actual entry ID.
+        """
+        if operation:
+            tx = self.wait_for_operation(tx)
+
         response = self.get_historical(f"/entries/{tx}/receipt")
         if decode:
             return Receipt.decode(response.content)

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -6,6 +6,7 @@ import datetime
 import hashlib
 import json
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
@@ -289,6 +290,15 @@ def pub_key_pem_to_der(pem: Pem) -> bytes:
 def pub_key_pem_to_ssh(pem: Pem) -> str:
     pub_key = load_pem_public_key(pem.encode("ascii"))
     return pub_key.public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH).decode("ascii")
+
+
+def private_key_to_public(pem: Pem) -> Pem:
+    private_key = load_pem_private_key(pem.encode("ascii"), None)
+    return (
+        private_key.public_key()
+        .public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+        .decode("ascii")
+    )
 
 
 def private_key_pem_to_ssh(pem: Pem) -> str:
@@ -627,6 +637,7 @@ def jwk_from_public_key(
     return jwk
 
 
+@dataclass(init=False)
 class Signer:
     private_key: Pem
     issuer: Optional[str]

--- a/test/constants.py
+++ b/test/constants.py
@@ -4,4 +4,5 @@
 # This file mirrors some of the constants from the src/constants.h file.
 # Make sure to keep them in sync.
 
+OPERATION_EXPIRY_SECONDS = 60 * 60
 DID_RESOLUTION_CACHE_EXPIRY_SECONDS = 60 * 30

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+
+from pyscitt import crypto
+from pyscitt.client import Client
+
+from . import constants
+from .infra.assertions import service_error
+from .infra.cchost import CCHost
+from .infra.did_web_server import DIDWebServer
+
+
+@pytest.mark.isolated_test(enable_faketime=True)
+def test_purge_old_operations(
+    did_web: DIDWebServer,
+    client: Client,
+    cchost: CCHost,
+):
+    """
+    Operations are purged from the service's memory after a while.
+    """
+    identity = did_web.create_identity()
+    claim = crypto.sign_json_claimset(identity, "Payload")
+
+    # Create two operations, such that one will be old enough to be purged but
+    # not the other.
+    tx1 = client.submit_claim(claim).operation_tx
+    cchost.advance_time(seconds=constants.OPERATION_EXPIRY_SECONDS // 2)
+
+    tx2 = client.submit_claim(claim).operation_tx
+    cchost.advance_time(seconds=constants.OPERATION_EXPIRY_SECONDS // 2)
+
+    # Just moving time forward doesn't actually do anything yet.
+    # For now, both operations are still in memory.
+    txs = [o["operationId"] for o in client.get_operations()]
+    assert tx1 in txs
+    assert tx2 in txs
+
+    # Submit a claim again, just to get the indexing strategy
+    # to run. This is what actually triggers a purge.
+    client.submit_claim(claim)
+
+    # Now the first operation has actually been purged, but not the second,
+    # since that one is only half as old.
+    txs = [o["operationId"] for o in client.get_operations()]
+    assert tx1 not in txs
+    assert tx2 in txs
+
+    # Looking up an expired operation fails deterministically.
+    with service_error("OperationExpired: Operation ID is too old"):
+        client.wait_for_operation(tx1)
+
+    # We can still look up the one that hasn't expired though.
+    client.wait_for_operation(tx2)

--- a/test/test_resolution.py
+++ b/test/test_resolution.py
@@ -21,7 +21,7 @@ def submit_concurrently(
     did_web: DIDWebServer,
 ):
     """
-    A fixture which allows multiple receipts to be submitted concurrently.
+    A fixture which allows multiple claims to be submitted concurrently.
 
     This is achieved by suspending the DID web server, submitting all the
     claims, then finally resuming the server.

--- a/test/test_resolution.py
+++ b/test/test_resolution.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import time
+from typing import Callable, List, Tuple
 
 import pytest
 
@@ -12,6 +13,36 @@ from pyscitt.verify import TrustStore, verify_receipt
 from . import constants
 from .infra.assertions import service_error
 from .infra.did_web_server import DIDWebServer
+
+
+@pytest.fixture
+def submit_concurrently(
+    client: Client,
+    did_web: DIDWebServer,
+):
+    """
+    A fixture which allows multiple receipts to be submitted concurrently.
+
+    This is achieved by suspending the DID web server, submitting all the
+    claims, then finally resuming the server.
+
+    Returns the list of operation IDs.
+    """
+
+    def f(claims: List[bytes]) -> List[str]:
+        with did_web.suspend():
+            operations = [
+                client.submit_claim(c, skip_confirmation=True).operation_tx
+                for c in claims
+            ]
+
+            # Give the ledger a second to kick off the requests before we
+            # unblock the DID server.
+            time.sleep(1)
+
+        return operations
+
+    return f
 
 
 def test_cache_resolution(
@@ -32,11 +63,69 @@ def test_cache_resolution(
         receipt1 = client.submit_claim(claim1).receipt
 
         claim2 = crypto.sign_json_claimset(identity, "World")
-        receipt2 = client.submit_claim(claim2, allow_retries=False).receipt
+        receipt2 = client.submit_claim(claim2).receipt
 
     assert metrics.request_count == 1
     verify_receipt(claim1, trust_store, receipt1)
     verify_receipt(claim2, trust_store, receipt2)
+
+
+def test_concurrent_resolution(
+    client: Client,
+    did_web: DIDWebServer,
+    trust_store: TrustStore,
+    submit_concurrently: Callable[[List[bytes]], List[str]],
+):
+    """
+    Submit two claims signed with the same key, concurrently.
+
+    The ledger should aggregate the two resolutions into a single HTTP request
+    to the same server.
+    """
+    identity = did_web.create_identity()
+    claim1 = crypto.sign_json_claimset(identity, "Hello")
+    claim2 = crypto.sign_json_claimset(identity, "World")
+
+    with did_web.monitor() as metrics:
+        [tx1, tx2] = submit_concurrently([claim1, claim2])
+        receipt1 = client.get_receipt(tx1, operation=True)
+        receipt2 = client.get_receipt(tx2, operation=True)
+
+    # TODO: Aggregation of resolution is not yet implemented.
+    # Once it is, we should change this to `== 1`
+    assert metrics.request_count == 2
+    verify_receipt(claim1, trust_store, receipt1)
+    verify_receipt(claim2, trust_store, receipt2)
+
+
+def test_key_rotation(
+    client: Client,
+    did_web: DIDWebServer,
+    trust_store: TrustStore,
+):
+    """
+    When rotating the key found in a DID document, the ledger doesn't use the
+    cached document but instead fetches the document again.
+    """
+
+    with did_web.monitor() as metrics:
+        identity1 = did_web.create_identity()
+        claim1 = crypto.sign_json_claimset(identity1, "Hello")
+        receipt1 = client.submit_claim(claim1).receipt
+
+        identity2 = did_web.create_identity(identifier=identity1.issuer)
+        claim2 = crypto.sign_json_claimset(identity2, "World")
+        receipt2 = client.submit_claim(claim2).receipt
+
+    assert identity1.issuer == identity2.issuer
+    assert identity1.kid != identity2.kid
+    assert metrics.request_count == 2
+    verify_receipt(claim1, trust_store, receipt1)
+    verify_receipt(claim2, trust_store, receipt2)
+
+    # The old claim can't be submitted anymore, since it uses the old key.
+    with service_error("Missing assertion method in DID document"):
+        client.submit_claim(claim1)
 
 
 @pytest.mark.isolated_test(enable_faketime=True)
@@ -55,7 +144,7 @@ def test_key_expiry(client, did_web, cchost):
 
     # The ledger still has the DID document cached, so will accept a claim
     # signed with the old key.
-    client.submit_claim(claim, allow_retries=False)
+    client.submit_claim(claim)
 
     # Time travel, enough for the cached document to expire.
     cchost.advance_time(seconds=constants.DID_RESOLUTION_CACHE_EXPIRY_SECONDS)
@@ -64,10 +153,9 @@ def test_key_expiry(client, did_web, cchost):
     # ledger has to re-fetch it, but will eventually fail since the document
     # now contains a new key.
     #
-    # TODO: make the assertion on the error more precise. We should really
-    # check that the second resolution fails because of a wrong key ID.
-    with service_error("DIDResolutionInProgressRetryLater"):
-        client.submit_claim(claim, allow_retries=False)
+    # The ledger will re-resolve the DID, and won't find the old key anymore.
+    with service_error("Missing assertion method in DID document"):
+        client.submit_claim(claim)
 
     # TODO: exiting while a resolution is in progress causes libuv to fail with
     # EBUSY, since the external process is still running. Once we have a better
@@ -114,6 +202,13 @@ def test_multiple_keys(
     submit(private_key1, "#key-1", "Hello")
     submit(private_key2, "#key-2", "World")
 
+    # If we don't specify a KID when signing the claim, it becomes ambigous
+    # which key we wanted to use and the server rejects the claim.
+    with service_error(
+        "DID document must have exactly one assertion method if no assertion method id is provided"
+    ):
+        submit(private_key1, None, "World")
+
 
 def test_claim_without_kid(
     client: Client,
@@ -133,6 +228,107 @@ def test_claim_without_kid(
 
     receipt = client.submit_claim(claim).receipt
     verify_receipt(claim, trust_store, receipt)
+
+
+class TestDIDMismatch:
+    """
+    Test DID resolution with an inconsistent DID document.
+
+    The "id" field of the document does not match the expected value.
+
+    This error scenario isn't particularly interesting in itself, but it is an
+    easy way to test the ledger's handling of errors during resolution.
+    """
+
+    @pytest.fixture
+    def identity(self, did_web) -> crypto.Signer:
+        issuer = did_web.generate_identifier()
+        private_key, _ = crypto.generate_keypair(kty="ec")
+        return crypto.Signer(private_key, issuer=issuer)
+
+    @pytest.fixture(autouse=True)
+    def create_document(self, did_web: DIDWebServer, identity: crypto.Signer):
+        # Create a document, but write a random DID into that does not
+        # correspond to the location of the document nor the issuer we use in
+        # claims.
+        document = did.create_document(
+            did=did_web.generate_identifier(),
+            public_key=crypto.private_key_to_public(identity.private_key),
+        )
+
+        assert document["id"] != identity.issuer
+
+        did_web.write_did_document(document, identifier=identity.issuer)
+
+    def test_submit(self, client: Client, identity: crypto.Signer):
+        claim = crypto.sign_json_claimset(identity, "Payload")
+
+        with service_error("DID document ID does not match expected value"):
+            client.submit_claim(claim)
+
+    def test_submit_concurrently(
+        self,
+        client: Client,
+        did_web: DIDWebServer,
+        identity: crypto.Signer,
+        submit_concurrently: Callable[[List[bytes]], List[str]],
+    ):
+        """
+        Submit two claims signed with the same key, sequentially.
+
+        The server should aggregate the resolutions into a single request, yet
+        correctly report the resolution error on both operations.
+        """
+
+        claim1 = crypto.sign_json_claimset(identity, "Hello")
+        claim2 = crypto.sign_json_claimset(identity, "World")
+
+        with did_web.monitor() as metrics:
+            [tx1, tx2] = submit_concurrently([claim1, claim2])
+
+            with service_error("DID document ID does not match expected value"):
+                client.wait_for_operation(tx1)
+
+            with service_error("DID document ID does not match expected value"):
+                client.wait_for_operation(tx2)
+
+        # TODO: Aggregation of resolution is not yet implemented.
+        # Once it is, we should change this to `== 1`
+        assert metrics.request_count == 2
+
+    def test_dont_cache_error(
+        self,
+        client: Client,
+        did_web: DIDWebServer,
+        trust_store: TrustStore,
+        identity: crypto.Signer,
+    ):
+        """
+        Test that the ledger does not cache failed resolutions.
+
+        After fixing the cause of the error, the server should immediately be
+        able to resolve the DID again.
+        """
+
+        assert identity.issuer is not None
+
+        claim = crypto.sign_json_claimset(identity, "Payload")
+
+        # Submit the claim a first time, with the invalid document
+        with service_error("DID document ID does not match expected value"):
+            client.submit_claim(claim)
+
+        # Update the published document. This time it uses the correct DID.
+        # (Each test runs with a different DID, so this won't affect others).
+        document = did.create_document(
+            did=identity.issuer,
+            public_key=crypto.private_key_to_public(identity.private_key),
+        )
+        did_web.write_did_document(document)
+
+        # Submitting the same claim now works just fine.
+        receipt = client.submit_claim(claim).receipt
+        verify_receipt(claim, trust_store, receipt)
 
 
 def test_consistent_kid(

--- a/test/test_resolution.py
+++ b/test/test_resolution.py
@@ -151,17 +151,10 @@ def test_key_expiry(client, did_web, cchost):
 
     # The cached document can't be used anymore since it has expired. The
     # ledger has to re-fetch it, but will eventually fail since the document
-    # now contains a new key.
-    #
-    # The ledger will re-resolve the DID, and won't find the old key anymore.
+    # now contains a new key. When it does, the document won't contain the old
+    # key anymore and resolution will fail.
     with service_error("Missing assertion method in DID document"):
         client.submit_claim(claim)
-
-    # TODO: exiting while a resolution is in progress causes libuv to fail with
-    # EBUSY, since the external process is still running. Once we have a better
-    # way of monitoring the status of DID resolution we can be a bit smarter
-    # about this.
-    time.sleep(5)
 
 
 def test_multiple_keys(


### PR DESCRIPTION
This introduces the concept of a long-running operation to the API. When
submitting a claim, the ledger returns a temporary operation ID. Clients
must poll an endpoint to check the status of the operation.

Eventually, the operation will complete and the status endpoint will
return long-term entry ID, which the client can use to retrieve a
receipt.

This schema can be used to model both the DID-web resolution phase and
the CCF consensus process.

If submitting a claim requires a DID resolution, the initial POST to the
`/claims` endpoint creates a new operation by saving the claim to a
special KV, and triggers the external process to fetch the DID document.
When the external process invokes the operation callback with the
resolution payload, the ledger uses a historical to get the original
claim back. Once both the claim and DID document are available, the
existing registration process takes place and a new row is added to the
KV to mark the operation as complete.

After a claim has been written the the KV, either synchronously in the
original POST request or asynchronously in the resolution callback, the
operation is still considered as pending, until the transaction is
globally committed and a receipt is available. At this point only will
the operation be considered completed.

This new API has multiple benefits:
- It surfaces DID resolution errors to the end-user. Previously, clients
  would only ever receive "resolution in progress" messages, but never
  any hard errors with informative description. Now the operation can be
  marked as failed by writing details of the error to the KV, and the
  error message is returned when a client polls the operation status.
- It is a more intuitive API and does not require clients to retry POST
  requests anymore. The only request that needs polling is a GET to
  check the operation status, and one day this may even be replaced by a
  long-polling request.
- It unifies different delays, such as resolution and consensus, under a
  single interface, abstracting implementation details from clients.

Fixes #108 