### PR TITLE
Remove verify work-arounds for Notary style claims

### DIFF
--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -202,12 +202,12 @@ namespace scitt::cose
     // parameter in the context of a profile.
     bool is_known(
       const std::variant<int64_t, std::string>& label,
-      std::set<std::variant<int64_t, std::string>> profile_paramters) const
+      std::set<std::variant<int64_t, std::string>> profile_parameters) const
     {
       if (
         BASIC_HEADER_PARAMS.contains(label) ||
         EXTRA_HEADER_PARAMS.contains(label) ||
-        profile_paramters.contains(label))
+        profile_parameters.contains(label))
       {
         return true;
       }

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -645,17 +645,12 @@ namespace scitt::cose
     t_cose_sign1_verify_ctx verify_ctx;
 
     // Do some preliminary decoding, to get the header parameters and potential
-    // auxiliary buffer size. T_COSE_OPT_UNKNOWN_CRIT_ALLOWED
+    // auxiliary buffer size.
     t_cose_parameters params;
-    uint32_t prelim_options;
+    uint32_t prelim_options = T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY;
     if (allow_unknown_crit)
     {
-      prelim_options = T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY |
-        T_COSE_OPT_UNKNOWN_CRIT_ALLOWED;
-    }
-    else
-    {
-      prelim_options = T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY;
+      prelim_options |= T_COSE_OPT_UNKNOWN_CRIT_ALLOWED;
     }
     t_cose_sign1_verify_init(&verify_ctx, prelim_options);
     t_cose_err_t error =
@@ -680,14 +675,10 @@ namespace scitt::cose
     EVP_PKEY* evp_key = key.get_evp_pkey();
     cose_key.k.key_ptr = evp_key;
 
-    uint32_t options;
+    uint32_t options = T_COSE_OPT_TAG_REQUIRED;
     if (allow_unknown_crit)
     {
-      options = T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_UNKNOWN_CRIT_ALLOWED;
-    }
-    else
-    {
-      options = T_COSE_OPT_TAG_REQUIRED;
+      options |= T_COSE_OPT_UNKNOWN_CRIT_ALLOWED;
     }
     t_cose_sign1_verify_init(&verify_ctx, options);
     t_cose_sign1_set_verification_key(&verify_ctx, cose_key);

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -21,6 +21,7 @@
 #include <optional>
 #include <qcbor/qcbor.h>
 #include <qcbor/qcbor_spiffy_decode.h>
+#include <set>
 #include <span>
 #include <string>
 #include <t_cose/t_cose_sign1_verify.h>
@@ -34,7 +35,7 @@ namespace scitt::cose
   static constexpr int64_t COSE_HEADER_PARAM_KID = 4;
   static constexpr int64_t COSE_HEADER_PARAM_X5CHAIN = 33;
 
