### PR TITLE
Remove t_cose work-arounds for Notary style claims

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/ccf/app/dev:3.0.2-virtual
+FROM mcr.microsoft.com/ccf/app/dev:3.0.6-virtual

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,10 +15,10 @@ on:
 jobs:
   analyze:
     name: Analyze
-    
+
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/ccf/app/dev:3.0.2-virtual
-    
+    container: mcr.microsoft.com/ccf/app/dev:3.0.6-virtual
+
     permissions:
       actions: read
       contents: read
@@ -47,7 +47,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
-        
+
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 parameters:
   - name: CCF_VERSION
     type: string
-    default: 3.0.2
+    default: 3.0.6
 
 resources:
   containers:
@@ -22,7 +22,7 @@ resources:
 
 variables:
   # This is used in functional tests to make certain tests mandatory
-  # in CI, but optional during local development. 
+  # in CI, but optional during local development.
   SCITT_CI: 1
 
   ACR_REGISTRY: scittoss.azurecr.io
@@ -109,7 +109,7 @@ stages:
 
           - script: ./scripts/ci-checks.sh
             displayName: "CI checks"
-            
+
       - job: scanbuild
         displayName: Static Analysis
         container: virtual
@@ -123,7 +123,7 @@ stages:
 
           - script: ./scripts/scan-build.sh
             displayName: "Scan build"
-  
+
   - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
     - stage: release
       jobs:
@@ -141,7 +141,7 @@ stages:
           - script: |
               echo "##vso[task.setvariable variable=git_tag]${BUILD_SOURCEBRANCH#refs/tags/}"
             displayName: Get image tag from git tag
-          
+
           - script: |
               docker load --input $(Pipeline.Workspace)/scitt-ccf-ledger-sgx.tar
               docker tag scitt-ccf-ledger-sgx $(ACR_REGISTRY)/public/scitt-ccf-ledger/app/run:$(git_tag)-sgx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Dependencies
