### PR TITLE
Fix SCITT demo script

### DIFF
--- a/demo/github/1-scitt-setup.sh
+++ b/demo/github/1-scitt-setup.sh
@@ -8,19 +8,20 @@ mkdir -p tmp
 
 SCITT_URL="https://127.0.0.1:8000"
 
-curl -o tmp/cacert.pem "https://ccadb-public.secure.force.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites"
+curl -L -o tmp/cacert.pem "https://ccadb-public.secure.force.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites"
 scitt governance propose_ca_certs \
+    --name did_web_tls_roots \
     --ca-certs tmp/cacert.pem \
     --url $SCITT_URL \
-    --member-key workspace/sandbox_common/member0_privk.pem \
-    --member-cert workspace/sandbox_common/member0_cert.pem \
+    --member-key workspace/member0_privk.pem \
+    --member-cert workspace/member0_cert.pem \
     --development
 
 echo '{ "authentication": { "allow_unauthenticated": true } }' > tmp/configuration.json
 scitt governance propose_configuration \
     --configuration tmp/configuration.json \
-    --member-key workspace/sandbox_common/member0_privk.pem \
-    --member-cert workspace/sandbox_common/member0_cert.pem \
+    --member-key workspace/member0_privk.pem \
+    --member-cert workspace/member0_cert.pem \
     --development
 
 TRUST_STORE=tmp/trust_store


### PR DESCRIPTION
Fixes a few minor issues with the [1-scitt-setup.sh](https://github.com/microsoft/scitt-ccf-ledger/blob/main/demo/github/1-scitt-setup.sh) script, in order to fully run a SCITT demo following the [README](https://github.com/microsoft/scitt-ccf-ledger/blob/main/demo/github/README.md) instructions.