-  std::vector<std::variant<int64_t, std::string>> BASIC_HEADER_PARAMS{
+  std::set<std::variant<int64_t, std::string>> BASIC_HEADER_PARAMS{
     COSE_HEADER_PARAM_ALG,
     COSE_HEADER_PARAM_CRIT,
     COSE_HEADER_PARAM_CTY,
@@ -47,7 +48,7 @@ namespace scitt::cose
   static constexpr int64_t COSE_HEADER_PARAM_FEED = 392;
   static constexpr int64_t COSE_HEADER_PARAM_SCITT_RECEIPTS = 394;
 
-  std::vector<std::variant<int64_t, std::string>> EXTRA_HEADER_PARAMS{
+  std::set<std::variant<int64_t, std::string>> EXTRA_HEADER_PARAMS{
     COSE_HEADER_PARAM_ISSUER,
     COSE_HEADER_PARAM_FEED,
     COSE_HEADER_PARAM_SCITT_RECEIPTS,
@@ -63,7 +64,7 @@ namespace scitt::cose
   static constexpr const char* NOTARY_HEADER_PARAM_EXPIRY =
     "io.cncf.notary.expiry";
 
-  std::vector<std::variant<int64_t, std::string>> NOTARY_HEADER_PARAMS{
+  std::set<std::variant<int64_t, std::string>> NOTARY_HEADER_PARAMS{
     NOTARY_HEADER_PARAM_SIGNING_SCHEME,
     NOTARY_HEADER_PARAM_SIGNING_TIME,
     NOTARY_HEADER_PARAM_AUTHENTIC_SIGNING_TIME,
@@ -199,32 +200,18 @@ namespace scitt::cose
 
     // Returns a bool representing whether the input label is a known
     // parameter in the context of a notary profile.
-    bool is_known_in_notary(
-      const std::variant<int64_t, std::string>& label) const
+    bool is_known(
+      const std::variant<int64_t, std::string>& label,
+      std::set<std::variant<int64_t, std::string>> profile_paramters) const
     {
-      // List of known header parameters in a notary profile
-      auto notary_known_params(BASIC_HEADER_PARAMS);
-      notary_known_params.insert(
-        notary_known_params.end(),
-        EXTRA_HEADER_PARAMS.begin(),
-        EXTRA_HEADER_PARAMS.end());
-      notary_known_params.insert(
-        notary_known_params.end(),
-        NOTARY_HEADER_PARAMS.begin(),
-        NOTARY_HEADER_PARAMS.end());
-
       if (
-        std::find(
-          std::begin(notary_known_params),
-          std::end(notary_known_params),
-          label) == std::end(notary_known_params))
-      {
-        return false;
-      }
-      else
+        BASIC_HEADER_PARAMS.contains(label) ||
+        EXTRA_HEADER_PARAMS.contains(label) ||
+        profile_paramters.contains(label))
       {
         return true;
       }
+      return false;
     }
   };
 

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -34,10 +34,24 @@ namespace scitt::cose
   static constexpr int64_t COSE_HEADER_PARAM_KID = 4;
   static constexpr int64_t COSE_HEADER_PARAM_X5CHAIN = 33;
 
+  std::vector<std::variant<int64_t, std::string>> BASIC_HEADER_PARAMS{
+    COSE_HEADER_PARAM_ALG,
+    COSE_HEADER_PARAM_CRIT,
+    COSE_HEADER_PARAM_CTY,
+    COSE_HEADER_PARAM_KID,
+    COSE_HEADER_PARAM_X5CHAIN,
+  };
+
   // Temporary assignments from draft-birkholz-scitt-architecture
   static constexpr int64_t COSE_HEADER_PARAM_ISSUER = 391;
   static constexpr int64_t COSE_HEADER_PARAM_FEED = 392;
   static constexpr int64_t COSE_HEADER_PARAM_SCITT_RECEIPTS = 394;
+
+  std::vector<std::variant<int64_t, std::string>> EXTRA_HEADER_PARAMS{
+    COSE_HEADER_PARAM_ISSUER,
+    COSE_HEADER_PARAM_FEED,
+    COSE_HEADER_PARAM_SCITT_RECEIPTS,
+  };
 
   // Notary header parameters.
   static constexpr const char* NOTARY_HEADER_PARAM_SIGNING_SCHEME =
@@ -48,6 +62,12 @@ namespace scitt::cose
     "io.cncf.notary.authenticSigningTime";
   static constexpr const char* NOTARY_HEADER_PARAM_EXPIRY =
     "io.cncf.notary.expiry";
+
+  std::vector<std::variant<int64_t, std::string>> NOTARY_HEADER_PARAMS{
+    NOTARY_HEADER_PARAM_SIGNING_SCHEME,
+    NOTARY_HEADER_PARAM_SIGNING_TIME,
+    NOTARY_HEADER_PARAM_AUTHENTIC_SIGNING_TIME,
+    NOTARY_HEADER_PARAM_EXPIRY};
 
   struct COSEDecodeError : public std::runtime_error
   {
@@ -76,6 +96,91 @@ namespace scitt::cose
     std::optional<int64_t> notary_authentic_signing_time;
     std::optional<int64_t> notary_expiry;
 
+    bool is_present(const std::variant<int64_t, std::string>& label) const
+    {
+      // Helper function checking if a known label has a value in the protected
+      // header.
+      // Intended for checking if critical parameters are present in the
+      // protected header. Hence this should only be called once it is
+      // established that the label is known.
+      if (
+        label == std::variant<int64_t, std::string>(COSE_HEADER_PARAM_ALG) and
+        alg.has_value())
+      {
+        return true;
+      }
+      if (
+        label == std::variant<int64_t, std::string>(COSE_HEADER_PARAM_CRIT) and
+        crit.has_value())
+      {
+        return true;
+      }
+      if (
+        label == std::variant<int64_t, std::string>(COSE_HEADER_PARAM_CTY) and
+        cty.has_value())
+      {
+        return true;
+      }
+      if (
+        label == std::variant<int64_t, std::string>(COSE_HEADER_PARAM_KID) and
+        kid.has_value())
+      {
+        return true;
+      }
+      if (
+        label ==
+          std::variant<int64_t, std::string>(COSE_HEADER_PARAM_X5CHAIN) and
+        x5chain.has_value())
+      {
+        return true;
+      }
+      if (
+        label ==
+          std::variant<int64_t, std::string>(COSE_HEADER_PARAM_ISSUER) and
+        issuer.has_value())
+      {
+        return true;
+      }
+      if (
+        label == std::variant<int64_t, std::string>(COSE_HEADER_PARAM_FEED) and
+        feed.has_value())
+      {
+        return true;
+      }
+      if (
+        label ==
+          std::variant<int64_t, std::string>(
+            NOTARY_HEADER_PARAM_SIGNING_SCHEME) and
+        notary_signing_scheme.has_value())
+      {
+        return true;
+      }
+      if (
+        label ==
+          std::variant<int64_t, std::string>(
+            NOTARY_HEADER_PARAM_SIGNING_TIME) and
+        notary_signing_time.has_value())
+      {
+        return true;
+      }
+      if (
+        label ==
+          std::variant<int64_t, std::string>(
+            NOTARY_HEADER_PARAM_AUTHENTIC_SIGNING_TIME) and
+        notary_authentic_signing_time.has_value())
+      {
+        return true;
+      }
+      if (
+        label ==
+          std::variant<int64_t, std::string>(NOTARY_HEADER_PARAM_EXPIRY) and
+        notary_expiry.has_value())
+      {
+        return true;
+      }
+      return false;
+    }
+
     bool is_critical(const std::variant<int64_t, std::string>& label) const
     {
       if (!crit.has_value())
@@ -90,6 +195,36 @@ namespace scitt::cose
         }
       }
       return false;
+    }
+
+    // Returns a bool representing whether the input label is a known
+    // parameter in the context of a notary profile.
+    bool is_known_in_notary(
+      const std::variant<int64_t, std::string>& label) const
+    {
+      // List of known header parameters in a notary profile
+      auto notary_known_params(BASIC_HEADER_PARAMS);
+      notary_known_params.insert(
+        notary_known_params.end(),
+        EXTRA_HEADER_PARAMS.begin(),
+        EXTRA_HEADER_PARAMS.end());
+      notary_known_params.insert(
+        notary_known_params.end(),
+        NOTARY_HEADER_PARAMS.begin(),
+        NOTARY_HEADER_PARAMS.end());
+
+      if (
+        std::find(
+          std::begin(notary_known_params),
+          std::end(notary_known_params),
+          label) == std::end(notary_known_params))
+      {
+        return false;
+      }
+      else
+      {
+        return true;
+      }
     }
   };
 
@@ -450,139 +585,6 @@ namespace scitt::cose
     {}
   };
 
-  // Temporarily needed for notary_verify().
-  bool is_ecdsa_alg(int64_t cose_alg)
-  {
-    return cose_alg == T_COSE_ALGORITHM_ES256 ||
-      cose_alg == T_COSE_ALGORITHM_ES384 || cose_alg == T_COSE_ALGORITHM_ES512;
-  }
-
-  // Temporarily needed for notary_verify().
-  bool is_rsa_pss_alg(int64_t cose_alg)
-  {
-    return cose_alg == T_COSE_ALGORITHM_PS256 ||
-      cose_alg == T_COSE_ALGORITHM_PS384 || cose_alg == T_COSE_ALGORITHM_PS512;
-  }
-
-  // Temporarily needed for notary_verify().
-  crypto::MDType get_md_type(int64_t cose_alg)
-  {
-    switch (cose_alg)
-    {
-      case T_COSE_ALGORITHM_ES256:
-      case T_COSE_ALGORITHM_PS256:
-        return crypto::MDType::SHA256;
-      case T_COSE_ALGORITHM_ES384:
-      case T_COSE_ALGORITHM_PS384:
-        return crypto::MDType::SHA384;
-      case T_COSE_ALGORITHM_ES512:
-      case T_COSE_ALGORITHM_PS512:
-        return crypto::MDType::SHA512;
-      case T_COSE_ALGORITHM_EDDSA:
-        return crypto::MDType::NONE;
-      default:
-        throw std::runtime_error("Unsupported COSE algorithm");
-    }
-  }
-
-  // Temporarily needed for notary_verify().
-  const EVP_MD* get_openssl_md_type(crypto::MDType type)
-  {
-    switch (type)
-    {
-      case crypto::MDType::NONE:
-        return nullptr;
-      case crypto::MDType::SHA1:
-        return EVP_sha1();
-      case crypto::MDType::SHA256:
-        return EVP_sha256();
-      case crypto::MDType::SHA384:
-        return EVP_sha384();
-      case crypto::MDType::SHA512:
-        return EVP_sha512();
-      default:
-        throw std::runtime_error("Unsupported hash algorithm");
-    }
-    return nullptr;
-  }
-
-  // Temporarily needed for notary_verify().
-  std::vector<uint8_t> create_sign1_tbs(
-    std::span<const uint8_t> protected_header, std::span<const uint8_t> payload)
-  {
-    // Note: This function does not return the hash of the TBS because
-    // EdDSA does not support pre-hashed messages as input.
-
-    // Sig_structure = [
-    //     context: "Signature1",
-    //     body_protected: empty_or_serialized_map,
-    //     external_aad: bstr,
-    //     payload: bstr
-    // ]
-
-    cbor::encoder ctx(protected_header.size() + payload.size() + 1024);
-    QCBOREncode_OpenArray(ctx);
-
-    // context
-    QCBOREncode_AddSZString(ctx, "Signature1");
-
-    // body_protected: The protected header of the message.
-    QCBOREncode_AddBytes(ctx, cbor::from_bytes(protected_header));
-
-    // external_aad: always empty.
-    QCBOREncode_AddBytes(ctx, NULLUsefulBufC);
-
-    // payload: The payload of the message.
-    QCBOREncode_AddBytes(ctx, cbor::from_bytes(payload));
-
-    QCBOREncode_CloseArray(ctx);
-
-    return ctx.finish();
-  }
-
-  // Temporarily needed for notary_verify().
-  std::vector<uint8_t> ecdsa_sig_from_r_s(
-    const uint8_t* r,
-    size_t r_size,
-    const uint8_t* s,
-    size_t s_size,
-    bool big_endian = true)
-  {
-    OpenSSL::Unique_BIGNUM r_bn;
-    OpenSSL::Unique_BIGNUM s_bn;
-    if (big_endian)
-    {
-      OpenSSL::CHECKNULL(BN_bin2bn(r, r_size, r_bn));
-      OpenSSL::CHECKNULL(BN_bin2bn(s, s_size, s_bn));
-    }
-    else
-    {
-      OpenSSL::CHECKNULL(BN_lebin2bn(r, r_size, r_bn));
-      OpenSSL::CHECKNULL(BN_lebin2bn(s, s_size, s_bn));
-    }
-    OpenSSL::Unique_ECDSA_SIG sig;
-    OpenSSL::CHECK1(ECDSA_SIG_set0(sig, r_bn, s_bn));
-    // Ignore previous pointers, as they're now managed by ECDSA_SIG_set0
-    // https://www.openssl.org/docs/man1.1.1/man3/ECDSA_SIG_get0.html
-    (void)r_bn.release();
-    (void)s_bn.release();
-    auto der_size = i2d_ECDSA_SIG(sig, nullptr);
-    OpenSSL::CHECK0(der_size);
-    std::vector<uint8_t> der_sig(der_size);
-    auto der_sig_buf = der_sig.data();
-    OpenSSL::CHECK0(i2d_ECDSA_SIG(sig, &der_sig_buf));
-    return der_sig;
-  }
-
-  // Temporarily needed for notary_verify().
-  std::vector<uint8_t> ecdsa_sig_p1363_to_der(
-    std::span<const uint8_t> signature)
-  {
-    auto half_size = signature.size() / 2;
-    return ecdsa_sig_from_r_s(
-      signature.data(), half_size, signature.data() + half_size, half_size);
-  }
-
   /**
    * Extract the bstr fields from a COSE Sign1.
    *
@@ -625,73 +627,16 @@ namespace scitt::cose
     return {phdrs, payload, signature};
   }
 
-  // Temporarily needed for notary_verify().
-  /**
-   * Verify the signature of a Notary COSE Sign1 message using the given public
-   * key.
-   *
-   * Beyond the basic verification of key usage and the signature
-   * itself, no particular validation of the message is done.
-   *
-   * This function is a temporary workaround until t_cose supports custom header
-   * parameters in the crit parameter list.
-   */
-  void notary_verify(
-    const std::vector<uint8_t>& cose_sign1,
-    const ProtectedHeader& phdr,
-    const PublicKey& key)
-  {
-    auto header_alg = phdr.alg.value();
-    auto key_alg = key.get_cose_alg();
-    if (key_alg.has_value() && header_alg != key_alg.value())
-    {
-      throw COSESignatureValidationError(
-        "Algorithm mismatch between protected header and public key");
-    }
-
-    auto [protected_header, payload, signature] =
-      extract_sign1_fields(cose_sign1);
-
-    auto md_type = get_md_type(header_alg);
-    auto ossl_md_type = get_openssl_md_type(md_type);
-    auto tbs = create_sign1_tbs(protected_header, payload);
-
-    std::vector<uint8_t> signature_tmp;
-    if (is_ecdsa_alg(header_alg))
-    {
-      signature_tmp = ecdsa_sig_p1363_to_der(signature);
-      signature = signature_tmp;
-    }
-
-    OpenSSL::Unique_EVP_MD_CTX md_ctx;
-    EVP_MD_CTX_init(md_ctx);
-    EVP_PKEY_CTX* pctx;
-    OpenSSL::CHECK1(EVP_DigestVerifyInit(
-      md_ctx, &pctx, ossl_md_type, nullptr, key.get_evp_pkey()));
-    if (is_rsa_pss_alg(header_alg))
-    {
-      OpenSSL::CHECK1(
-        EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PSS_PADDING));
-    }
-
-    auto valid =
-      EVP_DigestVerify(
-        md_ctx, signature.data(), signature.size(), tbs.data(), tbs.size()) ==
-      1;
-
-    if (!valid)
-    {
-      throw COSESignatureValidationError("Signature verification failed");
-    }
-  }
-
   /**
    * Verify the signature of a COSE Sign1 message using the given public key.
    *
    * Beyond the basic verification of key usage and the signature
    * itself, no particular validation of the message is done.
    */
