### PR TITLE
Enhance devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,4 @@
 FROM mcr.microsoft.com/ccf/app/dev:3.0.9-virtual
+
+# Dependency of the virtual build of attested-fetch.
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,18 @@
 {
-  "name": "Development Container for CCF C++ Apps",
+  "name": "Development Container for scitt-ccf-ledger",
   "dockerFile": "Dockerfile",
-  "extensions": [
-    "ms-vscode.cpptools"
-  ],
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools"
+      ]
+    }
+  },
   "features": {
     "ghcr.io/devcontainers/features/docker-from-docker:1": {
       "version": "20.10.8"
     }
-  }
+  },
+  "onCreateCommand": "apt-get update && apt-get install -y libcurl4-openssl-dev"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,5 @@
     "ghcr.io/devcontainers/features/docker-from-docker:1": {
       "version": "20.10.8"
     }
-  },
-  "onCreateCommand": "apt-get update && apt-get install -y libcurl4-openssl-dev"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,12 @@
 {
   "name": "Development Container for scitt-ccf-ledger",
   "dockerFile": "Dockerfile",
+  "hostRequirements": {
+    "cpus": 4
+  },
+  "remoteEnv": {
+    "PLATFORM": "virtual"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "Development Container for scitt-ccf-ledger",
   "dockerFile": "Dockerfile",
-
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
- Install missing libcurl4-openssl-dev package
- Set minimum CPU count to let GitHub pick a reasonable default
- Set `PLATFORM=virtual` to avoid having to type it when invoking build/test scripts