### PR TITLE
Make x509 certificate validation stricter.

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -129,6 +129,7 @@ if (BUILD_TESTS)
 
   add_executable(
     unit_tests
+    unit-tests/main.cpp
     unit-tests/cbor_test.cpp
     unit-tests/verifier_test.cpp
     unit-tests/configurable_auth_test.cpp
@@ -142,7 +143,7 @@ if (BUILD_TESTS)
   target_compile_options(unit_tests PUBLIC ${COMPILE_LIBCXX})
   target_link_libraries(
     unit_tests PRIVATE
-    GTest::gmock_main
+    GTest::gmock
     rapidcheck
     rapidcheck_gtest
     t_cose.host

--- a/app/unit-tests/main.cpp
+++ b/app/unit-tests/main.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <ccf/ds/logger.h>
+#include <gmock/gmock.h>
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleMock(&argc, argv);
+
+  // Initialise the CCF logging.
+  logger::config::default_init();
+
+  return RUN_ALL_TESTS();
+}

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -19,6 +19,7 @@ from pyscitt.verify import StaticTrustStore
 from .cchost import CCHost, get_default_cchost_path, get_enclave_path
 from .did_web_server import DIDWebServer
 from .proxy import Proxy
+from .x5chain_certificate_authority import X5ChainCertificateAuthority
 
 # This file defines a collection of pytest fixtures used to manage and
 # interact with the SCITT ledger.
@@ -374,6 +375,19 @@ def did_web(client, tmp_path_factory):
         )
 
         yield did_web_server
+
+
+@pytest.fixture(scope="class")
+def trusted_ca(client) -> X5ChainCertificateAuthority:
+    """
+    Create a X5ChainCertificateAuthority and add its root to the SCITT service.
+
+    The service will accept claims signed using certificates issued by the CA.
+    """
+    ca = X5ChainCertificateAuthority(kty="ec")
+    proposal = governance.set_ca_bundle_proposal("x509_roots", ca.cert_bundle)
+    client.governance.propose(proposal, must_pass=True)
+    return ca
 
 
 @pytest.fixture(scope="class")

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -1,22 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import json
 import os
-import time
 
-import cbor2
-import pycose
 import pycose.headers
 import pytest
-from pycose.messages import Sign1Message
 
 from pyscitt import crypto, governance
 from pyscitt.client import Client, ServiceError
 from pyscitt.verify import verify_receipt
 
 from .infra.did_web_server import DIDWebServer
-from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 
 
 # Temporary monkey-patch for pycose until https://github.com/TimothyClaeys/pycose/pull/107
@@ -63,113 +57,6 @@ def test_submit_claim(client: Client, did_web, trust_store, params):
 
     embedded = crypto.embed_receipt_in_cose(claims, receipt)
     verify_receipt(embedded, trust_store, None)
