### PR TITLE
Aggregate did:web resolutions

### DIFF
--- a/app/fetch-did-web-doc.py
+++ b/app/fetch-did-web-doc.py
@@ -216,10 +216,10 @@ def process_requests(url, unattested):
             os.remove(request_path)
 
         except Exception as e:
-            logging.warn(
+            logging.error(
                 f"Error while processing first request in {queue_dir}", exc_info=e
             )
-            logging.warn(f"Removing queue {queue_dir} and aborting")
+            logging.info(f"Removing queue {queue_dir} and aborting")
             # Move the queue dir to a temporary location that will be deleted.
             os.rename(queue_dir, tmp_queue_dir)
             raise

--- a/app/fetch-did-web-doc.py
+++ b/app/fetch-did-web-doc.py
@@ -220,13 +220,11 @@ def process_requests(url, unattested):
                 f"Error while processing first request in {queue_dir}", exc_info=e
             )
             logging.info(f"Removing queue {queue_dir} and aborting")
-            # Move the queue dir to a temporary location that will be deleted.
-            os.rename(queue_dir, tmp_queue_dir)
             raise
-
-        # Move the queue folder to a temporary location that will be deleted and
-        # process any remaining requests that were added in the meantime.
-        os.rename(queue_dir, tmp_queue_dir)
+        finally:
+            # Move the queue folder to a temporary location that will be deleted and
+            # process any remaining requests that were added in the meantime.
+            os.rename(queue_dir, tmp_queue_dir)
 
         for fname in os.listdir(tmp_queue_dir):
             # Process remaining requests by relying on the resolution

--- a/app/src/call_types.h
+++ b/app/src/call_types.h
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "kv_types.h"
 #include "did/web/method.h"
+#include "kv_types.h"
 
 #include <ccf/ds/json.h>
 #include <nlohmann/json.hpp>
@@ -127,15 +127,19 @@ namespace scitt
   DECLARE_JSON_REQUIRED_FIELDS(GetAllOperations::Out, operations);
 
   template <typename T>
-  struct PostOperationCallback {
+  struct PostOperationCallback
+  {
     struct In
     {
       std::optional<T> result;
     };
   };
 
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(PostOperationCallback<did::web::ResolutionCallbackData>::In);
-  DECLARE_JSON_REQUIRED_FIELDS(PostOperationCallback<did::web::ResolutionCallbackData>::In);
-  DECLARE_JSON_OPTIONAL_FIELDS(PostOperationCallback<did::web::ResolutionCallbackData>::In, result);
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(
+    PostOperationCallback<did::web::ResolutionCallbackData>::In);
+  DECLARE_JSON_REQUIRED_FIELDS(
+    PostOperationCallback<did::web::ResolutionCallbackData>::In);
+  DECLARE_JSON_OPTIONAL_FIELDS(
+    PostOperationCallback<did::web::ResolutionCallbackData>::In, result);
 
 } // namespace scitt

--- a/app/src/call_types.h
+++ b/app/src/call_types.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "kv_types.h"
+#include "did/web/method.h"
 
 #include <ccf/ds/json.h>
 #include <nlohmann/json.hpp>
@@ -124,5 +125,17 @@ namespace scitt
   };
   DECLARE_JSON_TYPE(GetAllOperations::Out);
   DECLARE_JSON_REQUIRED_FIELDS(GetAllOperations::Out, operations);
+
+  template <typename T>
+  struct PostOperationCallback {
+    struct In
+    {
+      std::optional<T> result;
+    };
+  };
+
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(PostOperationCallback<did::web::ResolutionCallbackData>::In);
+  DECLARE_JSON_REQUIRED_FIELDS(PostOperationCallback<did::web::ResolutionCallbackData>::In);
+  DECLARE_JSON_OPTIONAL_FIELDS(PostOperationCallback<did::web::ResolutionCallbackData>::In, result);
 
 } // namespace scitt

--- a/app/src/did/attested.h
+++ b/app/src/did/attested.h
@@ -50,6 +50,8 @@ namespace scitt::did
     std::string evidence;
     std::string endorsements;
     std::string data;
