### PR TITLE
Upgrade to CCF 4.0.7

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,4 +40,4 @@ Checks: >
 
 WarningsAsErrors: '*'
 # Include current directory files and exclude ccf imported code
-HeaderFilterRegex: '^(?!.*\/opt\/ccf_virtual\/include\/).*'
+HeaderFilterRegex: '^(?!.*(\/opt_ccf.*\/include\/)).*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,4 +39,5 @@ Checks: >
   -readability-qualified-auto,
 
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*'
+# Include current directory files and exclude ccf imported code
+HeaderFilterRegex: '^(?!.*\/opt\/ccf_virtual\/include\/).*'

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/ccf/app/dev:4.0.6-virtual
+FROM mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
 
 # Dependency of the virtual build of attested-fetch.
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/ccf/app/dev:3.0.12-virtual
+FROM mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
 
 # Dependency of the virtual build of attested-fetch.
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
+FROM mcr.microsoft.com/ccf/app/dev:4.0.6-virtual
 
 # Dependency of the virtual build of attested-fetch.
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/build-test-virtual.yml
+++ b/.github/workflows/build-test-virtual.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: mcr.microsoft.com/ccf/app/dev:4.0.6-virtual
+      image: mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
       env:
         # Helps to distinguish between CI and local builds.
         SCITT_CI: 1

--- a/.github/workflows/build-test-virtual.yml
+++ b/.github/workflows/build-test-virtual.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
+      image: mcr.microsoft.com/ccf/app/dev:4.0.6-virtual
       env:
         # Helps to distinguish between CI and local builds.
         SCITT_CI: 1

--- a/.github/workflows/build-test-virtual.yml
+++ b/.github/workflows/build-test-virtual.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: mcr.microsoft.com/ccf/app/dev:3.0.12-virtual
+      image: mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
       env:
         # Helps to distinguish between CI and local builds.
         SCITT_CI: 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     name: Analyze
     
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/ccf/app/dev:3.0.12-virtual
+    container: mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
     
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     name: Analyze
     
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
+    container: mcr.microsoft.com/ccf/app/dev:4.0.6-virtual
     
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     name: Analyze
     
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/ccf/app/dev:4.0.6-virtual
+    container: mcr.microsoft.com/ccf/app/dev:4.0.7-virtual
     
     permissions:
       actions: read

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 parameters:
   - name: CCF_VERSION
     type: string
-    default: 3.0.12
+    default: 4.0.7
 
 resources:
   containers:

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -101,7 +101,7 @@ stages:
 
           # faketime does not play well with ASAN so don't enable it here.
           FunctionalTestArguments: '--enable-prefix-tree'
-          InstallPackages: [ libcurl4-openssl-dev, libstdc++-11-dev ]
+          InstallPackages: [ libcurl4-openssl-dev, libstdc++-10-dev ]
 
       - template: common.yml
         parameters:

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 parameters:
   - name: CCF_VERSION
     type: string
-    default: 4.0.6
+    default: 4.0.7
 
 resources:
   containers:

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -97,11 +97,12 @@ stages:
             CMAKE_BUILD_TYPE: Debug
             ENABLE_PREFIX_TREE: ON
             # Fast unwinder only gives us partial stack traces in LeakSanitzer
+            # Alloc/dealloc mismatch has been disabled in CCF: https://github.com/microsoft/CCF/pull/5157
             ASAN_OPTIONS: fast_unwind_on_malloc=0:alloc_dealloc_mismatch=0
 
           # faketime does not play well with ASAN so don't enable it here.
           FunctionalTestArguments: '--enable-prefix-tree'
-          InstallPackages: [ libcurl4-openssl-dev, libstdc++-10-dev ]
+          InstallPackages: [ libcurl4-openssl-dev ]
 
       - template: common.yml
         parameters:

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
             CMAKE_BUILD_TYPE: Debug
             ENABLE_PREFIX_TREE: ON
             # Fast unwinder only gives us partial stack traces in LeakSanitzer
-            ASAN_OPTIONS: fast_unwind_on_malloc=0
+            ASAN_OPTIONS: fast_unwind_on_malloc=0:alloc_dealloc_mismatch=0
 
           # faketime does not play well with ASAN so don't enable it here.
           FunctionalTestArguments: '--enable-prefix-tree'

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -101,7 +101,7 @@ stages:
 
           # faketime does not play well with ASAN so don't enable it here.
           FunctionalTestArguments: '--enable-prefix-tree'
