### PR TITLE
Wait for cchost config to be available

### DIFF
--- a/demo/github/1-scitt-setup.sh
+++ b/demo/github/1-scitt-setup.sh
@@ -12,7 +12,7 @@ curl -L -o tmp/cacert.pem "https://ccadb-public.secure.force.com/mozilla/Include
 scitt governance propose_ca_certs \
     --name did_web_tls_roots \
     --ca-certs tmp/cacert.pem \
-    --url $SCITT_URL \
+    --url "$SCITT_URL" \
     --member-key workspace/member0_privk.pem \
     --member-cert workspace/member0_cert.pem \
     --development
@@ -27,4 +27,4 @@ scitt governance propose_configuration \
 TRUST_STORE=tmp/trust_store
 mkdir -p $TRUST_STORE
 
-curl -k -f $SCITT_URL/parameters > $TRUST_STORE/scitt.json
+curl -k -f "$SCITT_URL"/parameters > $TRUST_STORE/scitt.json

--- a/demo/github/1-scitt-setup.sh
+++ b/demo/github/1-scitt-setup.sh
@@ -6,7 +6,7 @@ set -ex
 
 mkdir -p tmp
 
-SCITT_URL="https://127.0.0.1:8000"
+SCITT_URL=${SCITT_URL:-"https://127.0.0.1:8000"}
 
 curl -L -o tmp/cacert.pem "https://ccadb-public.secure.force.com/mozilla/IncludedRootsPEMTxt?TrustBitsInclude=Websites"
 scitt governance propose_ca_certs \

--- a/demo/github/2-create-did.sh
+++ b/demo/github/2-create-did.sh
@@ -4,10 +4,10 @@
 
 set -ex
 
-: ${GITHUB_USER:?"variable not set! Please run 'export GITHUB_USER=<YOUR USERNAME>'"}
+: "${GITHUB_USER:?"variable not set! Please run 'export GITHUB_USER=<YOUR USERNAME>'"}"
 
 TMP_DIR=tmp/github
 rm -rf $TMP_DIR
 mkdir -p $TMP_DIR
-scitt create-did-web --url https://$GITHUB_USER.github.io --out-dir $TMP_DIR
+scitt create-did-web --url https://"$GITHUB_USER".github.io --out-dir $TMP_DIR
 scitt upload-did-web-github tmp/github/did.json

--- a/demo/github/4-submit.sh
+++ b/demo/github/4-submit.sh
@@ -11,6 +11,6 @@ TMP_DIR=tmp/github
 
 scitt submit $TMP_DIR/claims.cose \
     --receipt $TMP_DIR/claims.receipt.cbor \
-    --url $SCITT_URL \
+    --url "$SCITT_URL" \
     --service-trust-store $SCITT_TRUST_STORE \
     --development

--- a/demo/github/README.md
+++ b/demo/github/README.md
@@ -14,6 +14,12 @@ Acting as the SCITT Operator run:
 ./start.sh
 ```
 
+Alternatively, set the SCITT_URL variable if you are targeting a remote instance:
+
+```
+export SCITT_URL=<address>
+```
+
 In a new terminal run:
 ```
 ./demo/github/0-install-cli.sh

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -54,6 +54,10 @@ COPY --from=builder /usr/src/app/mrenclave.txt mrenclave.txt
 COPY app/fetch-did-web-doc.py /tmp/scitt/fetch-did-web-doc.py
 COPY --from=builder /usr/src/app/attested-fetch /tmp/scitt/
 
+COPY ./docker/start-app.sh /usr/src/app/start-app.sh
+
+RUN ["chmod", "+x", "/usr/src/app/start-app.sh"]
+
 WORKDIR /host/node
 
-ENTRYPOINT ["cchost"]
+ENTRYPOINT [ "/usr/src/app/start-app.sh" ]

--- a/docker/enclave.Dockerfile.dockerignore
+++ b/docker/enclave.Dockerfile.dockerignore
@@ -1,3 +1,4 @@
 *
 !app
 !3rdparty/attested-fetch
+!docker

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -90,7 +90,7 @@ docker run --name "$CONTAINER_NAME" \
     -d \
     "${DOCKER_FLAGS[@]}" \
     -v "$VOLUME_NAME":/host \
-    "$DOCKER_TAG" "--config /host/dev-config.json"
+    "$DOCKER_TAG" --config /host/dev-config.json
 
 echo "Setting up python virtual environment."
 if [ ! -f "venv/bin/activate" ]; then

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -90,7 +90,7 @@ docker run --name "$CONTAINER_NAME" \
     -d \
     "${DOCKER_FLAGS[@]}" \
     -v "$VOLUME_NAME":/host \
-    "$DOCKER_TAG" --config /host/dev-config.json
+    "$DOCKER_TAG" "--config /host/dev-config.json"
 
 echo "Setting up python virtual environment."
 if [ ! -f "venv/bin/activate" ]; then

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Starting app"
+config_arg=$1
+
+cchost --check ${config_arg}
+code=$?
+while [[ $code -ne 0 ]]; do
+    echo "Waiting for configuration file to be ready..."
+    sleep 10
+    cchost --check ${config_arg}
+    code=$?
+done
+
+echo "Running cchost from $(pwd)"
+stdbuf -o L cchost ${config_arg}

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -5,12 +5,12 @@
 # the SCITT container is deployed in Kubernetes without any orchestration sidecars.
 
 WAIT_TIME_SEC=3