-  void verify(const std::vector<uint8_t>& cose_sign1, const PublicKey& key)
+  void verify(
+    const std::vector<uint8_t>& cose_sign1,
+    const PublicKey& key,
+    bool allow_unknown_crit = false)
   {
     q_useful_buf_c signed_cose;
     signed_cose.ptr = cose_sign1.data();
@@ -700,10 +645,19 @@ namespace scitt::cose
     t_cose_sign1_verify_ctx verify_ctx;
 
     // Do some preliminary decoding, to get the header parameters and potential
-    // auxiliary buffer size.
+    // auxiliary buffer size. T_COSE_OPT_UNKNOWN_CRIT_ALLOWED
     t_cose_parameters params;
-    t_cose_sign1_verify_init(
-      &verify_ctx, T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY);
+    uint32_t prelim_options;
+    if (allow_unknown_crit)
+    {
+      prelim_options = T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY |
+        T_COSE_OPT_UNKNOWN_CRIT_ALLOWED;
+    }
+    else
+    {
+      prelim_options = T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_DECODE_ONLY;
+    }
+    t_cose_sign1_verify_init(&verify_ctx, prelim_options);
     t_cose_err_t error =
       t_cose_sign1_verify(&verify_ctx, signed_cose, nullptr, &params);
     if (error)
@@ -726,7 +680,16 @@ namespace scitt::cose
     EVP_PKEY* evp_key = key.get_evp_pkey();
     cose_key.k.key_ptr = evp_key;
 
-    t_cose_sign1_verify_init(&verify_ctx, T_COSE_OPT_TAG_REQUIRED);
+    uint32_t options;
+    if (allow_unknown_crit)
+    {
+      options = T_COSE_OPT_TAG_REQUIRED | T_COSE_OPT_UNKNOWN_CRIT_ALLOWED;
+    }
+    else
+    {
+      options = T_COSE_OPT_TAG_REQUIRED;
+    }
+    t_cose_sign1_verify_init(&verify_ctx, options);
     t_cose_sign1_set_verification_key(&verify_ctx, cose_key);
 
     // EdDSA signature verification needs an auxiliary buffer.

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -199,7 +199,7 @@ namespace scitt::cose
     }
 
     // Returns a bool representing whether the input label is a known
