### PR TITLE
Add support for COSE signing in python clients and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ workspace/
 *.egg-info/
 .vscode/settings.json
 perf.json
+**/*.pem
+**/*.pid
+.mypy_cache/
+**/*.cose
+**/*.cbor

--- a/demo/github/1-scitt-setup.sh
+++ b/demo/github/1-scitt-setup.sh
@@ -20,6 +20,7 @@ scitt governance propose_ca_certs \
 echo '{ "authentication": { "allow_unauthenticated": true } }' > tmp/configuration.json
 scitt governance propose_configuration \
     --configuration tmp/configuration.json \
+    --url "$SCITT_URL" \
     --member-key workspace/member0_privk.pem \
     --member-cert workspace/member0_cert.pem \
     --development

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -53,7 +53,7 @@ class MemberAuthenticationMethod(ABC):
         """
 
     @abstractmethod
-    def cose_sign(self, data: bytes, cose_headers: dict) -> bytes:
+    def cose_sign(self, data: bytes, cose_headers: Optional[Dict] = None) -> bytes:
         """Generates a COSE payload for the specified request with the specified headers.
 
         https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
@@ -61,7 +61,7 @@ class MemberAuthenticationMethod(ABC):
         :param data: The intended body for the HTTP request.
         :type data: bytes
         :param cose_headers: The headers to include in the COSE payload.
-        :type cose_headers: dict
+        :type cose_headers: Optional[Dict]
 
         :return: The full payload, with signature, to be sent to CCF.
         :rtype: bytes

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -4,11 +4,10 @@
 import base64
 import hashlib
 import json
-import threading
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from http import HTTPStatus
 from typing import Any, Dict, Iterable, Literal, Optional, TypeVar, Union, overload

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -3,11 +3,14 @@
 
 import base64
 import hashlib
+import json
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
 from http import HTTPStatus
-from typing import Iterable, Literal, Optional, TypeVar, Union, overload
+from typing import Any, Dict, Iterable, Literal, Optional, TypeVar, Union, overload
 from urllib.parse import urlencode
 
 import httpx
@@ -22,12 +25,47 @@ from .verify import ServiceParameters
 CCF_TX_ID_HEADER = "x-ms-ccf-transaction-id"
 
 
+class SigningType(Enum):
+    """Types of signatures supported by CCF.
+
+    https://microsoft.github.io/CCF/main/governance/hsm_keys.html#signing-governance-requests
+    """
+
+    COSE = "COSE"
+    HTTP = "HTTP"
+
+
 class MemberAuthenticationMethod(ABC):
     cert: str
 
     @abstractmethod
-    def sign(self, data: bytes) -> bytes:
-        pass
+    def http_sign(self, data: bytes) -> bytes:
+        """
+        Generates a HTTP signing payload for the specified request with the specified headers.
+
+        https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
+
+        :param data: The intended body for the HTTP request.
+        :type data: bytes
+
+        :return: The full payload, with signature, to be sent to CCF.
+        :rtype: bytes
+        """
+
+    @abstractmethod
+    def cose_sign(self, data: bytes, cose_headers: dict) -> bytes:
+        """Generates a COSE payload for the specified request with the specified headers.
+
+        https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
+
+        :param data: The intended body for the HTTP request.
+        :type data: bytes
+        :param cose_headers: The headers to include in the COSE payload.
+        :type cose_headers: dict
+
+        :return: The full payload, with signature, to be sent to CCF.
+        :rtype: bytes
+        """
 
 
 # copied from CCF/tests/infra/clients.py
@@ -52,7 +90,7 @@ class HttpSig(httpx.Auth):
             ]
         ).encode("utf-8")
 