-
-
-@pytest.mark.parametrize(
-    "params,x5c_len",
-    [
-        ({"alg": "PS384", "kty": "rsa"}, 1),
-        ({"alg": "PS384", "kty": "rsa"}, 2),
-        ({"alg": "PS384", "kty": "rsa"}, 3),
-        ({"alg": "ES256", "kty": "ec", "ec_curve": "P-256"}, 1),
-    ],
-)
-def test_submit_claim_x5c(client: Client, trust_store, params: dict, x5c_len: int):
-    """
-    Submit claims to the SCITT CCF ledger and verify the resulting receipts for x5c.
-
-    Test is parametrized over different signing parameters.
-    """
-    x5c_ca = X5ChainCertificateAuthority(**params)
-
-    client.governance.propose(
-        governance.set_ca_bundle_proposal("x509_roots", x5c_ca.cert_bundle),
-        must_pass=True,
-    )
-
-    identity = x5c_ca.create_identity(x5c_len, **params)
-
-    # Sign and submit a dummy claim using our new identity
-    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
-    receipt = client.submit_claim(claims).receipt
-    verify_receipt(claims, trust_store, receipt)
-
-
-def test_invalid_x5c(client: Client):
-    x5c_ca = X5ChainCertificateAuthority(alg="ES256", kty="ec")
-    client.governance.propose(
-        governance.set_ca_bundle_proposal("x509_roots", x5c_ca.cert_bundle),
-        must_pass=True,
-    )
-
-    # Create a signer with a missing certificate in the chain
-    x5c, private_key = x5c_ca.create_chain(length=3, kty="ec")
-    identity = crypto.Signer(private_key, x5c=x5c[1:])
-    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
-
-    with pytest.raises(ServiceError, match="Signature verification failed"):
-        client.submit_claim(claims)
-
-
-@pytest.mark.parametrize(
-    "params,x5c_len",
-    [
-        ({"alg": "PS384", "kty": "rsa"}, 1),
-        ({"alg": "ES256", "kty": "ec", "ec_curve": "P-256"}, 1),
-    ],
-)
-def test_submit_claim_notary_x509(
-    client: Client, trust_store, params: dict, x5c_len: int
-):
-    """
-    Submit claims to the SCITT CCF ledger and verify the resulting receipts for x5c.
-
-    Test is parametrized over different signing parameters.
-    """
-    x5c_ca = X5ChainCertificateAuthority(**params)
-
-    client.governance.propose(
-        governance.set_ca_bundle_proposal("x509_roots", x5c_ca.cert_bundle),
-        must_pass=True,
-    )
-
-    identity = x5c_ca.create_identity(x5c_len, **params)
-
-    phdr: dict = {}
-    phdr[pycose.headers.Algorithm] = identity.algorithm
-    phdr[pycose.headers.ContentType] = "application/vnd.cncf.notary.payload.v1+json"
-    phdr[pycose.headers.Critical] = ["io.cncf.notary.signingScheme"]
-    phdr["io.cncf.notary.signingTime"] = cbor2.CBORTag(1, int(time.time()))
-    phdr["io.cncf.notary.signingScheme"] = "notary.x509"
-
-    uhdr: dict = {}
-    assert identity.x5c is not None
-    uhdr[pycose.headers.X5chain] = [crypto.cert_pem_to_der(x5) for x5 in identity.x5c]
-    uhdr["io.cncf.notary.signingAgent"] = "Notation/1.0.0"
-
-    payload = json.dumps(
-        {
-            "targetArtifact": {
-                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-                "digest": "sha256:beac45bd57e10fa6b607fb84daa51dce8d81928f173d215f1f3544c07f90c8c1",
-                "size": 942,
-            }
-        }
-    ).encode("utf-8")
-
-    msg = Sign1Message(phdr=phdr, uhdr=uhdr, payload=payload)
-    msg.key = crypto.cose_private_key_from_pem(identity.private_key)
-    claim = msg.encode(tag=True)
-
-    submission = client.submit_claim(claim)
-    verify_receipt(claim, trust_store, submission.receipt)
-
-    # Embedding the receipt requires re-encoding the unprotected header.
-    # Notary has x5chain in the unprotected header.
-    # This checks whether x5chain is preserved after re-encoding by simply
-    # submitting the claim again.
-    claim_with_receipt = client.get_claim(submission.tx, embed_receipt=True)
-    client.submit_claim(claim_with_receipt)
 
 
 def test_default_did_port(client: Client, trust_store, tmp_path):

