### PR TITLE
Add a `service_error` helper to the test infrastucture.

### DIFF
--- a/test/infra/assertions.py
+++ b/test/infra/assertions.py
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+
+from pyscitt.client import ServiceError
+
+
+def service_error(match: str):
+    return pytest.raises(ServiceError, match=match)

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -7,27 +7,10 @@ import pycose.headers
 import pytest
 
 from pyscitt import crypto, governance
-from pyscitt.client import Client, ServiceError
+from pyscitt.client import Client
 from pyscitt.verify import verify_receipt
 
 from .infra.did_web_server import DIDWebServer
-
-
-# Temporary monkey-patch for pycose until https://github.com/TimothyClaeys/pycose/pull/107
-# is released.
-def crit_is_array(value):
-    if (
-        not isinstance(value, list)
-        or len(value) < 1
-        or not all(isinstance(x, (int, str)) for x in value)
-    ):
-        raise ValueError(
-            "CRITICAL should be a list with at least one integer or string element"
-        )
-    return value
-
-
-pycose.headers.Critical.value_parser = crit_is_array
 
 
 @pytest.mark.parametrize(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -15,9 +15,9 @@ from pyscitt.cli.governance import (
     SCITT_CONSTITUTION_MARKER_START,
 )
 from pyscitt.cli.main import main
-from pyscitt.client import ServiceError
 from pyscitt.governance import ProposalNotAccepted
 
+from .infra.assertions import service_error
 from .infra.did_web_server import DIDWebServer
 
 
@@ -475,7 +475,7 @@ class TestUpdateScittConstitution:
         proposal.write_text(json.dumps({"actions": [{"name": "my_action"}]}))
 
         # The my_action action does not exist yet.
-        with pytest.raises(ServiceError, match="my_action: no such action"):
+        with service_error("my_action: no such action"):
             run(
                 "governance",
                 "propose_generic",
@@ -505,7 +505,7 @@ class TestUpdateScittConstitution:
         # After updating the constitution again, the my_action action will
         # fail to run, showing that we actually modified the SCITT constitution,
         # and didn't just append to it.
-        with pytest.raises(ServiceError, match="my_action: no such action"):
+        with service_error("my_action: no such action"):
             run(
                 "governance",
                 "propose_generic",

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -14,6 +14,7 @@ from pyscitt.client import Client, ServiceError
 from pyscitt.crypto import cert_pem_to_der
 from pyscitt.verify import verify_receipt
 
+from .infra.assertions import service_error
 from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 
 
@@ -161,10 +162,6 @@ class TestNonCanonicalEncoding:
         assert original_pieces[0] == updated_pieces[0]
         assert original_pieces[2] == updated_pieces[2]
         assert original_pieces[3] == updated_pieces[3]
-
-
-def service_error(match):
-    return pytest.raises(ServiceError, match=match)
 
 
 class TestHeaderParameters:

--- a/test/test_prefix_tree.py
+++ b/test/test_prefix_tree.py
@@ -5,7 +5,8 @@ import pytest
 from cryptography.exceptions import InvalidSignature
 
 from pyscitt import crypto
-from pyscitt.client import ServiceError
+
+from .infra.assertions import service_error
 
 
 @pytest.mark.needs_prefix_tree
@@ -20,7 +21,7 @@ def test_prefix_tree(did_web, client):
     pt = client.prefix_tree
 
     # Until we flush the prefix tree, the claim does not appear
-    with pytest.raises(ServiceError, match="UnknownFeed"):
+    with service_error("UnknownFeed: No claim found for given issuer and feed"):
         pt.get_read_receipt(identity.issuer, feed)
 
     pt.flush()
@@ -71,14 +72,14 @@ def test_prefix_tree(did_web, client):
         receipt.verify(first_claims, service_parameters)
 
 
-# This test only works on an isolated cchost instance, since we require the service to be blank.
+# This test only works on an isolated cchost instance, since we require the
+# service to be blank.
 @pytest.mark.isolated_test
-@pytest.mark.needs_cchost
 @pytest.mark.needs_prefix_tree
 def test_empty_prefix_tree(client):
     """Before any flush has been committed, fetching the prefix tree receipt returns a graceful error."""
 
-    with pytest.raises(ServiceError, match="NoPrefixTree"):
+    with service_error("NoPrefixTree: No prefix tree has been committed yet"):
         client.get_historical("/prefix_tree")
 
     client.prefix_tree.flush()

--- a/test/test_tracing.py
+++ b/test/test_tracing.py
@@ -5,7 +5,9 @@ import re
 
 import pytest
 
-from pyscitt.client import Client, ServiceError
+from pyscitt.client import Client
+
+from .infra.assertions import service_error
 
 REQUEST_ID_HEADER = "x-ms-request-id"
 CLIENT_REQUEST_ID_HEADER = "x-ms-client-request-id"
@@ -21,8 +23,9 @@ def test_tracing_headers(client: Client):
     assert response.headers[CLIENT_REQUEST_ID_HEADER] == "123"
     assert REQUEST_ID_REGEX.match(response.headers[REQUEST_ID_HEADER])
 
-    with pytest.raises(ServiceError, match="InvalidInput") as exc_info:
+    with service_error("InvalidInput: Invalid client request id") as exc_info:
         client.get("/version", headers={CLIENT_REQUEST_ID_HEADER: "123 456"})
+
     error = exc_info.value
     assert CLIENT_REQUEST_ID_HEADER not in error.headers
     assert REQUEST_ID_REGEX.match(error.headers[REQUEST_ID_HEADER])


### PR DESCRIPTION
It is very common for our integration tests to check for errors returned by the server, and this is generally accomplished by using pytest's `raises` context manager, eg:

    with pytest.raises(ServiceError, match="expected message"):
        client.do_something()

Because the expected message is often long, this regularly doesn't fit on a single line and needs to be broken up and looks messy and hard to read. By having a short hand for this we can avoid the line breaks most of the time.

The short-hand version already existed in test_encoding, but is now moved to a shared file and used consistently.