-TIMEOUT_SEC=300
+TIMEOUT_SEC=5
 
 echo "Starting app"
-config_arg=$1
+config_arg=${1:?first argument is the configuration argument to pass to cchost (e.g., "--config /path/to/config.json"))}
 
-cchost --check ${config_arg}
+cchost --check "${config_arg}"
 code=$?
 
 start_time=$(date +%s)
@@ -18,16 +18,17 @@ start_time=$(date +%s)
 while [[ $code -ne 0 ]]; do
     
     # Exit if timeout is reached
-    if [[ $(($(date +%s) - $start_time)) -ge $TIMEOUT_SEC ]]; then
+    current_time=$(date +%s)
+    if [[ $((current_time - start_time)) -ge $TIMEOUT_SEC ]]; then
         echo "Timeout reached. Exiting..."
         exit 1
     fi
     
     echo "Waiting for configuration file to be ready..."
     sleep $WAIT_TIME_SEC
-    cchost --check ${config_arg}
+    cchost --check "${config_arg}"
     code=$?
 done
 
 echo "Running cchost from $(pwd)"
-stdbuf -o L cchost ${config_arg}
+stdbuf -o L cchost "${config_arg}"

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -8,9 +8,8 @@ WAIT_TIME_SEC=3
 TIMEOUT_SEC=300
 
 echo "Starting app"
-args=$(printf '%s ' "$@") # concatenate all input cchost arguments into a single string
 
-cchost --check "${args}"
+cchost --check "$@"
 code=$?
 
 start_time=$(date +%s)
@@ -26,9 +25,9 @@ while [[ $code -ne 0 ]]; do
     
     echo "Waiting for configuration file to be ready..."
     sleep $WAIT_TIME_SEC
-    cchost --check "${args}"
+    cchost --check "$@"
     code=$?
 done
 
 echo "Running cchost from $(pwd)"
-stdbuf -o L cchost "${args}"
+stdbuf -o L cchost "$@"

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 
+# This configuration is a temporary workaround until we migrate to CCF 4.0.3, which supports
+# a cchost "config-timeout" option to accomplish a similar result. This logic is required when
+# the SCITT container is deployed in Kubernetes without any orchestration sidecars.
+
+WAIT_TIME_SEC=3
+TIMEOUT_SEC=300
+
 echo "Starting app"
 config_arg=$1
 
 cchost --check ${config_arg}
 code=$?
+
+start_time=$(date +%s)
+
 while [[ $code -ne 0 ]]; do
+    
+    # Exit if timeout is reached
+    if [[ $(($(date +%s) - $start_time)) -ge $TIMEOUT_SEC ]]; then
+        echo "Timeout reached. Exiting..."
+        exit 1
+    fi
+    
     echo "Waiting for configuration file to be ready..."
-    sleep 10
+    sleep $WAIT_TIME_SEC
     cchost --check ${config_arg}
     code=$?
 done

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -5,12 +5,12 @@
 # the SCITT container is deployed in Kubernetes without any orchestration sidecars.
 
 WAIT_TIME_SEC=3
-TIMEOUT_SEC=5
+TIMEOUT_SEC=300
 
 echo "Starting app"
-config_arg=${1:?first argument is the configuration argument to pass to cchost (e.g., "--config /path/to/config.json"))}
+args=$(printf '%s ' "$@") # concatenate all input cchost arguments into a single string
 
-cchost --check "${config_arg}"
+cchost --check "${args}"
 code=$?
 
 start_time=$(date +%s)
@@ -26,9 +26,9 @@ while [[ $code -ne 0 ]]; do
     
     echo "Waiting for configuration file to be ready..."
     sleep $WAIT_TIME_SEC
-    cchost --check "${config_arg}"
+    cchost --check "${args}"
     code=$?
 done
 
 echo "Running cchost from $(pwd)"
-stdbuf -o L cchost "${config_arg}"
+stdbuf -o L cchost "${args}"

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -41,6 +41,10 @@ COPY --from=builder /usr/src/app/share/VERSION VERSION
 COPY app/fetch-did-web-doc.py /tmp/scitt/fetch-did-web-doc.py
 COPY --from=builder /usr/src/app/attested-fetch /tmp/scitt/
 
+COPY ./docker/start-app.sh /usr/src/app/start-app.sh
+
+RUN ["chmod", "+x", "start-app.sh"]
+
 WORKDIR /host/node
 
-ENTRYPOINT ["cchost"]
+ENTRYPOINT [ "/usr/src/app/start-app.sh" ]

--- a/docker/virtual.Dockerfile.dockerignore
+++ b/docker/virtual.Dockerfile.dockerignore
@@ -1,3 +1,4 @@
 *
 !app
 !3rdparty/attested-fetch
+!docker


### PR DESCRIPTION
This PR modifies the SCITT Dockerfiles to include a simple script that allows waiting for the `cchost` config file to be available and exit if the condition is not met within a certain timeout. 

This is to support the current deployment of SCITT in Kubernetes using the CCF orchestration layer without sidecars. This configuration will eventually be removed once we upgrade SCITT to CCF 4.0.3, which supports a new `config-timeout` option to achieve a similar goal.