### PR TITLE
Don't store operation contexts in the KV.

### DIFF
--- a/app/src/call_types.h
+++ b/app/src/call_types.h
@@ -126,20 +126,17 @@ namespace scitt
   DECLARE_JSON_TYPE(GetAllOperations::Out);
   DECLARE_JSON_REQUIRED_FIELDS(GetAllOperations::Out, operations);
 
-  template <typename T>
   struct PostOperationCallback
   {
     struct In
     {
-      std::optional<T> result;
+      std::vector<uint8_t> context;
+      std::optional<nlohmann::json> result;
     };
   };
 
-  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(
-    PostOperationCallback<did::AttestedResolution>::In);
-  DECLARE_JSON_REQUIRED_FIELDS(
-    PostOperationCallback<did::AttestedResolution>::In);
-  DECLARE_JSON_OPTIONAL_FIELDS(
-    PostOperationCallback<did::AttestedResolution>::In, result);
+  DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(PostOperationCallback::In);
+  DECLARE_JSON_REQUIRED_FIELDS(PostOperationCallback::In, context);
+  DECLARE_JSON_OPTIONAL_FIELDS(PostOperationCallback::In, result);
 
 } // namespace scitt

--- a/app/src/did/web/method.h
+++ b/app/src/did/web/method.h
@@ -116,6 +116,7 @@ namespace scitt::did::web
     static void trigger_asynchronous_resolution(
       ccfapp::AbstractNodeContext& context,
       const std::string& callback_url,
+      const std::vector<uint8_t>& callback_context,
       const std::string& did,
       const std::string& nonce)
     {
@@ -123,7 +124,7 @@ namespace scitt::did::web
 
       auto host_processes = context.get_subsystem<ccf::AbstractHostProcesses>();
       host_processes->trigger_host_process_launch(
-        {DID_WEB_RESOLVER_SCRIPT, url, nonce, callback_url});
+        {DID_WEB_RESOLVER_SCRIPT, url, nonce, callback_url}, callback_context);
     }
 
     /**

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -6,6 +6,7 @@
 #include "odata_error.h"
 #include "signature_algorithms.h"
 
+#include <ccf/crypto/hash_provider.h>
 #include <ccf/ds/json.h>
 #include <ccf/kv/map.h>
 #include <ccf/kv/value.h>
@@ -82,13 +83,13 @@ namespace scitt
     std::optional<ccf::TxID> operation_id;
 
     std::optional<time_t> created_at;
-    std::optional<nlohmann::json> context;
+    std::optional<crypto::Sha256Hash> context_digest;
     std::optional<nlohmann::json> error;
   };
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(OperationLog);
   DECLARE_JSON_REQUIRED_FIELDS(OperationLog, status);
   DECLARE_JSON_OPTIONAL_FIELDS(
-    OperationLog, operation_id, created_at, context, error);
+    OperationLog, operation_id, created_at, context_digest, error);
 
   /**
    * SCITT Service configuration. This is stored in the KV and updated


### PR DESCRIPTION
When performing an asynchronous operation, we need to propagate some data from the trigger phase to the completion callback. So far we'd been storing that data in the operations table in the KV, but this pollutes the KV with unprocessed data and requires a historical query on completion.

This is now replaced by passing the context to the external process' standard input, and having it include it back in the callback's payload.

In order to ensure the integrity of the callback context, it is hashed and the digest is stored in the KV. We still use a historical query to fetch the context, but in the future this may be replaced by caching the digest in the indexing strategy, since it is small enough.

Fixes #116