### PR TITLE
Add a flag in cchost.py to run with GDB.

### DIFF
--- a/test/infra/async_utils.py
+++ b/test/infra/async_utils.py
@@ -201,3 +201,12 @@ class EventLoopThread(ABC):
 
             # Clear the flag, so it can be re-used by subclasses.
             self._ready = False
+
+    def join(self) -> None:
+        """
+        Wait for the event loop thread to exit.
+        """
+        self._thread.join()
+
+        if self._exception is not None:
+            raise self._exception


### PR DESCRIPTION
The cchost infra (and start.sh) can now be given a `--with-gdb` argument, which will start the cchost process in a debugger. This can be a handy way to get stack traces when debugging crashes or exceptions.

While pytest cannot start a cchost process inside of GDB, most tests can still be used while connecting to an external service (as used in our Docker CI). This allows pytest to be using together with `./start.sh --with-gdb`, if trying to run tests under a debugger.

For now, using GDB probably only works on virtual builds. It might require a bit more setup to function on SGX builds.