-        signature = self.member_auth_client.sign(string_to_sign)
+        signature = self.member_auth_client.http_sign(string_to_sign)
         b64signature = base64.b64encode(signature).decode("ascii")
         request.headers[
             "authorization"
@@ -71,6 +109,73 @@ class ServiceError(Exception):
 
 
 SelfClient = TypeVar("SelfClient", bound="BaseClient")
+
+
+def cose_protected_headers(request_path: str, method: str):
+    """
+    Generate the COSE protected headers for CCF governance given a request path and HTTP method.
+
+    :param request_path: The path of the request.
+    :type request_path: str
+    :param method: The method of the request.
+    :type method: str
+
+    :return: The COSE protected headers.
+    :rtype: dict
+    """
+
+    cose_headers: Dict[str, Any] = {}
+
+    # Set the created_at header to the current time
+    cose_headers = {
+        "ccf.gov.msg.created_at": int(datetime.now(tz=timezone.utc).timestamp())
+    }
+
+    # Set headers based on the request path and method
+    if request_path.endswith("gov/ack/update_state_digest"):
+        cose_headers["ccf.gov.msg.type"] = "state_digest"
+    elif request_path.endswith("gov/ack"):
+        cose_headers["ccf.gov.msg.type"] = "ack"
+    elif request_path.endswith("gov/proposals"):
+        cose_headers["ccf.gov.msg.type"] = "proposal"
+    elif request_path.endswith("/ballots"):
+        pid = request_path.split("/")[-2]
+        cose_headers["ccf.gov.msg.type"] = "ballot"
+        cose_headers["ccf.gov.msg.proposal_id"] = pid
+    elif request_path.endswith("/withdraw"):
+        pid = request_path.split("/")[-2]
+        cose_headers["ccf.gov.msg.type"] = "withdrawal"
+        cose_headers["ccf.gov.msg.proposal_id"] = pid
+    elif request_path.endswith("gov/recovery_share"):
+        if method == "GET":
+            cose_headers["ccf.gov.msg.type"] = "encrypted_recovery_share"
+        if method == "POST":
+            cose_headers["ccf.gov.msg.type"] = "recovery_share"
+
+    return cose_headers
+
+
+def get_content_data(body: Optional[Union[dict, str, bytes]]) -> bytes:
+    """
+    Get the request body from the body parameter
+
+    :param body: The body of the request. Can be a string, bytes, or dict.
+    :type body: Optional[Union[dict, str, bytes]]
+
+    :return: The request body
+    :rtype: bytes
+    """
+
+    if isinstance(body, str):
+        request_body = body.encode()
+    elif isinstance(body, dict):
+        request_body = json.dumps(body).encode()
+    elif isinstance(body, bytes):
+        request_body = body
+    else:
+        raise ValueError(f"Invalid body type: {type(body)}")
+
+    return request_body
 
 
 class BaseClient:
@@ -97,6 +202,7 @@ class BaseClient:
         *,
         auth_token: Optional[str] = None,
         member_auth: Optional[MemberAuthenticationMethod] = None,
+        member_signing_type: SigningType = SigningType.COSE,
         wait_time: Optional[float] = None,
         development: bool = False,
     ):
@@ -107,11 +213,14 @@ class BaseClient:
             A bearer token for all requests made by this instance.
 
         member_auth:
-            MemberAuthenticationMethod include A pair of certificate and private key in PEM format or AKV login idenity, used to sign requests.
+            MemberAuthenticationMethod include A pair of certificate and private key in PEM format or AKV login identity, used to sign requests with HTTP Signing.
             Each request that needs signing must also be given the `sign_request=True` parameter.
 
         wait_time:
             The time to wait between retries. If None, the default wait time is used.
+
+        member_signing_type:
+            The type of signing to use for member authentication. Currently, only COSE and HTTP signing are supported.
 
         development:
             If true, the TLS certificate of the server will not be verified.
@@ -123,6 +232,7 @@ class BaseClient:
         self.url = url
         self.auth_token = auth_token
         self.member_auth = member_auth
+        self.member_signing_type = member_signing_type
         self.wait_time = wait_time
         self.development = development
 
@@ -130,7 +240,7 @@ class BaseClient:
         if auth_token:
             headers["Authorization"] = "Bearer " + auth_token
 
-        if member_auth:
+        if member_auth and member_signing_type == SigningType.HTTP:
             self.member_http_sig = HttpSig(member_auth)
         else:
             self.member_http_sig = None
@@ -150,6 +260,7 @@ class BaseClient:
             "url": self.url,
             "auth_token": self.auth_token,
             "member_auth": self.member_auth,
+            "member_signing_type": self.member_signing_type,
             "wait_time": self.wait_time,
             "development": self.development,
         }
