### PR TITLE
Fix a memory leak in get_certificate_ecdsa_curve_size.

### DIFF
--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -94,6 +94,8 @@ stages:
           Environment:
             CMAKE_BUILD_TYPE: Debug
             ENABLE_PREFIX_TREE: ON
+            # Fast unwinder only gives us partial stack traces in LeakSanitzer
+            ASAN_OPTIONS: fast_unwind_on_malloc=0
           FunctionalTestArguments: '--enable-prefix-tree'
 
       - job: format

--- a/app/src/receipt.h
+++ b/app/src/receipt.h
@@ -82,7 +82,7 @@ namespace scitt
   size_t get_certificate_ecdsa_curve_size(std::span<const uint8_t> der)
   {
     OpenSSL::Unique_X509 cert(OpenSSL::Unique_BIO(der), false, true);
-    EVP_PKEY* pk = X509_get_pubkey(cert);
+    OpenSSL::Unique_PKEY pk(X509_get_pubkey(cert), EVP_PKEY_free);
 
     size_t bits = EVP_PKEY_bits(pk);
     return (bits + 7) / 8;


### PR DESCRIPTION
We use X509_get_pubkey to get the PKEY object from an X509 certificate. The returned pointer was never freed, probably because of an incorrect assumption that it was borrowed from the X509 object.

According to [the documentation for the X509_get_pubkey function](https://www.openssl.org/docs/man1.1.1/man3/X509_get_pubkey.html):

> If successful it returns the public key as an EVP_PKEY pointer with its
reference count incremented: this means the returned key must be freed up after use.

We now use the Unique_PKEY class to manage the object's lifetime, automatically calling EVP_PKEY_free when the function terminates.

This bug was correctly caught by ASan's memory leak detection, but leaks are only raised during process shutdown, and our test infrastructure never checked for cchost's return code. Moreover, a bug in aiotools's TaskGroup was hiding exceptions that were happening during shutdown, which we now need to work around.

While at it, add another workaround for a Python bug that would occasionally cause noise on our console output.