+- [ISSUE-100](https://github.com/microsoft/scitt-ccf-ledger/issues/100): Update CCF from [3.0.2 to 3.0.6](https://github.com/microsoft/CCF/compare/ccf-3.0.2...ccf-3.0.6) which means a `t_cose` upgrade from [v1.1 to v1.1.1](https://github.com/laurencelundblade/t_cose/compare/v1.1...v1.1.1).
+
 ## [0.2.1]
 ### Changed
 - Include all past service identities in the DID endpoint (#85).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- [ISSUE-101](https://github.com/microsoft/scitt-ccf-ledger/issues/101): Replaced workaround code with `t_cose` for signature verification of Notary style claims.
+
 ### Dependencies
 - [ISSUE-100](https://github.com/microsoft/scitt-ccf-ledger/issues/100): Update CCF from [3.0.2 to 3.0.6](https://github.com/microsoft/CCF/compare/ccf-3.0.2...ccf-3.0.6) which means a `t_cose` upgrade from [v1.1 to v1.1.1](https://github.com/laurencelundblade/t_cose/compare/v1.1...v1.1.1).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-# Development guidelines 
+# Development guidelines
 
 The following explains how to build, run, and test scitt-ccf-ledger outside of Docker.
 
@@ -10,13 +10,13 @@ This means TEE hardware, here SGX, is required to run and test scitt-ccf-ledger 
 However, scitt-ccf-ledger also supports running in *virtual* mode which does not require TEE hardware
 and is generally sufficient for local development.
 
-For *virtual* mode development only, instead of following the steps below, you can also use GitHub Codespaces and then continue with the "Building" section: 
+For *virtual* mode development only, instead of following the steps below, you can also use GitHub Codespaces and then continue with the "Building" section:
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=562968818&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestEurope)
 
 Follow the steps below to setup your development environment, replacing `<sgx|virtual>` with either one, as desired:
 
-1. Set up machine: 
+1. Set up machine:
     - If using SGX, it is recommended that you provision a virtual machine:
       - On Azure, provision a DC-series VM, for example, [DCsv2](https://learn.microsoft.com/en-us/azure/virtual-machines/dcv2-series)
       - Enable running SGX enclaves: `sudo usermod -a -G sgx_prv $(whoami)`
@@ -24,10 +24,10 @@ Follow the steps below to setup your development environment, replacing `<sgx|vi
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-3.0.2.tar.gz
-    tar xvzf ccf-3.0.2.tar.gz
-    cd CCF-ccf-3.0.2/getting_started/setup_vm/
-    ./run.sh app-dev.yml -e ccf_ver=3.0.2 -e platform=<sgx|virtual>
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-3.0.6.tar.gz
+    tar xvzf ccf-3.0.6.tar.gz
+    cd CCF-ccf-3.0.6/getting_started/setup_vm/
+    ./run.sh app-dev.yml -e ccf_ver=3.0.6 -e platform=<sgx|virtual>
     ```
 
 ## Building

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -438,139 +438,6 @@ namespace scitt::cose
     {}
   };
 
-  // Temporarily needed for notary_verify().
-  bool is_ecdsa_alg(int64_t cose_alg)
-  {
-    return cose_alg == T_COSE_ALGORITHM_ES256 ||
-      cose_alg == T_COSE_ALGORITHM_ES384 || cose_alg == T_COSE_ALGORITHM_ES512;
-  }
-
-  // Temporarily needed for notary_verify().
-  bool is_rsa_pss_alg(int64_t cose_alg)
-  {
-    return cose_alg == T_COSE_ALGORITHM_PS256 ||
-      cose_alg == T_COSE_ALGORITHM_PS384 || cose_alg == T_COSE_ALGORITHM_PS512;
-  }
-
-  // Temporarily needed for notary_verify().
-  crypto::MDType get_md_type(int64_t cose_alg)
-  {
-    switch (cose_alg)
-    {
-      case T_COSE_ALGORITHM_ES256:
-      case T_COSE_ALGORITHM_PS256:
-        return crypto::MDType::SHA256;
-      case T_COSE_ALGORITHM_ES384:
-      case T_COSE_ALGORITHM_PS384:
-        return crypto::MDType::SHA384;
-      case T_COSE_ALGORITHM_ES512:
-      case T_COSE_ALGORITHM_PS512:
-        return crypto::MDType::SHA512;
-      case T_COSE_ALGORITHM_EDDSA:
-        return crypto::MDType::NONE;
-      default:
-        throw std::runtime_error("Unsupported COSE algorithm");
-    }
-  }
-
-  // Temporarily needed for notary_verify().
-  const EVP_MD* get_openssl_md_type(crypto::MDType type)
-  {
-    switch (type)
-    {
-      case crypto::MDType::NONE:
-        return nullptr;
-      case crypto::MDType::SHA1:
-        return EVP_sha1();
-      case crypto::MDType::SHA256:
-        return EVP_sha256();
-      case crypto::MDType::SHA384:
-        return EVP_sha384();
-      case crypto::MDType::SHA512:
-        return EVP_sha512();
-      default:
-        throw std::runtime_error("Unsupported hash algorithm");
-    }
-    return nullptr;
-  }
-
-  // Temporarily needed for notary_verify().
-  std::vector<uint8_t> create_sign1_tbs(
-    std::span<const uint8_t> protected_header, std::span<const uint8_t> payload)
-  {
-    // Note: This function does not return the hash of the TBS because
-    // EdDSA does not support pre-hashed messages as input.
-
-    // Sig_structure = [
-    //     context: "Signature1",
-    //     body_protected: empty_or_serialized_map,
-    //     external_aad: bstr,
-    //     payload: bstr
-    // ]
-
-    cbor::encoder ctx(protected_header.size() + payload.size() + 1024);
-    QCBOREncode_OpenArray(ctx);
-
-    // context
-    QCBOREncode_AddSZString(ctx, "Signature1");
-
-    // body_protected: The protected header of the message.
-    QCBOREncode_AddBytes(ctx, cbor::from_bytes(protected_header));
-
-    // external_aad: always empty.
-    QCBOREncode_AddBytes(ctx, NULLUsefulBufC);
-
-    // payload: The payload of the message.
-    QCBOREncode_AddBytes(ctx, cbor::from_bytes(payload));
-
-    QCBOREncode_CloseArray(ctx);
-
-    return ctx.finish();
-  }
-
-  // Temporarily needed for notary_verify().
-  std::vector<uint8_t> ecdsa_sig_from_r_s(
-    const uint8_t* r,
-    size_t r_size,
-    const uint8_t* s,
-    size_t s_size,
-    bool big_endian = true)
-  {
-    OpenSSL::Unique_BIGNUM r_bn;
-    OpenSSL::Unique_BIGNUM s_bn;
-    if (big_endian)
-    {
-      OpenSSL::CHECKNULL(BN_bin2bn(r, r_size, r_bn));
-      OpenSSL::CHECKNULL(BN_bin2bn(s, s_size, s_bn));
-    }
-    else
-    {
-      OpenSSL::CHECKNULL(BN_lebin2bn(r, r_size, r_bn));
-      OpenSSL::CHECKNULL(BN_lebin2bn(s, s_size, s_bn));
-    }
-    OpenSSL::Unique_ECDSA_SIG sig;
-    OpenSSL::CHECK1(ECDSA_SIG_set0(sig, r_bn, s_bn));
-    // Ignore previous pointers, as they're now managed by ECDSA_SIG_set0
-    // https://www.openssl.org/docs/man1.1.1/man3/ECDSA_SIG_get0.html
-    (void)r_bn.release();
-    (void)s_bn.release();
-    auto der_size = i2d_ECDSA_SIG(sig, nullptr);
-    OpenSSL::CHECK0(der_size);
-    std::vector<uint8_t> der_sig(der_size);
-    auto der_sig_buf = der_sig.data();
-    OpenSSL::CHECK0(i2d_ECDSA_SIG(sig, &der_sig_buf));
-    return der_sig;
-  }
-
-  // Temporarily needed for notary_verify().
-  std::vector<uint8_t> ecdsa_sig_p1363_to_der(
-    std::span<const uint8_t> signature)
-  {
-    auto half_size = signature.size() / 2;
-    return ecdsa_sig_from_r_s(
-      signature.data(), half_size, signature.data() + half_size, half_size);
-  }
-
   /**
    * Extract the bstr fields from a COSE Sign1.
    *
@@ -613,66 +480,6 @@ namespace scitt::cose
     return {phdrs, payload, signature};
   }
 
-  // Temporarily needed for notary_verify().
-  /**
-   * Verify the signature of a Notary COSE Sign1 message using the given public
-   * key.
-   *
-   * Beyond the basic verification of key usage and the signature
-   * itself, no particular validation of the message is done.
-   *
-   * This function is a temporary workaround until t_cose supports custom header
-   * parameters in the crit parameter list.
-   */
-  void notary_verify(
-    const std::vector<uint8_t>& cose_sign1,
-    const ProtectedHeader& phdr,
-    const PublicKey& key)
-  {
-    auto header_alg = phdr.alg.value();
-    auto key_alg = key.get_cose_alg();
-    if (key_alg.has_value() && header_alg != key_alg.value())
-    {
-      throw COSESignatureValidationError(
-        "Algorithm mismatch between protected header and public key");
-    }
-
-    auto [protected_header, payload, signature] =
-      extract_sign1_fields(cose_sign1);
-
-    auto md_type = get_md_type(header_alg);
-    auto ossl_md_type = get_openssl_md_type(md_type);
-    auto tbs = create_sign1_tbs(protected_header, payload);
-
-    std::vector<uint8_t> signature_tmp;
-    if (is_ecdsa_alg(header_alg))
-    {
-      signature_tmp = ecdsa_sig_p1363_to_der(signature);
-      signature = signature_tmp;
-    }
-
-    OpenSSL::Unique_EVP_MD_CTX md_ctx;
-    EVP_MD_CTX_init(md_ctx);
-    EVP_PKEY_CTX* pctx;
-    OpenSSL::CHECK1(EVP_DigestVerifyInit(
-      md_ctx, &pctx, ossl_md_type, nullptr, key.get_evp_pkey()));
-    if (is_rsa_pss_alg(header_alg))
-    {
-      OpenSSL::CHECK1(
-        EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PSS_PADDING));
-    }
-
-    auto valid =
-      EVP_DigestVerify(
-        md_ctx, signature.data(), signature.size(), tbs.data(), tbs.size()) ==
-      1;
-
-    if (!valid)
-    {
-      throw COSESignatureValidationError("Signature verification failed");
-    }
-  }
-
   /**
    * Verify the signature of a COSE Sign1 message using the given public key.
    *
@@ -691,7 +498,7 @@ namespace scitt::cose
     // auxiliary buffer size.
     t_cose_parameters params;
     t_cose_sign1_verify_init(
-      &verify_ctx, T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY);
+      &verify_ctx, T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY | T_COSE_OPT_UNKNOWN_CRIT_ALLOWED);
     t_cose_err_t error =
       t_cose_sign1_verify(&verify_ctx, signed_cose, nullptr, &params);
     if (error)
@@ -714,7 +521,7 @@ namespace scitt::cose
     EVP_PKEY* evp_key = key.get_evp_pkey();
     cose_key.k.key_ptr = evp_key;
 
-    t_cose_sign1_verify_init(&verify_ctx, T_COSE_OPT_TAG_REQUIRED);
+    t_cose_sign1_verify_init(&verify_ctx, T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_UNKNOWN_CRIT_ALLOWED);
     t_cose_sign1_set_verification_key(&verify_ctx, cose_key);
 
     // EdDSA signature verification needs an auxiliary buffer.

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -498,7 +498,9 @@ namespace scitt::cose
     // auxiliary buffer size.
     t_cose_parameters params;
     t_cose_sign1_verify_init(
-      &verify_ctx, T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY | T_COSE_OPT_UNKNOWN_CRIT_ALLOWED);
+      &verify_ctx,
+      T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY |
+        T_COSE_OPT_UNKNOWN_CRIT_ALLOWED);
     t_cose_err_t error =
       t_cose_sign1_verify(&verify_ctx, signed_cose, nullptr, &params);
     if (error)
@@ -521,7 +523,8 @@ namespace scitt::cose
     EVP_PKEY* evp_key = key.get_evp_pkey();
     cose_key.k.key_ptr = evp_key;
 
-    t_cose_sign1_verify_init(&verify_ctx, T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_UNKNOWN_CRIT_ALLOWED);
+    t_cose_sign1_verify_init(
+      &verify_ctx, T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_UNKNOWN_CRIT_ALLOWED);
     t_cose_sign1_set_verification_key(&verify_ctx, cose_key);
 
     // EdDSA signature verification needs an auxiliary buffer.

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -323,9 +323,7 @@ namespace scitt::verifier
           // Verify signature.
           try
           {
-            // TODO: replace with cose::verify() once the t_cose workarounds are
-            // removed.
-            cose::notary_verify(data, phdr, key);
+            cose::verify(data, key);
           }
           catch (const cose::COSESignatureValidationError& e)
           {

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=3.0.2
+ARG CCF_VERSION=3.0.6
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-sgx as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=3.0.2
+ARG CCF_VERSION=3.0.6
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-virtual as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,7 +13,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==3.0.2",
+        "ccf==3.0.6",
         "cryptography==38.*",  # needs to match ccf
         "httpx",
         "cbor2",


### PR DESCRIPTION
- [ISSUE-100](https://github.com/microsoft/scitt-ccf-ledger/issues/100): Update CCF from [3.0.2 to 3.0.6](https://github.com/microsoft/CCF/compare/ccf-3.0.2...ccf-3.0.6) which means a `t_cose` upgrade from [v1.1 to v1.1.1](https://github.com/laurencelundblade/t_cose/compare/v1.1...v1.1.1).
- [ISSUE-101](https://github.com/microsoft/scitt-ccf-ledger/issues/101): Replaced workaround code with `t_cose` for signature verification of Notary style claims.

Note: for testing, now that SCITT doesn't accept self-signed leaf certificates (which is what notation generates for testing), it's much easier to make use of X5ChainCertificateAuthority.create_chain() in test/infra/x5chain_certificate_authority.py to generate a cert chain with the correct extensions and flags, than to try to get the openssl incantation right. 