-    // parameter in the context of a notary profile.
+    // parameter in the context of a profile.
     bool is_known(
       const std::variant<int64_t, std::string>& label,
       std::set<std::variant<int64_t, std::string>> profile_paramters) const

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -186,10 +186,26 @@ namespace scitt::verifier
 
       // decode_protected_header checks crit is not empty
 
-      // TODO: For each param in crit check it is in known params and that it is
-      // in the protected header, else fail. Or wait until t_cose supports
-      // custom header parameters in crit and then we get this for free when we
-      // use t_cose for signature validation.
+      // TODO: Replace all of this critical param checking once t_cose properly
+      // supports custom header parameters in crit.
+      for (const auto& crit_param : crit)
+      {
+        if (!phdr.is_known_in_notary(crit_param))
+        {
+          SCITT_INFO("Unknown critical parameter: {}", crit_param);
+          throw cose::COSEDecodeError("Unknown parameter found in crit");
+        }
+        else
+        {
+          if (!phdr.is_present(crit_param))
+          {
+            SCITT_INFO(
+              "Critical param {} missing from protected header", crit_param);
+            throw cose::COSEDecodeError(
+              "Critial param missing from protected header");
+          }
+        }
+      }
 
       if (!phdr.is_critical("io.cncf.notary.signingScheme"))
       {
@@ -326,9 +342,7 @@ namespace scitt::verifier
           // Verify signature.
           try
           {
-            // TODO: replace with cose::verify() once the t_cose workarounds are
-            // removed.
-            cose::notary_verify(data, phdr, key);
+            cose::verify(data, key, true);
           }
           catch (const cose::COSESignatureValidationError& e)
           {

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -200,9 +200,9 @@ namespace scitt::verifier
           if (!phdr.is_present(crit_param))
           {
             SCITT_INFO(
-              "Critical param {} missing from protected header", crit_param);
+              "Critical parameter {} missing from protected header", crit_param);
             throw cose::COSEDecodeError(
-              "Critial param missing from protected header");
+              "Critial parameter missing from protected header");
           }
         }
       }

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -190,7 +190,7 @@ namespace scitt::verifier
       // supports custom header parameters in crit.
       for (const auto& crit_param : crit)
       {
-        if (!phdr.is_known_in_notary(crit_param))
+        if (!phdr.is_known(crit_param, cose::NOTARY_HEADER_PARAMS))
         {
           SCITT_INFO("Unknown critical parameter: {}", crit_param);
           throw cose::COSEDecodeError("Unknown parameter found in crit");
@@ -200,7 +200,8 @@ namespace scitt::verifier
           if (!phdr.is_present(crit_param))
           {
             SCITT_INFO(
-              "Critical parameter {} missing from protected header", crit_param);
+              "Critical parameter {} missing from protected header",
+              crit_param);
             throw cose::COSEDecodeError(
               "Critial parameter missing from protected header");
           }
@@ -342,7 +343,11 @@ namespace scitt::verifier
           // Verify signature.
           try
           {
-            cose::verify(data, key, true);
+            // Note it is okay to allow unknown critical params here because
+            // validation of critical parameters has already been done during
+            // validation of the protected header in
+            // `validate_notary_protected_header`
+            cose::verify(data, key, /* allow_unknown_crit */ true);
           }
           catch (const cose::COSESignatureValidationError& e)
           {


### PR DESCRIPTION
Supersedes PR: https://github.com/microsoft/scitt-ccf-ledger/pull/107 
Addresses issue: https://github.com/microsoft/scitt-ccf-ledger/issues/101

 Replaces workaround signature verification code with t_cose for Notary style claims.

To discuss: Adds checks (for the notary validation case) to ensure critical params are known and present in the protected header. 

