### PR TITLE
Add documentation to build and push docker images

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,42 @@
+# Build and push SCITT Docker images
+
+This folder contains scripts and utilities to build and run docker images for the SCITT application.
+
+## Build and run docker images
+
+To build a docker image, run the following command from the root of the repository:
+
+```bash
+./docker/build.sh
+```
+
+To run a docker container using a built image, run the following command from the root of the repository:
+
+```bash
+./docker/run-dev.sh
+```
+
+Both scripts accept different variables for customization. For example to build a docker image for non-SGX environments and with a custom docker tag, you can run the following command:
+
+```bash
+PLATFORM="virtual" DOCKER_TAG="scitt-virtual" ./docker/build.sh
+```
+
+Please refer to the corresponding scripts for the full list of available variables to use.
+
+## Build and push docker images to a container registry
+
+After building a docker image, you can push it to a container registry. For example, to build and push a docker image to an Azure Container Registry (ACR) for SCITT in SGX, you can run the following commands:
+
+```bash
+ACR="<acr-name>" # Define your ACR name here
+
+# Build docker image for SGX
+PLATFORM="sgx" DOCKER_TAG="$ACR.azurecr.io/scitt-ccf-ledger-sgx:latest" ./docker/build.sh
+
+# Login to ACR
+az acr login --name $ACR 
+
+# Push docker image to ACR
+docker push $ACR.azurecr.io/scitt-ccf-ledger-sgx:latest
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,7 @@ To run a docker container using a built image, run the following command from th
 ./docker/run-dev.sh
 ```
 
-Both scripts accept different variables for customization. For example to build a docker image for non-SGX environments and with a custom docker tag, you can run the following command:
+Both scripts accept different variables for customization. For example, to build a docker image for non-SGX environments and with a custom docker tag, you can run the following command:
 
 ```bash
 PLATFORM="virtual" DOCKER_TAG="scitt-virtual" ./docker/build.sh
@@ -26,7 +26,7 @@ Please refer to the corresponding scripts for the full list of available variabl
 
 ## Build and push docker images to a container registry
 
-After building a docker image, you can push it to a container registry. For example, to build and push a docker image to an Azure Container Registry (ACR) for SCITT in SGX, you can run the following commands:
+After building a docker image, you can push it to a container registry. For example, to build and push a docker image to an Azure Container Registry (ACR) for the SCITT application running in SGX, you can run the following set of commands:
 
 ```bash
 ACR="<acr-name>" # Define your ACR name here

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -7,7 +7,6 @@ set -e
 PLATFORM=${PLATFORM:-sgx}
 SAVE_IMAGE_PATH=${SAVE_IMAGE_PATH:-""}
 DOCKER_TAG=${DOCKER_TAG:-"scitt-ccf-ledger-$PLATFORM"}
-DOCKER_TAG=${DOCKER_TAG:-"scitt-ccf-ledger-$PLATFORM"}
 
 if [ "$PLATFORM" = "sgx" ]; then
     DOCKERFILE="enclave.Dockerfile"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,6 +6,8 @@ set -e
 
 PLATFORM=${PLATFORM:-sgx}
 SAVE_IMAGE_PATH=${SAVE_IMAGE_PATH:-""}
+DOCKER_TAG=${DOCKER_TAG:-"scitt-ccf-ledger-$PLATFORM"}
+DOCKER_TAG=${DOCKER_TAG:-"scitt-ccf-ledger-$PLATFORM"}
 
 if [ "$PLATFORM" = "sgx" ]; then
     DOCKERFILE="enclave.Dockerfile"
@@ -20,8 +22,6 @@ git submodule sync
 git submodule update --init --recursive
 
 SCITT_VERSION_OVERRIDE=$(git describe --tags --match="*.*.*")
-
-DOCKER_TAG="scitt-ccf-ledger-$PLATFORM"
 
 DOCKER_BUILDKIT=1 docker build \
     -t "$DOCKER_TAG" \


### PR DESCRIPTION
This PR adds a README file inside the `docker/` folder to provide details on how to build, run, and push docker container images for the SCITT application.