--- a/test/test_x509.py
+++ b/test/test_x509.py
@@ -1,0 +1,245 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import json
+import time
+
+import cbor2
+import pycose
+import pytest
+from pycose.messages import Sign1Message
+
+from pyscitt import crypto, governance
+from pyscitt.client import Client, ServiceError
+from pyscitt.verify import TrustStore, verify_receipt
+
+from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
+
+
+@pytest.mark.parametrize(
+    "length, algorithm, params",
+    [
+        (1, "PS384", {"kty": "rsa"}),
+        (2, "PS384", {"kty": "rsa"}),
+        (3, "PS384", {"kty": "rsa"}),
+        (1, "ES256", {"kty": "ec", "ec_curve": "P-256"}),
+    ],
+)
+def test_submit_claim_x5c(
+    client: Client,
+    trust_store: TrustStore,
+    trusted_ca: X5ChainCertificateAuthority,
+    length: int,
+    algorithm: str,
+    params: dict,
+):
+    """
+    Submit claims to the SCITT CCF ledger and verify the resulting receipts for x5c.
+
+    Test is parametrized over different signing parameters.
+    """
+    identity = trusted_ca.create_identity(length=length, alg=algorithm, **params)
+
+    # Sign and submit a dummy claim using our new identity
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+    receipt = client.submit_claim(claims).receipt
+    verify_receipt(claims, trust_store, receipt)
+
+
+def test_invalid_certificate_chain(
+    client: Client,
+    trusted_ca: X5ChainCertificateAuthority,
+):
+    # Create a certificate chain, but remove one of the intermediate certs
+    x5c, private_key = trusted_ca.create_chain(length=3, kty="ec")
+    del x5c[1]
+
+    identity = crypto.Signer(private_key, x5c=x5c)
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+
+    with pytest.raises(ServiceError, match="Certificate chain is invalid"):
+        client.submit_claim(claims)
+
+
+def test_wrong_certificate(
+    client: Client,
+    trusted_ca: X5ChainCertificateAuthority,
+):
+    """
+    Submit a claim that embeds a x509 certificate chain for a different key pair.
+    """
+
+    # Create two different certificates from the CA, but use the private key of
+    # one and the certificate chain of the other
+    _, private_key = trusted_ca.create_chain(kty="ec")
+    x5c, _ = trusted_ca.create_chain(kty="ec")
+    identity = crypto.Signer(private_key, x5c=x5c)
+
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+
+    with pytest.raises(ServiceError, match="Signature verification failed"):
+        client.submit_claim(claims)
+
+
+def test_untrusted_ca(client: Client):
+    """
+    Submit a claim signed by a certificate issued by an untrusted CA.
+    """
+    untrusted_ca = X5ChainCertificateAuthority(kty="ec")
+    identity = untrusted_ca.create_identity(alg="ES256", kty="ec")
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+
+    with pytest.raises(ServiceError, match="Certificate chain is invalid"):
+        client.submit_claim(claims)
+
+
+def test_self_signed_trusted(
+    client: Client,
+    trust_store: TrustStore,
+):
+    """
+    Submit a claim signed by a trusted self-signed certificate.
+    """
+
+    private_key, _ = crypto.generate_keypair(kty="ec")
+    cert_pem = crypto.generate_cert(private_key, ca=False)
+
+    proposal = governance.set_ca_bundle_proposal("x509_roots", cert_pem)
+    client.governance.propose(proposal, must_pass=True)
+
+    identity = crypto.Signer(private_key, x5c=[cert_pem])
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+
+    # See verifier.h's check_certificate_policy for a discussion of why we
+    # choose to reject this.
+    # We're pretty flexible about the error message here, because the exact
+    # behaviour depends on the OpenSSL version.
+    with pytest.raises(ServiceError, match="Certificate chain"):
+        client.submit_claim(claims)
+
+
+def test_multiple_trusted_roots(client: Client, trust_store: TrustStore):
+    first_ca = X5ChainCertificateAuthority(kty="ec")
+    second_ca = X5ChainCertificateAuthority(kty="ec")
+
+    # The cert bundles are just PEM bags of certificates.
+    # We can combine them simply using string concatenation.
+    proposal = governance.set_ca_bundle_proposal(
+        "x509_roots", first_ca.cert_bundle + second_ca.cert_bundle
+    )
+    client.governance.propose(proposal, must_pass=True)
+
+    first_identity = first_ca.create_identity(alg="ES256", kty="ec")
+    first_claims = crypto.sign_json_claimset(first_identity, {"foo": "bar"})
+
+    second_identity = second_ca.create_identity(alg="ES256", kty="ec")
+    second_claims = crypto.sign_json_claimset(second_identity, {"foo": "bar"})
+
+    first_receipt = client.submit_claim(first_claims).receipt
+    second_receipt = client.submit_claim(second_claims).receipt
+
+    verify_receipt(first_claims, trust_store, first_receipt)
+    verify_receipt(second_claims, trust_store, second_receipt)
+
+
+def test_self_signed_untrusted(client: Client):
+    """
+    Submit a claim signed by a untrusted self-signed certificate.
+    """
+    private_key, _ = crypto.generate_keypair(kty="ec")
+    cert_pem = crypto.generate_cert(private_key, ca=False)
+
+    identity = crypto.Signer(private_key, x5c=[cert_pem])
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+
+    with pytest.raises(ServiceError, match="Certificate chain is invalid"):
+        client.submit_claim(claims)
+
+
+def test_leaf_ca(
+    client: Client,
+    trusted_ca: X5ChainCertificateAuthority,
+):
+    """
+    Submit claims signed by a leaf certificate with the CA flag set.
+    """
+    identity = trusted_ca.create_identity(alg="ES256", kty="ec", ca=True)
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+    with pytest.raises(ServiceError, match="Signing certificate is CA"):
+        client.submit_claim(claims).receipt
+
+
+def test_root_ca(
+    client: Client,
+    trusted_ca: X5ChainCertificateAuthority,
+):
+    """
+    Submit claims signed by the trusted root CA.
+    """
+
+    identity = crypto.Signer(trusted_ca.root_key_pem, x5c=[trusted_ca.root_cert_pem])
+    claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
+    with pytest.raises(
+        ServiceError, match="Certificate chain must include at least one CA certificate"
+    ):
+        client.submit_claim(claims).receipt
+
+
+@pytest.mark.parametrize(
+    "length, algorithm, params",
+    [
+        (1, "PS384", {"kty": "rsa"}),
+        (2, "PS384", {"kty": "rsa"}),
+        (1, "ES256", {"kty": "ec", "ec_curve": "P-256"}),
+    ],
+)
+def test_submit_claim_notary_x509(
+    client: Client,
+    trust_store: TrustStore,
+    trusted_ca: X5ChainCertificateAuthority,
+    length: int,
+    algorithm: str,
+    params: dict,
+):
+    """
+    Submit claims to the SCITT CCF ledger and verify the resulting receipts for x5c.
+
+    Test is parametrized over different signing parameters.
+    """
+    identity = trusted_ca.create_identity(length=length, alg=algorithm, **params)
+
+    phdr: dict = {}
+    phdr[pycose.headers.Algorithm] = identity.algorithm
+    phdr[pycose.headers.ContentType] = "application/vnd.cncf.notary.payload.v1+json"
+    phdr[pycose.headers.Critical] = ["io.cncf.notary.signingScheme"]
+    phdr["io.cncf.notary.signingTime"] = cbor2.CBORTag(1, int(time.time()))
+    phdr["io.cncf.notary.signingScheme"] = "notary.x509"
+
+    uhdr: dict = {}
+    assert identity.x5c is not None
+    uhdr[pycose.headers.X5chain] = [crypto.cert_pem_to_der(x5) for x5 in identity.x5c]
+    uhdr["io.cncf.notary.signingAgent"] = "Notation/1.0.0"
+
+    payload = json.dumps(
+        {
+            "targetArtifact": {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:beac45bd57e10fa6b607fb84daa51dce8d81928f173d215f1f3544c07f90c8c1",
+                "size": 942,
+            }
+        }
+    ).encode("utf-8")
+
+    msg = Sign1Message(phdr=phdr, uhdr=uhdr, payload=payload)
+    msg.key = crypto.cose_private_key_from_pem(identity.private_key)
+    claim = msg.encode(tag=True)
+
+    submission = client.submit_claim(claim)
+    verify_receipt(claim, trust_store, submission.receipt)
+
+    # Embedding the receipt requires re-encoding the unprotected header.
+    # Notary has x5chain in the unprotected header.
+    # This checks whether x5chain is preserved after re-encoding by simply
+    # submitting the claim again.
+    claim_with_receipt = client.get_claim(submission.tx, embed_receipt=True)
+    client.submit_claim(claim_with_receipt)


### PR DESCRIPTION
Certificate chains embedded in claims (as part of the x5chain parameter) now need to include the self-signed root certificate. This was previously not necessary, since the root certificate would be resolved from the service's trust store. Requiring it improves auditability however, since it ensures the claim can be verified in isolation after the fact. This is also in line with Notary's policy.

Additionally, leaf certificates may not have the CA bit set in their basic constraints anymore.

Test coverage for certificate validation has been moved to its own file and broadly extended to cover many more cases.

This was split off of PR #97 