-          InstallPackages: [ libcurl4-openssl-dev ]
+          InstallPackages: [ libcurl4-openssl-dev, libstdc++-11-dev ]
 
       - template: common.yml
         parameters:

--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -9,7 +9,7 @@ trigger:
 parameters:
   - name: CCF_VERSION
     type: string
-    default: 4.0.7
+    default: 4.0.6
 
 resources:
   containers:

--- a/.pipelines/ccf.yml
+++ b/.pipelines/ccf.yml
@@ -11,17 +11,24 @@ parameters:
 
 steps:
   - script: |
+      set -ex
+      sudo rm -rf $(Pipeline.Workspace)/CCF
       git clone --single-branch -b ccf-${{ parameters.Version }} https://github.com/microsoft/CCF $(Pipeline.Workspace)/CCF
     displayName: Checkout CCF ${{ parameters.Version }}
 
   - script: |
+      set -ex
       cd getting_started/setup_vm
       ./run.sh ccf-dev.yml -e ccf_ver=${{ parameters.Version }} -e platform=${{ parameters.Platform }} -e clang_version=15
     workingDirectory: $(Pipeline.Workspace)/CCF
     displayName: Setup CCF development environment
 
   - script: |
-      CC=`which clang-15` CXX=`which clang++-15` cmake -GNinja -B build \
+      set -ex
+      sudo rm -rf build
+      mkdir build
+      cd build
+      CC=`which clang-15` CXX=`which clang++-15` cmake -L -GNinja .. \
         -DCMAKE_INSTALL_PREFIX=/opt/ccf_${{ parameters.Platform }} \
         -DCOMPILE_TARGET=${{ parameters.Platform }} \
         -DBUILD_TESTS=OFF \

--- a/.pipelines/ccf.yml
+++ b/.pipelines/ccf.yml
@@ -15,11 +15,12 @@ steps:
     displayName: Checkout CCF ${{ parameters.Version }}
 
   - script: |
+      apt-get update && apt-get install -y libstdc++-10-dev
       cmake -GNinja -B build \
         -DCMAKE_INSTALL_PREFIX=/opt/ccf_${{ parameters.Platform }} \
         -DCOMPILE_TARGET=${{ parameters.Platform }} \
-        -DBUILD_TESTS=ON \
-        -DBUILD_UNIT_TESTS=ON \
+        -DBUILD_TESTS=OFF \
+        -DBUILD_UNIT_TESTS=OFF \
         ${{ parameters.CMakeArgs }}
     workingDirectory: $(Pipeline.Workspace)/CCF
     displayName: Configure CCF

--- a/.pipelines/ccf.yml
+++ b/.pipelines/ccf.yml
@@ -19,7 +19,7 @@ steps:
         -DCMAKE_INSTALL_PREFIX=/opt/ccf_${{ parameters.Platform }} \
         -DCOMPILE_TARGET=${{ parameters.Platform }} \
         -DBUILD_TESTS=ON \
-        -DBUILD_UNIT_TESTS=OFF \
+        -DBUILD_UNIT_TESTS=ON \
         ${{ parameters.CMakeArgs }}
     workingDirectory: $(Pipeline.Workspace)/CCF
     displayName: Configure CCF

--- a/.pipelines/ccf.yml
+++ b/.pipelines/ccf.yml
@@ -18,7 +18,7 @@ steps:
       cmake -GNinja -B build \
         -DCMAKE_INSTALL_PREFIX=/opt/ccf_${{ parameters.Platform }} \
         -DCOMPILE_TARGET=${{ parameters.Platform }} \
-        -DBUILD_TESTS=OFF \
+        -DBUILD_TESTS=ON \
         -DBUILD_UNIT_TESTS=OFF \
         ${{ parameters.CMakeArgs }}
     workingDirectory: $(Pipeline.Workspace)/CCF

--- a/.pipelines/ccf.yml
+++ b/.pipelines/ccf.yml
@@ -15,8 +15,13 @@ steps:
     displayName: Checkout CCF ${{ parameters.Version }}
 
   - script: |
