### PR TITLE
Fix a use after free bug in LRU.

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -135,6 +135,7 @@ if (BUILD_TESTS)
     unit-tests/configurable_auth_test.cpp
     unit-tests/did/resolver_test.cpp
     unit-tests/did/web/syntax_test.cpp
+    unit-tests/historical/lru_test.cpp
     unit-tests/prefix_tree/bitvector_test.cpp
     unit-tests/prefix_tree/prefix_tree_test.cpp
     unit-tests/prefix_tree/batched_prefix_tree_test.cpp

--- a/app/src/historical/lru.h
+++ b/app/src/historical/lru.h
@@ -44,11 +44,11 @@ private:
     {
       const auto& least_recent_entry = entries_list.back();
       iter_map.erase(least_recent_entry.first);
-      entries_list.pop_back();
       if (cull_callback_fn)
       {
         cull_callback_fn(least_recent_entry.first, least_recent_entry.second);
       }
+      entries_list.pop_back();
     }
   }
 
@@ -134,9 +134,9 @@ public:
     return entries_list.begin();
   }
 
-  V& operator[](K&& k)
+  V& operator[](const K& k)
   {
-    auto it = insert(std::forward<K>(k), V{});
+    auto it = insert(k, V{});
     return it->second;
   }
 

--- a/app/unit-tests/historical/lru_test.cpp
+++ b/app/unit-tests/historical/lru_test.cpp
@@ -1,0 +1,115 @@
+#include "historical/lru.h"
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <rapidcheck.h>
+#include <rapidcheck/gtest.h>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace std
+{
+  template <typename T>
+  void showValue(optional<T> value, ostream& os)
+  {
+    if (value.has_value())
+    {
+      os << "optional(" << rc::toString(*value) << ")";
+    }
+    else
+    {
+      os << "nullopt";
+    }
+  }
+}
+
+namespace
+{
+  /**
+   * Take a history of insertions into the cache, and compute what the current
+   * state of the cache should be, as well as whether a key was evicted during
+   * the last insertion.
+   */
+  template <typename K, typename V>
+  std::pair<std::map<K, V>, std::optional<std::pair<K, V>>> recent_keys(
+    size_t n, std::span<const std::pair<K, V>> history)
+  {
+    bool update = false;
+    std::map<K, V> result;
+
+    // Iterate over the history backwards, until we find N+1 unique keys.
+    // The last one we found is the entry that was evicted.
+    auto it = history.rbegin();
+    for (; it != history.rend(); it++)
+    {
+      // The last element to have been inserted already existed earlier in the
+      // history: this was an in-place update and did not cause any eviction.
+      if (it != history.rbegin() && it->first == history.rbegin()->first)
+      {
+        update = true;
+      }
+
+      if (result.size() == n && update)
+      {
+        return {result, std::nullopt};
+      }
+      else if (result.size() == n && !result.contains(it->first))
+      {
+        // This is the N+1th unique key, ie. the one that got evicted.
+        return {result, *it};
+      }
+      else
+      {
+        // This does not overwrite the entry if it is already present.
+        // This matches our expectation since entries later in the history (ie.
+        // earlier in iteration order) take precedence.
+        result.emplace(it->first, it->second);
+      }
+    }
+
+    // If we reach this point then there are not enough keys in the history to
+    // fill the cache. Nothing gets evicted.
+    return {result, std::nullopt};
+  }
+
+  RC_GTEST_PROP(
+    LRUTest,
+    lru_cache,
+    (size_t capacity, const std::vector<std::pair<int, int>>& insertions))
+  {
+    RC_PRE(capacity > 0);
+    LRU<int, int> cache(capacity);
+    std::optional<std::pair<int, int>> last_culled;
+
+    cache.set_cull_callback([&last_culled](int k, int v) {
+      last_culled = {{k, v}};
+    });
+
+    for (size_t i = 0; i < insertions.size(); i++)
+    {
+      last_culled.reset();
+      auto [k, v] = insertions.at(i);
+      cache[k] = v;
+
+      auto history = std::span(insertions).first(i + 1);
+      auto [expected_state, expected_victim] = recent_keys(capacity, history);
+
+      RC_LOG() << "i=" << i << " insert=" << rc::toString(std::make_pair(k, v))
+               << " expected_state=" << rc::toString(expected_state)
+               << " expected_evicted=" << rc::toString(expected_victim)
+               << " last_culled=" << rc::toString(last_culled) << std::endl;
+
+      RC_ASSERT(expected_victim == last_culled);
+      RC_ASSERT(expected_state.size() == cache.size());
+      for (const auto& [k, v] : expected_state)
+      {
+        // Thankfully, lookups in the cache have no side effect.
+        auto it = cache.find(k);
+        RC_ASSERT(it != cache.end());
+        RC_ASSERT(it->second == v);
+      }
+    }
+  }
+}

--- a/app/unit-tests/historical/lru_test.cpp
+++ b/app/unit-tests/historical/lru_test.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "historical/lru.h"
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
The LRU cache picks the last item from its queue, removes it from the list and invokes a custom callback. However, removing the entry from the list deallocates it, which leads to a use-after-free when invoking the callback. Instead it should first invoke the callback, and only then remove it from the list using `pop_back()`.

This was found in CI job running ASan. I think this just happened to be the first time an ASan build reached the threshold where the cache is full. It can easily be reproduced this on a local ASan build, by submitting hundreds of claims and fething receipts for all of them.

Added a new property-based test for the LRU cache to check for basic correctness of it, and which would have caught this bug.