+
+    bool operator==(const AttestedResolution& other) const = default;
   };
 
   DECLARE_JSON_TYPE(AttestedResolution);

--- a/app/src/did/unattested.h
+++ b/app/src/did/unattested.h
@@ -23,6 +23,8 @@ namespace scitt::did
     std::string url;
     std::string nonce;
     std::string body;
+
+    bool operator==(const UnattestedResolution& other) const = default;
   };
   DECLARE_JSON_TYPE(UnattestedResolution);
   DECLARE_JSON_REQUIRED_FIELDS(UnattestedResolution, url, nonce, body);

--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -131,8 +131,7 @@ namespace scitt::did::web
       const std::string& did,
       const std::string& nonce)
     {
-      // add nonce to query param for cache busting
-      auto url = get_did_web_doc_url_from_did(did) + "?" + nonce;
+      auto url = get_did_web_doc_url_from_did(did);
 
       auto host_processes = context.get_subsystem<ccf::AbstractHostProcesses>();
       host_processes->trigger_host_process_launch(

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -353,7 +353,7 @@ namespace scitt
                                        const nlohmann::json& callback_context,
                                        nlohmann::json&& params) {
         auto post_entry_context = callback_context.get<DIDFetchContext>();
-        auto resolution = params.get<did::web::ResolutionCallbackData>();
+        auto resolution = params.get<PostOperationCallback<did::web::ResolutionCallbackData>::In>();
 
         ::timespec host_time;
         auto result = get_untrusted_host_time_v1(host_time);
@@ -363,13 +363,16 @@ namespace scitt
             fmt::format("Failed to retrieve host time: {}", result));
         }
 
-        SCITT_INFO("Updating DID document for {}", post_entry_context.issuer);
-        did::web::DidWebResolver::update_did_document(
-          host_time,
-          ctx.tx,
-          resolution,
-          post_entry_context.issuer,
-          post_entry_context.nonce);
+        if (resolution.result.has_value())
+        {
+          SCITT_INFO("Updating DID document for {}", post_entry_context.issuer);
+          did::web::DidWebResolver::update_did_document(
+            host_time,
+            ctx.tx,
+            resolution.result.value(),
+            post_entry_context.issuer,
+            post_entry_context.nonce);
+        }
 
         // We intentionally don't catch AsyncResolutionNeeded this time around.
         // If resolution fails despite the updated DID document then the

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -353,7 +353,9 @@ namespace scitt
                                        const nlohmann::json& callback_context,
                                        nlohmann::json&& params) {
         auto post_entry_context = callback_context.get<DIDFetchContext>();
-        auto resolution = params.get<PostOperationCallback<did::web::ResolutionCallbackData>::In>();
+        auto resolution =
+          params
+            .get<PostOperationCallback<did::web::ResolutionCallbackData>::In>();
 
         ::timespec host_time;
         auto result = get_untrusted_host_time_v1(host_time);

--- a/test/test_resolution.py
+++ b/test/test_resolution.py
@@ -91,9 +91,7 @@ def test_concurrent_resolution(
         receipt1 = client.get_receipt(tx1, operation=True)
         receipt2 = client.get_receipt(tx2, operation=True)
 
-    # TODO: Aggregation of resolution is not yet implemented.
-    # Once it is, we should change this to `== 1`
-    assert metrics.request_count == 2
+    assert metrics.request_count == 1
     verify_receipt(claim1, trust_store, receipt1)
     verify_receipt(claim2, trust_store, receipt2)
 
@@ -284,9 +282,7 @@ class TestDIDMismatch:
             with service_error("DID document ID does not match expected value"):
                 client.wait_for_operation(tx2)
 
-        # TODO: Aggregation of resolution is not yet implemented.
-        # Once it is, we should change this to `== 1`
-        assert metrics.request_count == 2
+        assert metrics.request_count == 1
 
     def test_dont_cache_error(
         self,


### PR DESCRIPTION
This aggregates did:web resolutions (avoiding duplicate concurrent resolutions) in the fetch helper script by maintaining simple folder-based queues. In the future, this code will hopefully go away again but in the meantime it helps with the new operation-based API.