-      apt-get update && apt-get install -y libstdc++-10-dev
-      cmake -GNinja -B build \
+      cd getting_started/setup_vm
+      ./run.sh ccf-dev.yml -e ccf_ver=${{ parameters.Version }} -e platform=${{ parameters.Platform }} -e clang_version=15
+    workingDirectory: $(Pipeline.Workspace)/CCF
+    displayName: Setup CCF development environment
+
+  - script: |
+      CC=`which clang-15` CXX=`which clang++-15` cmake -GNinja -B build \
         -DCMAKE_INSTALL_PREFIX=/opt/ccf_${{ parameters.Platform }} \
         -DCOMPILE_TARGET=${{ parameters.Platform }} \
         -DBUILD_TESTS=OFF \

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,16 +18,16 @@ Follow the steps below to setup your development environment, replacing `<sgx|vi
 
 1. Set up machine: 
     - If using SGX, it is recommended that you provision a virtual machine:
-      - On Azure, provision a DC-series VM, for example, [DCsv2](https://learn.microsoft.com/en-us/azure/virtual-machines/dcv2-series)
+      - On Azure, provision a DC-series VM, for example, [DCsv3](https://learn.microsoft.com/en-us/azure/virtual-machines/dcv3-series)
       - Enable running SGX enclaves: `sudo usermod -a -G sgx_prv $(whoami)`
     - If using virtual mode, running Ubuntu 20.04 on any platform (WSL, VM, etc.) is enough
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-3.0.12.tar.gz
-    tar xvzf ccf-3.0.12.tar.gz
-    cd CCF-ccf-3.0.12/getting_started/setup_vm/
-    ./run.sh app-dev.yml -e ccf_ver=3.0.12 -e platform=<sgx|virtual>
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-4.0.7.tar.gz
+    tar xvzf ccf-4.0.7.tar.gz
+    cd CCF-ccf-4.0.7/getting_started/setup_vm/
+    ./run.sh app-dev.yml -e ccf_ver=4.0.7 -e platform=<sgx|virtual>
     ```
 
 ## Building

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,7 +27,7 @@ Follow the steps below to setup your development environment, replacing `<sgx|vi
     wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-4.0.7.tar.gz
     tar xvzf ccf-4.0.7.tar.gz
     cd CCF-ccf-4.0.7/getting_started/setup_vm/
-    ./run.sh app-dev.yml -e ccf_ver=4.0.7 -e platform=<sgx|virtual>
+    ./run.sh app-dev.yml -e ccf_ver=4.0.7 -e platform=<sgx|virtual> -e clang_version=<11|15>
     ```
 
 ## Building

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,10 +24,10 @@ Follow the steps below to setup your development environment, replacing `<sgx|vi
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-4.0.7.tar.gz
-    tar xvzf ccf-4.0.7.tar.gz
-    cd CCF-ccf-4.0.7/getting_started/setup_vm/
-    ./run.sh app-dev.yml -e ccf_ver=4.0.7 -e platform=<sgx|virtual>
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-4.0.6.tar.gz
+    tar xvzf ccf-4.0.6.tar.gz
+    cd CCF-ccf-4.0.6/getting_started/setup_vm/
+    ./run.sh app-dev.yml -e ccf_ver=4.0.6 -e platform=<sgx|virtual>
     ```
 
 ## Building

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,10 +24,10 @@ Follow the steps below to setup your development environment, replacing `<sgx|vi
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-4.0.6.tar.gz
-    tar xvzf ccf-4.0.6.tar.gz
-    cd CCF-ccf-4.0.6/getting_started/setup_vm/
-    ./run.sh app-dev.yml -e ccf_ver=4.0.6 -e platform=<sgx|virtual>
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-4.0.7.tar.gz
+    tar xvzf ccf-4.0.7.tar.gz
+    cd CCF-ccf-4.0.7/getting_started/setup_vm/
+    ./run.sh app-dev.yml -e ccf_ver=4.0.7 -e platform=<sgx|virtual>
     ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build/test (virtual)](https://github.com/microsoft/scitt-ccf-ledger/actions/workflows/build-test-virtual.yml/badge.svg)](https://github.com/microsoft/scitt-ccf-ledger/actions/workflows/build-test-virtual.yml)
 
+[![Build/test (all platforms)](https://github-private.visualstudio.com/microsoft/_apis/build/status%2Fmicrosoft.scitt-ccf-ledger?branchName=main)](https://github-private.visualstudio.com/microsoft/_build/latest?definitionId=540&branchName=main)
+
 This repository contains the source code for scitt-ccf-ledger, an application
 that runs on top of [CCF](https://ccf.dev/) implementing draft standards developed within the [IETF SCITT WG](https://datatracker.ietf.org/wg/scitt/about/). Its purpose is to provide provenance for artefacts in digital supply chains, increasing trust in those artefacts. scitt-ccf-ledger achieves this by allowing signed claims about artefacts to be submitted to a secure immutable ledger, and returning receipts which prove claims have been stored and registration policies applied.
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.16)
 if((NOT CMAKE_CXX_COMPILER)
    AND "$ENV{CXX}" STREQUAL ""
 )
-  set(CMAKE_CXX_COMPILER "/opt/oe_lvi/clang++-10")
-  message("Set CMAKE_CXX_COMPILER to /opt/oe_lvi/clang++-10")
+  set(CMAKE_CXX_COMPILER "clang++-11")
+  message("Set CMAKE_CXX_COMPILER to clang++-11")
 endif()
 
 project(scitt
@@ -30,9 +30,9 @@ if (CCF_UNSAFE)
     message(FATAL_ERROR "The unsafe CCF variant is only available on SGX builds.")
   endif()
 
-  find_package(ccf_sgx_unsafe 3.0.12 REQUIRED)
+  find_package(ccf_sgx_unsafe 4.0.7 REQUIRED)
 else()
-  find_package(ccf_${COMPILE_TARGET} 3.0.12 REQUIRED)
+  find_package(ccf_${COMPILE_TARGET} 4.0.7 REQUIRED)
 endif()
 
 if (ENABLE_PREFIX_TREE)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -30,9 +30,9 @@ if (CCF_UNSAFE)
     message(FATAL_ERROR "The unsafe CCF variant is only available on SGX builds.")
   endif()
 
-  find_package(ccf_sgx_unsafe 4.0.6 REQUIRED)
+  find_package(ccf_sgx_unsafe 4.0.7 REQUIRED)
 else()
-  find_package(ccf_${COMPILE_TARGET} 4.0.6 REQUIRED)
+  find_package(ccf_${COMPILE_TARGET} 4.0.7 REQUIRED)
 endif()
 
 if (ENABLE_PREFIX_TREE)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -30,9 +30,9 @@ if (CCF_UNSAFE)
     message(FATAL_ERROR "The unsafe CCF variant is only available on SGX builds.")
   endif()
 
-  find_package(ccf_sgx_unsafe 4.0.7 REQUIRED)
+  find_package(ccf_sgx_unsafe 4.0.6 REQUIRED)
 else()
-  find_package(ccf_${COMPILE_TARGET} 4.0.7 REQUIRED)
+  find_package(ccf_${COMPILE_TARGET} 4.0.6 REQUIRED)
 endif()
 
 if (ENABLE_PREFIX_TREE)

--- a/app/src/app_data.h
+++ b/app/src/app_data.h
@@ -10,7 +10,7 @@ namespace scitt
 {
   using TriggerAsynchronousOperation =
     std::function<void(std::string callback_url)>;
-  struct AsynchronousOperation
+  struct AsynchronousOperation // NOLINT(bugprone-exception-escape)
   {
     TriggerAsynchronousOperation trigger;
     std::string bind_address;

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -76,7 +76,7 @@ namespace scitt::cose
     COSEDecodeError(const std::string& msg) : std::runtime_error(msg) {}
   };
 
-  struct ProtectedHeader
+  struct ProtectedHeader // NOLINT(bugprone-exception-escape)
   {
     // All headers are optional here but optionality will later be validated
     // according to the COSE profile of the claim.

--- a/app/src/did/attested.h
+++ b/app/src/did/attested.h
@@ -72,7 +72,7 @@ namespace scitt::did
 
   // "error" field within "data" in AttestedResolution for
   // ATTESTED_FETCH_OE_SGX_ECDSA_V2
-  struct AttestedFetchError
+  struct AttestedFetchError // NOLINT(bugprone-exception-escape)
   {
     std::string message;
 
@@ -89,7 +89,7 @@ namespace scitt::did
     bool operator==(const AttestedFetchResult&) const = default;
   };
   // "data" field of AttestedResolution for ATTESTED_FETCH_OE_SGX_ECDSA_V2
-  struct AttestedFetchData
+  struct AttestedFetchData // NOLINT(bugprone-exception-escape)
   {
     std::string url;
     std::string nonce;

--- a/app/src/did/document.h
+++ b/app/src/did/document.h
@@ -15,7 +15,7 @@ namespace scitt::did
   static constexpr std::string_view VERIFICATION_METHOD_TYPE_JWK =
     "JsonWebKey2020";
 
-  struct Jwk
+  struct Jwk // NOLINT(bugprone-exception-escape)
   {
     std::string kty;
     std::optional<std::string> alg;
@@ -32,7 +32,7 @@ namespace scitt::did
   DECLARE_JSON_REQUIRED_FIELDS(Jwk, kty);
   DECLARE_JSON_OPTIONAL_FIELDS(Jwk, alg, n, e, crv, x, y, x5c);
 
-  struct DidVerificationMethod
+  struct DidVerificationMethod // NOLINT(bugprone-exception-escape)
   {
     std::string id;
     std::string type;
@@ -46,7 +46,7 @@ namespace scitt::did
   DECLARE_JSON_OPTIONAL_FIELDS_WITH_RENAMES(
     DidVerificationMethod, public_key_jwk, "publicKeyJwk");
 
-  struct DidDocument
+  struct DidDocument // NOLINT(bugprone-exception-escape)
   {
     std::string id;
     std::optional<std::vector<DidVerificationMethod>> verification_method;

--- a/app/src/did/resolver.h
+++ b/app/src/did/resolver.h
@@ -45,7 +45,7 @@ namespace scitt::did
     std::optional<DidWebOptions> did_web_options;
   };
 
-  struct DidResolutionResult
+  struct DidResolutionResult // NOLINT(bugprone-exception-escape)
   {
     DidDocument did_doc;
     DidResolutionMetadata resolution_metadata;

--- a/app/src/odata_error.h
+++ b/app/src/odata_error.h
@@ -9,7 +9,7 @@ namespace scitt
 {
   // CCF already defines an equivalent definition, but unfortunately it lacks a
   // operator==, which makes it impossible to use in an optional field.
-  struct ODataError
+  struct ODataError // NOLINT(bugprone-exception-escape)
   {
     std::string code;
     std::string message;

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -102,6 +102,12 @@ namespace scitt
 
     auto duration_ms = diff_timespec_ms(app_data.start_time, end);
 
+    if (duration_ms < 0)
+    {
+      SCITT_INFO(
+        "Computed request duration is negative: {} ms. Ignoring.", duration_ms);
+    }
+
     if (txid.has_value())
     {
       SCITT_INFO(
@@ -111,7 +117,7 @@ namespace scitt
         rpc_ctx->get_request_url(),
         rpc_ctx->get_response_status(),
         txid->to_str(),
-        duration_ms);
+        std::to_string(duration_ms));
     }
     else
     {
@@ -121,7 +127,7 @@ namespace scitt
         method,
         rpc_ctx->get_request_url(),
         rpc_ctx->get_response_status(),
-        duration_ms);
+        std::to_string(duration_ms));
     }
   }
 

--- a/app/unit-tests/main.cpp
+++ b/app/unit-tests/main.cpp
@@ -4,7 +4,7 @@
 #include <ccf/ds/logger.h>
 #include <gmock/gmock.h>
 
-int main(int argc, char** argv)
+int main(int argc, char** argv) // NOLINT(bugprone-exception-escape)
 {
   testing::InitGoogleMock(&argc, argv);
 

--- a/build.sh
+++ b/build.sh
@@ -9,10 +9,19 @@ PLATFORM=${PLATFORM:-sgx}
 CCF_UNSAFE=${CCF_UNSAFE:-OFF}
 ENABLE_PREFIX_TREE=${ENABLE_PREFIX_TREE:-OFF}
 BUILD_TESTS=${BUILD_TESTS:-ON}
-CC=${CC:-clang-10}
-CXX=${CXX:-clang++-10}
 ENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF}
 NINJA_FLAGS=${NINJA_FLAGS:-}
+
+if [ "$PLATFORM" = "sgx" ]; then
+    CC=${CC:-clang-11}
+    CXX=${CXX:-clang++-11}
+elif [ "$PLATFORM" = "virtual" ]; then
+    CC=${CC:-clang-15}
+    CXX=${CXX:-clang++-15}
+else
+    echo "Unknown platform: $PLATFORM, must be 'sgx' or 'virtual'"
+    exit 1
+fi
 
 git submodule sync
 git submodule update --init --recursive

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -54,10 +54,6 @@ COPY --from=builder /usr/src/app/mrenclave.txt mrenclave.txt
 COPY app/fetch-did-web-doc.py /tmp/scitt/fetch-did-web-doc.py
 COPY --from=builder /usr/src/app/attested-fetch /tmp/scitt/
 
-COPY ./docker/start-app.sh /usr/src/app/start-app.sh
-
-RUN ["chmod", "+x", "/usr/src/app/start-app.sh"]
-
 WORKDIR /host/node
 
-ENTRYPOINT [ "/usr/src/app/start-app.sh" ]
+ENTRYPOINT [ "cchost" ]

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=4.0.6
+ARG CCF_VERSION=4.0.7
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-sgx as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=4.0.7
+ARG CCF_VERSION=4.0.6
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-sgx as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=3.0.12
+ARG CCF_VERSION=4.0.7
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-sgx as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE
@@ -7,7 +7,7 @@ ARG SCITT_VERSION_OVERRIDE
 COPY ./3rdparty/attested-fetch /tmp/attested-fetch/
 RUN mkdir /tmp/attested-fetch-build && \
     cd /tmp/attested-fetch-build && \
-    CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja \
+    CC="clang-11" CXX="clang++-11" cmake -GNinja \
     -DCOMPILE_TARGET="sgx" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=/usr/src/app/attested-fetch \
@@ -22,7 +22,7 @@ RUN /opt/openenclave/bin/oesign dump -e libafetch.enclave.so.signed | sed -n "s/
 COPY ./app /tmp/app/
 RUN mkdir /tmp/app-build && \
     cd /tmp/app-build && \
-    CC="/opt/oe_lvi/clang-10" CXX="/opt/oe_lvi/clang++-10" cmake -GNinja \
+    CC="clang-11" CXX="clang++-11" cmake -GNinja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=/usr/src/app \
     -DCOMPILE_TARGET="sgx" \

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=3.0.12
+ARG CCF_VERSION=4.0.7
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-virtual as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y libcurl4-openssl-dev
 COPY ./3rdparty/attested-fetch /tmp/attested-fetch/
 RUN mkdir /tmp/attested-fetch-build && \
     cd /tmp/attested-fetch-build && \
-    CC=clang-10 CXX=clang++-10 cmake -GNinja \
+    CC=clang-15 CXX=clang++-15 cmake -GNinja \
     -DCOMPILE_TARGET="virtual" \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=/usr/src/app/attested-fetch \
@@ -19,7 +19,7 @@ RUN mkdir /tmp/attested-fetch-build && \
 COPY ./app /tmp/app/
 RUN mkdir /tmp/app-build && \
     cd /tmp/app-build && \
-    CC=clang-10 CXX=clang++-10 cmake -GNinja \
+    CC=clang-15 CXX=clang++-15 cmake -GNinja \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=/usr/src/app \
     -DCOMPILE_TARGET="virtual" \

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=4.0.7
+ARG CCF_VERSION=4.0.6
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-virtual as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -41,10 +41,6 @@ COPY --from=builder /usr/src/app/share/VERSION VERSION
 COPY app/fetch-did-web-doc.py /tmp/scitt/fetch-did-web-doc.py
 COPY --from=builder /usr/src/app/attested-fetch /tmp/scitt/
 
-COPY ./docker/start-app.sh /usr/src/app/start-app.sh
-
-RUN ["chmod", "+x", "start-app.sh"]
-
 WORKDIR /host/node
 
-ENTRYPOINT [ "/usr/src/app/start-app.sh" ]
+ENTRYPOINT [ "cchost" ]

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=4.0.6
+ARG CCF_VERSION=4.0.7
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-virtual as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -26,7 +26,7 @@ do a docker build locally but inside of the development version of CCF image:
 - Run a build inside of the CCF docker image:
 
     ```
