### PR TITLE
Switch the operations callback to use an indexing strategy.

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -698,7 +698,7 @@ namespace scitt
 
       register_service_endpoints(context, *this);
       register_operations_endpoints(
-        context, *this, is_tx_committed, authn_policy, post_entry_continuation);
+        context, *this, authn_policy, post_entry_continuation);
 
 #ifdef ENABLE_PREFIX_TREE
       PrefixTreeFrontend::init_handlers(context, *this);

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -206,7 +206,7 @@ namespace scitt
         case ccf::TxStatus::Unknown:
         case ccf::TxStatus::Pending:
           // This can happen when the transaction hasn't been globally
-          // committed to the ledger yet. Not point looking up in the map yet,
+          // committed to the ledger yet. No point looking up in the map yet,
           // but we throw a transient error since eventually the transaction ID
           // could be valid.
           throw ServiceUnavailableError(


### PR DESCRIPTION
The callback endpoint when completing an operation needs to access the KV to check the integrity of the operation context that is being passed by the caller.

We previously used as historical query to look this up, but this almost always ends up returning a Service Unavailable error while the historical transaction is being fetched, and the callback needs to be retried after a short delay.

This replaces the historical query by caching the expected digest in the existing operations indexing strategy. This increases memory usage a little, but given that the indexing strategy is periodically purged, this increase should be bounded. If the operation completes too quickly, there is still a chance the strategy won't have indexed the original transaction yet, and the existing retry mechanism will be used.