@@ -187,16 +298,48 @@ class BaseClient:
         Other keyword-arguments are passed to httpx.
         """
         if sign_request:
-            if not self.member_http_sig:
-                raise ValueError("Cannot sign request: no member key configured")
-            elif "auth" in kwargs:
+            # Check that the request is not already signed
+            if "auth" in kwargs:
                 raise ValueError("Cannot use `auth` with `sign_request`")
-            else:
+
+            # Sign with COSE
+            if self.member_signing_type == SigningType.COSE and self.member_auth:
+                # Get the COSE headers
+                cose_headers = cose_protected_headers(url, method)
+
+                def _get_data():
+                    """Get the data to sign from the request"""
+
+                    # The data is in `content` or `json` kwargs
+                    content = kwargs.get("content")
+                    if content:
+                        content = get_content_data(content)
+
+                    json_data = kwargs.get("json")
+                    if json_data:
+                        json_data = get_content_data(json_data)
+
+                    if content and json_data:
+                        raise ValueError("Cannot use both `content` and `json`")
+
+                    return content or json_data or b""
+
+                payload = self.member_auth.cose_sign(_get_data(), cose_headers)
+
+                # Set the request data and the content-type header
+                kwargs["content"] = payload
+                kwargs.setdefault("headers", {})["content-type"] = "application/cose"
+
+            # Sign with HTTP signing
+            elif self.member_signing_type == SigningType.HTTP and self.member_http_sig:
                 kwargs["auth"] = self.member_http_sig
 
-            if method == "GET":
-                # Content-length is necessary for signing, even on GET requests.
-                kwargs.setdefault("headers", {}).setdefault("Content-Length", "0")
+                if method == "GET":
+                    # Content-length is necessary for signing, even on GET requests.
+                    kwargs.setdefault("headers", {}).setdefault("Content-Length", "0")
+
+            else:
+                raise ValueError(f"Cannot sign request with {self.member_signing_type}")
 
         default_wait_time = 2
         timeout = 30
@@ -241,6 +384,7 @@ class BaseClient:
 
         if not response.is_success:
             error = response.json()["error"]
+            LOG.error(f"Request failed: {error}")
             raise ServiceError(response.headers, error["code"], error["message"])
 
         if wait_for_confirmation:

--- a/pyscitt/pyscitt/key_vault_sign_client.py
+++ b/pyscitt/pyscitt/key_vault_sign_client.py
@@ -8,6 +8,7 @@ from azure.identity import DefaultAzureCredential
 from azure.keyvault.certificates import CertificateClient, KeyVaultCertificate
 from azure.keyvault.keys import KeyClient
 from azure.keyvault.keys.crypto import CryptographyClient, SignatureAlgorithm
+from ccf.cose import create_cose_sign1_finish, create_cose_sign1_prepare
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 from cryptography.x509 import load_pem_x509_certificate
 
@@ -50,13 +51,66 @@ class KeyVaultSignClient(MemberAuthenticationMethod):
         cert_pem = f"-----BEGIN CERTIFICATE-----\n{decoded}\n-----END CERTIFICATE-----"
         return cert_pem
 
-    def sign(self, data: bytes):
+    def _get_crypto_client(self):
         key_client = KeyClient(vault_url=self._vault_url, credential=self.credential)
         key = key_client.get_key(
             name=self._identity_certificate_name,
             version=self._identity_certificate_version,
         )
         crypto_client = CryptographyClient(key, credential=self.credential)
+        return crypto_client
+
+    def cose_sign(self, data: bytes, cose_headers: dict) -> bytes:
+        """Generates a COSE payload for the specified request with the specified headers.
+
+        https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
+
+        :param data: The intended body for the HTTP request.
+        :type data: bytes
+        :param cose_headers: The headers to include in the COSE payload.
+        :type cose_headers: dict
+
+        :return: The full payload, with signature, to be sent to CCF.
+        :rtype: bytes
+        """
+
+        tbs = create_cose_sign1_prepare(
+            payload=data,
+            cert_pem=self.cert,
+            additional_protected_header=cose_headers,
+        )
+
+        digest_to_sign = base64.b64decode(tbs["value"].encode())
+
+        algorithm = SignatureAlgorithm(tbs["alg"])
+
+        crypto_client = self._get_crypto_client()
+
+        sign_result = crypto_client.sign(
+            algorithm=SignatureAlgorithm(algorithm), digest=digest_to_sign
+        )
+
+        return create_cose_sign1_finish(
+            payload=data,
+            cert_pem=self.cert,
+            signature=base64.urlsafe_b64encode(sign_result.signature).decode(),
+            additional_protected_header=cose_headers,
+        )
+
+    def http_sign(self, data: bytes):
+        """
+        Generates a HTTP signing payload for the specified request with the specified headers.
+
+        https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
+
+        :param data: The intended body for the HTTP request.
+        :type data: bytes
+
+        :return: The full payload, with signature, to be sent to CCF.
+        :rtype: bytes
+        """
+
+        crypto_client = self._get_crypto_client()
         cert = load_pem_x509_certificate(self.cert.encode("ascii"))
         pub_key = cert.public_key()
         assert isinstance(pub_key, (EllipticCurvePublicKey))

--- a/pyscitt/pyscitt/local_key_sign_client.py
+++ b/pyscitt/pyscitt/local_key_sign_client.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from ccf.cose import create_cose_sign1
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
@@ -18,7 +19,43 @@ class LocalKeySignClient(MemberAuthenticationMethod):
             password=None,
         )
 
-    def sign(self, data: bytes) -> bytes:
+    def cose_sign(self, data: bytes, cose_headers: dict) -> bytes:
+        """Generates a COSE payload for the specified request with the specified headers.
+
+        https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
+
+        :param data: The intended body for the HTTP request.
+        :type data: bytes
+        :param cose_headers: The headers to include in the COSE payload.
+        :type cose_headers: dict
+
+        :return: The full payload, with signature, to be sent to CCF.
+        :rtype: bytes
+        """
+
+        assert self.cert, "No identity public certificate available for this identity"
+        assert self.key, "No identity private key available for this identity"
+
+        return create_cose_sign1(
+            payload=data,
+            key_priv_pem=self.key,
+            cert_pem=self.cert,
+            additional_protected_header=cose_headers,
+        )
+
+    def http_sign(self, data: bytes):
+        """
+        Generates a HTTP signing payload for the specified request with the specified headers.
+
+        https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
+
+        :param data: The intended body for the HTTP request.
+        :type data: bytes
+
+        :return: The full payload, with signature, to be sent to CCF.
+        :rtype: bytes
+        """
+
         assert isinstance(self.private_key, (EllipticCurvePrivateKey))
         digest_algo = {256: hashes.SHA256(), 384: hashes.SHA384()}[
             self.private_key.curve.key_size

--- a/pyscitt/pyscitt/local_key_sign_client.py
+++ b/pyscitt/pyscitt/local_key_sign_client.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from typing import Dict, Optional
+
 from ccf.cose import create_cose_sign1
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -19,7 +21,7 @@ class LocalKeySignClient(MemberAuthenticationMethod):
             password=None,
         )
 
-    def cose_sign(self, data: bytes, cose_headers: dict) -> bytes:
+    def cose_sign(self, data: bytes, cose_headers: Optional[Dict] = None) -> bytes:
         """Generates a COSE payload for the specified request with the specified headers.
 
         https://microsoft.github.io/CCF/main/use_apps/issue_commands.html#signing