-    CCF_VERSION="4.0.6"
+    CCF_VERSION="4.0.7"
     docker run -it --rm \
         -w /__w/1/s -v $(pwd):/__w/1/s \
         -v /var/run/docker.sock:/var/run/docker.sock \

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -26,7 +26,7 @@ do a docker build locally but inside of the development version of CCF image:
 - Run a build inside of the CCF docker image:
 
     ```
-    CCF_VERSION="4.0.7"
+    CCF_VERSION="4.0.6"
     docker run -it --rm \
         -w /__w/1/s -v $(pwd):/__w/1/s \
         -v /var/run/docker.sock:/var/run/docker.sock \

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -26,7 +26,7 @@ do a docker build locally but inside of the development version of CCF image:
 - Run a build inside of the CCF docker image:
 
     ```
-    CCF_VERSION="3.0.12"
+    CCF_VERSION="4.0.7"
     docker run -it --rm \
         -w /__w/1/s -v $(pwd):/__w/1/s \
         -v /var/run/docker.sock:/var/run/docker.sock \

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,7 +13,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==4.0.6",
+        "ccf==4.0.7",
         "cryptography==40.*",  # needs to match ccf
         "httpx",
         "cbor2",

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,7 +13,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==4.0.7",
+        "ccf==4.0.6",
         "cryptography==40.*",  # needs to match ccf
         "httpx",
         "cbor2",

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,8 +13,8 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==3.0.12",
-        "cryptography==39.*",  # needs to match ccf
+        "ccf==4.0.7",
+        "cryptography==40.*",  # needs to match ccf
         "httpx",
         "cbor2",
         # TODO: remove this once pycose >= 1.0.2 is released

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -32,9 +32,9 @@ file_name_regex="^[[:lower:]0-9_]+$"
 unformatted_files=""
 badly_named_files=""
 for file in $(git ls-files "$@" | grep -e '\.h$' -e '\.hpp$' -e '\.cpp$' -e '\.c$' -e '\.proto$'); do
