### PR TITLE
Update to CCF 3.0.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/ccf/app/dev:3.0.6-virtual
+FROM mcr.microsoft.com/ccf/app/dev:3.0.7-virtual

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     name: Analyze
     
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/ccf/app/dev:3.0.6-virtual
+    container: mcr.microsoft.com/ccf/app/dev:3.0.7-virtual
     
     permissions:
       actions: read

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 parameters:
   - name: CCF_VERSION
     type: string
-    default: 3.0.6
+    default: 3.0.7
 
 resources:
   containers:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,10 +24,10 @@ Follow the steps below to setup your development environment, replacing `<sgx|vi
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-3.0.6.tar.gz
-    tar xvzf ccf-3.0.6.tar.gz
-    cd CCF-ccf-3.0.6/getting_started/setup_vm/
-    ./run.sh app-dev.yml -e ccf_ver=3.0.6 -e platform=<sgx|virtual>
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-3.0.7.tar.gz
+    tar xvzf ccf-3.0.7.tar.gz
+    cd CCF-ccf-3.0.7/getting_started/setup_vm/
+    ./run.sh app-dev.yml -e ccf_ver=3.0.7 -e platform=<sgx|virtual>
     ```
 
 ## Building

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=3.0.6
+ARG CCF_VERSION=3.0.7
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-sgx as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=3.0.6
+ARG CCF_VERSION=3.0.7
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-virtual as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,8 +13,8 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==3.0.6",
-        "cryptography==38.*",  # needs to match ccf
+        "ccf==3.0.7",
+        "cryptography==39.*",  # needs to match ccf
         "httpx",
         "cbor2",
         # TODO: remove this once pycose >= 1.0.2 is released


### PR DESCRIPTION
The only notable change is the backport of https://github.com/microsoft/CCF/pull/4949, which will allow us to work on #87.