@@ -27,7 +29,7 @@ class LocalKeySignClient(MemberAuthenticationMethod):
         :param data: The intended body for the HTTP request.
         :type data: bytes
         :param cose_headers: The headers to include in the COSE payload.
-        :type cose_headers: dict
+        :type cose_headers: Optional[Dict]
 
         :return: The full payload, with signature, to be sent to CCF.
         :rtype: bytes
@@ -36,6 +38,7 @@ class LocalKeySignClient(MemberAuthenticationMethod):
         assert self.cert, "No identity public certificate available for this identity"
         assert self.key, "No identity private key available for this identity"
 
+        # Use the CCF library to generate the COSE payload
         return create_cose_sign1(
             payload=data,
             key_priv_pem=self.key,

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -104,7 +104,7 @@ class CCHost(EventLoopThread):
         self.clock_offset = 0
         if enable_faketime:
             # Unfortunately there isn't really a portable way of finding this path.
-            # Hardcode what works on the CI images we use, and allow it to be overriden.
+            # Hardcode what works on the CI images we use, and allow it to be overridden.
             faketime_lib = Path(
                 os.getenv(
                     "LIBFAKETIME",

--- a/test/load_test/locustfile.py
+++ b/test/load_test/locustfile.py
@@ -4,7 +4,7 @@
 import random
 from pathlib import Path
 
-from locust import User, events, task
+from locust import FastHttpUser, events, task
 
 from pyscitt.client import Client
 
@@ -22,7 +22,7 @@ def init_parser(parser):
     )
 
 
-class ScittUser(User):
+class ScittUser(FastHttpUser):
     abstract = True
 
     def __init__(self, *args, **kwargs):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,6 +3,7 @@
 
 import json
 import shlex
+import time
 from pathlib import Path
 
 import pytest
@@ -457,6 +458,13 @@ class TestUpdateScittConstitution:
                 )
             else:
                 path.write_text(script)
+
+            # This fixture may send proposals identical in content using the SCITT CLI.
+            # If it runs too soon before or after, it risks signing proposals within the
+            # same second and hitting the ProposalReplay protection error from CCF.
+            # Therefore, we sleep for a second here to avoid the issue.
+            # See also https://github.com/microsoft/CCF/pull/4887
+            time.sleep(1)
 
             run(
                 "governance",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,7 +3,6 @@
 
 import json
 import shlex
-import time
 from pathlib import Path
 
 import pytest
@@ -458,13 +457,6 @@ class TestUpdateScittConstitution:
                 )
             else:
                 path.write_text(script)
-
-            # This fixture may send proposals identical in content using the SCITT CLI.
-            # If it runs too soon before or after, it risks signing proposals within the
-            # same second and hitting the ProposalReplay protection error from CCF.
-            # Therefore, we sleep for a second here to avoid the issue.
-            # See also https://github.com/microsoft/CCF/pull/4887
-            time.sleep(1)
 
             run(
                 "governance",


### PR DESCRIPTION
This PR modifies the pyscitt client and functional tests to use COSE signing instead of the deprecated HTTP signing, which will no longer be supported in CCF 4. 

COSE signing support has been added to both local and AKV member clients. The base client used to send requests to CCF instances has been modified to use COSE signing by default, including in tests.

The PR also contains minor adjustments and tests refactoring.