-  if ! clang-format-10 -n -Werror -style=file "$file"; then
+  if ! clang-format-11 -n -Werror -style=file "$file"; then
     if $fix ; then
-      clang-format-10 -style=file -i "$file"
+      clang-format-11 -style=file -i "$file"
     fi
     if [ "$unformatted_files" != "" ]; then
       unformatted_files+=$'\n'

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -24,6 +24,8 @@ from .async_utils import EventLoopThread, race_tasks
 LOG.level("FAIL", no=60, color="<red>")
 LOG.level("FATAL", no=60, color="<red>")
 
+CCHOST_PID_FILE_NAME = "cchost.pid"
+
 
 class CCHost(EventLoopThread):
     binary: str
@@ -108,7 +110,7 @@ class CCHost(EventLoopThread):
             faketime_lib = Path(
                 os.getenv(
                     "LIBFAKETIME",
-                    "/usr/lib/x86_64-linux-gnu/faketime/libfaketimeMT.so.1",
+                    "/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1",
                 )
             )
 
@@ -121,6 +123,12 @@ class CCHost(EventLoopThread):
                 LOG.warning("Could not find faketime library")
 
     def restart(self) -> None:
+        # Delete PID file to let cchost restart
+        # https://github.com/microsoft/CCF/pull/5361
+        cchost_pid_file_path = self.workspace.joinpath(CCHOST_PID_FILE_NAME)
+        if os.path.exists(cchost_pid_file_path):
+            os.remove(cchost_pid_file_path)
+
         self._set_event(self.restart_request)
         self.wait_ready()
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,5 +3,5 @@ httpx
 pytest
 loguru
 aiotools
-ccf==4.0.6
+ccf==4.0.7
 cryptography==40.*

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,3 +3,5 @@ httpx
 pytest
 loguru
 aiotools
+ccf==4.0.7
+cryptography==40.*

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,5 +3,5 @@ httpx
 pytest
 loguru
 aiotools
-ccf==4.0.7
+ccf==4.0.6
 cryptography==40.*


### PR DESCRIPTION
- Update SCITT app to CCF 4.0.7 and modify source code, tests, and pipelines definition following the new version updates
- The Virtual ASAN build job has been modified to be able to build CCF from source correctly by installing the required dependencies
- Dockerfiles have been modified to revert the changes made in https://github.com/microsoft/scitt-ccf-ledger/pull/144

Note: the app was not updated to the latest CCF patch versions (4.0.8 or 4.0.9) since those include a major version upgrade of OpenSSL that requires more work and introduce a non-minimal performance regression (~20% drop in throughput) for operations that require certificate authentication.