### PR TITLE
Print MRENCLAVE after the docker build

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -28,6 +28,9 @@ DOCKER_BUILDKIT=1 docker build \
     --build-arg SCITT_VERSION_OVERRIDE="$SCITT_VERSION_OVERRIDE" \
     .
 
+echo "MRENCLAVE:"
+docker run --rm -it --entrypoint /bin/cat "$DOCKER_TAG" /usr/src/app/mrenclave.txt
+
 if [ -n "$SAVE_IMAGE_PATH" ]; then
     docker save "$DOCKER_TAG" -o "$SAVE_IMAGE_PATH"
 fi

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -28,6 +28,9 @@ RUN mkdir /tmp/app-build && \
     /tmp/app && \
     ninja && ninja install
 
+WORKDIR /usr/src/app
+RUN /opt/openenclave/bin/oesign dump -e lib/libscitt.virtual.so | sed -n "s/mrenclave=//p" > mrenclave.txt
+
 FROM mcr.microsoft.com/ccf/app/run:${CCF_VERSION}-virtual
 ARG CCF_VERSION
 
@@ -37,6 +40,7 @@ RUN apt-get update && apt-get install -y python3 \
 WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/lib/libscitt.virtual.so libscitt.virtual.so
 COPY --from=builder /usr/src/app/share/VERSION VERSION
+COPY --from=builder /usr/src/app/mrenclave.txt mrenclave.txt
 
 COPY app/fetch-did-web-doc.py /tmp/scitt/fetch-did-web-doc.py
 COPY --from=builder /usr/src/app/attested-fetch /tmp/scitt/


### PR DESCRIPTION
To see if we can do reproducible builds on any environment we need to at least know what is in the built image in CI.

* Store synthetic MRENCLAVE in the virtual build to make it easier to test
* Print the MRENCLAVE file value after any docker build which will be visible in the CI logs