### PR TITLE
Add utility scripts for demos and testing

### DIFF
--- a/demo/cts_poc/README.md
+++ b/demo/cts_poc/README.md
@@ -1,0 +1,107 @@
+# CTS PoC Demo
+
+This demo provides a simple and generic Proof of Concept for a Code Transparency Service (CTS) using the SCITT CCF ledger. The scripts provided in this folder allow configuring a new SCITT CCF instance, generating and submitting claims in COSE format, getting a SCITT receipt for a submitted claim, and verifying the receipt validity. 
+
+## Prerequisites
+
+- A Certificate Authority (CA) certificate and private key are required to configure the SCITT instance. The CA certificate and private key must be provided by the SCITT Operator. For getting a sample pair for testing purposes, you can use [this Python script](../../test/infra/generate_cacert.py) after installing the required [test dependencies](../../test/requirements.txt). For example:
+
+    ```python
+    python test/infra/generate_cacert.py --output-dir "demo-poc/x509_roots" 
+    ```
+
+- Access to the CCF member certificate and private key is required to submit proposals to the CCF network. The provided member must be registered into the target CCF network. For a local SCITT instance (e.g., after running the [start.sh](../../start.sh) script), the member certificate and private key are generated automatically and stored in the `workspace` folder (`member0_cert.pem` and `member0_privk.pem`). For a remote SCITT instance, the member certificate and private key must be provided by the SCITT Operator. 
+
+## Instructions
+
+All the commands must be run from the root of the repository.
+
+### CTS Operator
+
+1. Start a new CCF network with a single member. For a local instance, run the following commands (set the `PLATFORM` variable first):
+
+    ```bash
+    export PLATFORM=<virtual|sgx>
+    ./build.sh
+    ./start.sh
+    ```
+
+    Alternatively, set the `SCITT_URL` variable if you are targeting a remote instance already deployed and publicly accessible:
+
+    ```
+    export SCITT_URL=<address>
+    ```
+
+    If the `SCITT_URL` variable is not set, the scripts will target a local instance by default (`http://localhost:8000`).
+
+2. Run the [`operator-demo.sh`](operator-demo.sh) script to activate the CCF member, configure the SCITT instance, and open the CCF network (all operations are idempotent and can be run on an already-configured instance, if needed).
+
+    For running the script, you are required to provide the following environment variables:
+
+    - `MEMBER_CERT_PATH`: Path to the member certificate PEM file.
+
+    - `MEMBER_KEY_PATH`: Path to the member private key PEM file.
+
+    - `CACERT_PATH`: Path to the CA certificate PEM file.
+
+    - `SCITT_CONFIG_PATH`: Path to the SCITT configuration JSON file. The JSON file needs to contain only the content of the `set_scitt_configuration` action. For example:
+
+        ```json
+        {
+           "authentication": {
+               "allow_unauthenticated": true
+           }
+        }
+        ```
+
+        Please refer to [this document](../../docs/configuration.md#scitt-configuration) for more details on the configuration options.
+
+    Example command:
+
+    ```bash
+    MEMBER_CERT_PATH="workspace/member0_cert.pem" MEMBER_KEY_PATH="workspace/member0_privk.pem" CACERT_PATH="demo-poc/x509_roots/cacert.pem" SCITT_CONFIG_PATH="demo-poc/configs/scitt_config.json" ./demo/cts_poc/operator-demo.sh
+    ```
+
+### CTS client
+
+1. [You can skip this step, if you already have a valid COSE claim to submit] Generate a valid COSE claim to submit to the SCITT ledger by running the [`claim-generator.sh`](claim-generator.sh) script.
+
+    For running the script, you are required to provide the following environment variables:
+
+    - `CACERT_PATH`: Path to the CA certificate PEM file.
+
+    - `PRIVATE_KEY_PATH`: Path to the CA private key PEM file.
+
+    - `CLAIM_CONTENT_PATH`: Path to the JSON/text file containing the claim content. For example:
+
+        ```json
+        {
+            "foo": "bar"
+        }
+        ```
+
+    - `COSE_CLAIMS_OUTPUT_PATH`: Path to the output file where the COSE file containing the signed claim will be stored.
+
+    - `CLAIM_CONTENT_TYPE`: Optionally, you can provide the content type of the claim content. If not provided, the content type will be set to `application/json` by default.
+    
+    Example command:
+
+    ```bash
+    CACERT_PATH="demo-poc/x509_roots/cacert.pem" PRIVATE_KEY_PATH="demo-poc/x509_roots/cacert_privk.pem" CLAIM_CONTENT_PATH="demo-poc/claims/claims.json" COSE_CLAIMS_OUTPUT_PATH="demo-poc/claims/claims.cose" ./demo/cts_poc/claim-generator.sh
+    ```
+
+2. Submit the COSE claim to the SCITT ledger and verify a receipt for the committed transaction by running the [`client-demo.sh`](client-demo.sh) script.
+
+    The script will submit the COSE claim to the SCITT ledger and will wait for a receipt to be generated. Once the receipt is generated, the script will print the CBOR receipt in a readable format, and verify the receipt validity.
+
+    For running the script, you are required to provide the following environment variables:
+
+    - `COSE_CLAIMS_PATH`: Path to the COSE file containing the signed claim.
+
+    - `OUTPUT_FOLDER`: Path to the folder where script artifacts (e.g., the receipt file) will be stored.
+
+    Example command:
+
+    ```bash
+    COSE_CLAIMS_PATH="demo-poc/claims/claims.cose" OUTPUT_FOLDER="test-folder" ./demo/cts_poc/client-demo.sh
+    ```

--- a/demo/cts_poc/claim-generator.sh
+++ b/demo/cts_poc/claim-generator.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+### Simple script to generate a signed claim to submit to the SCITT ledger
+
+set -e
+
+# Variables
+: "${CACERT_PATH:?"variable not set. Please define the path to the CA certificate PEM file"}"
+: "${PRIVATE_KEY_PATH:?"variable not set. Please define the path to the private key PEM file"}"
+: "${CLAIM_CONTENT_PATH:?"variable not set. Please define the path to the json/txt file to use as content for the claim"}"
+: "${COSE_CLAIMS_OUTPUT_PATH:?"variable not set. Please define the content type to use (e.g., \"application/json\")"}"
+
+CLAIM_CONTENT_TYPE=${CLAIM_CONTENT_TYPE:-"application/json"}
+
+# Activate environment and install pyscitt local library
+source venv/bin/activate
+pip install --disable-pip-version-check -q -e ./pyscitt
+
+# Create and sign claim with the provided content
+echo -e "\nCreating and signing claim"
+scitt sign \
+    --claims "$CLAIM_CONTENT_PATH" \
+    --content-type "$CLAIM_CONTENT_TYPE" \
+    --key "$PRIVATE_KEY_PATH" \
+    --x5c "$CACERT_PATH" \
+    --out "$COSE_CLAIMS_OUTPUT_PATH"
+
+echo -e "\nScript completed successfully"

--- a/demo/cts_poc/client-demo.sh
+++ b/demo/cts_poc/client-demo.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+### Client script to submit a claim to the SCITT ledger and verify the receipt 
+
+set -e
+
+# Variables
+: "${COSE_CLAIMS_PATH:?"variable not set. Please define the path to the COSE claim to register into the ledger"}"
+: "${OUTPUT_FOLDER:?"variable not set. Please define the output folder to use to store script artifacts"}"
+
+SCITT_URL=${SCITT_URL:-"https://127.0.0.1:8000"}
+
+# Create output folder
+mkdir -p "$OUTPUT_FOLDER"
+
+echo -e "\nInstalling pyscitt CLI"
+if [ ! -f "venv/bin/activate" ]; then
+    python3.8 -m venv "venv"
+fi
+
+# Activate environment and install pyscitt local library
+source venv/bin/activate
+pip install --disable-pip-version-check -q -e ./pyscitt
+
+# Get service parameters
+echo -e "\nGetting service parameters"
+SERVICE_PARAMS_FOLDER="$OUTPUT_FOLDER"/service_params
+mkdir -p "$SERVICE_PARAMS_FOLDER"
+
+curl -k -f "$SCITT_URL"/parameters > "$SERVICE_PARAMS_FOLDER"/scitt.json
+
+echo -e "\nSubmitting claim to the ledger and getting receipt for the committed transaction"
+RECEIPT_FOLDER="$OUTPUT_FOLDER"/receipts
+mkdir -p "$RECEIPT_FOLDER"
+RECEIPT_PATH="$RECEIPT_FOLDER"/claims.receipt.cbor
+
+# Submit signed claim
+scitt submit "$COSE_CLAIMS_PATH" \
+    --receipt "$RECEIPT_PATH" \
+    --url "$SCITT_URL" \
+    --development
+
+# View receipt
+echo -e "\nViewing decoded receipt content"
+scitt pretty-receipt "$RECEIPT_PATH"
+
+# Verify receipt
+echo -e "\nVerifying receipt"
+scitt validate "$COSE_CLAIMS_PATH" \
+    --receipt "$RECEIPT_PATH" \
+    --service-trust-store "$SERVICE_PARAMS_FOLDER"
+
+echo -e "\nScript completed successfully"

--- a/demo/cts_poc/operator-demo.sh
+++ b/demo/cts_poc/operator-demo.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+### Script to setup and configure a SCITT CCF instance with custom parameters
+
+set -e
+
+# Variables
+: "${MEMBER_CERT_PATH:?"variable not set. Please define the path to the CCF member certificate PEM file"}"
+: "${MEMBER_KEY_PATH:?"variable not set. Please define the path to the CCF member key PEM file"}"
+: "${CACERT_PATH:?"variable not set. Please define the path to the CA certificate PEM file"}"
+: "${SCITT_CONFIG_PATH:?"variable not set. Please define the path to SCITT configuration JSON file"}"
+
+SCITT_URL=${SCITT_URL:-"https://127.0.0.1:8000"}
+
+echo -e "\nInstalling pyscitt CLI"
+if [ ! -f "venv/bin/activate" ]; then
+    python3.8 -m venv "venv"
+fi
+
+# Activate environment and install pyscitt local library
+source venv/bin/activate
+pip install --disable-pip-version-check -q -e ./pyscitt
+
+echo -e "\nActivating member"
+
+# Send Proposal to activate member
+scitt governance activate_member \
+    --url "$SCITT_URL" \
+    --member-key "$MEMBER_KEY_PATH" \
+    --member-cert "$MEMBER_CERT_PATH" \
+    --development
+
+echo -e "\nConfiguring CCF instance"
+
+# Send proposal to set CA certs
+scitt governance propose_ca_certs \
+    --name x509_roots \
+    --ca-certs "$CACERT_PATH" \
+    --url "$SCITT_URL" \
+    --member-key "$MEMBER_KEY_PATH" \
+    --member-cert "$MEMBER_CERT_PATH" \
+    --development
+
+# Send proposal to set SCITT configuration 
+scitt governance propose_configuration \
+    --configuration "$SCITT_CONFIG_PATH" \
+    --url "$SCITT_URL" \
+    --member-key "$MEMBER_KEY_PATH" \
+    --member-cert "$MEMBER_CERT_PATH" \
+    --development
+
+echo -e "\Opening the network"
+
+# Get current service certificate
+SERVICE_CERT_PATH="service_cert.pem"
+curl -k "$SCITT_URL"/node/network | jq -r .service_certificate > "$SERVICE_CERT_PATH"
+
+# Send the proposal to open the network 
+scitt governance propose_open_service \
+    --url "$SCITT_URL" \
+    --member-key "$MEMBER_KEY_PATH" \
+    --member-cert "$MEMBER_CERT_PATH" \
+    --next-service-certificate "$SERVICE_CERT_PATH" \
+    --development
+
+# Remove the service certificate file
+rm "$SERVICE_CERT_PATH"
+
+echo -e "\nScript completed successfully"

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,17 +26,9 @@ Please refer to the corresponding scripts for the full list of available variabl
 
 ## Build and push docker images to a container registry
 
-After building a docker image, you can push it to a container registry. For example, to build and push a docker image to an Azure Container Registry (ACR) for the SCITT application running in SGX, you can run the following set of commands:
+After building a docker image, you can push it to a container registry (e.g., Azure Container Registry). You can use the `push_image.sh` script to automatically build and push the image to ACR:
 
 ```bash
-ACR="<acr-name>" # Define your ACR name here
-
 # Build docker image for SGX
-PLATFORM="sgx" DOCKER_TAG="$ACR.azurecr.io/scitt-sgx:latest" ./docker/build.sh
-
-# Login to ACR
-az acr login --name $ACR 
-
-# Push docker image to ACR
-docker push $ACR.azurecr.io/scitt-sgx:latest
+./docker/push_image.sh
 ```

--- a/docker/push_image.sh
+++ b/docker/push_image.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+### Script to build and push a docker image to ACR
+
+set -e
+
+# Variables
+ACR=${ACR:-"scittoss"}
+BASE_IMAGE_NAME=${BASE_IMAGE_NAME:-"scitt"}
+PLATFORM=${PLATFORM:-"sgx"}
+TAG=${TAG:-"latest"}
+
+# Derived variables
+DOCKER_TAG="$ACR.azurecr.io/$BASE_IMAGE_NAME-$PLATFORM:$TAG"
+
+echo "Building docker image for $PLATFORM platform with tag $DOCKER_TAG"
+
+# Build docker image for SGX
+PLATFORM=$PLATFORM DOCKER_TAG=$DOCKER_TAG ./docker/build.sh
+
+# Login to Azure
+if az account show > /dev/null; then
+  echo "Already logged in to Azure"
+else
+  echo "Logging in to Azure"
+  az login --only-show-errors > /dev/null
+fi
+
+# Login to ACR
+echo "Logging into ACR $ACR"
+az acr login --name $ACR --only-show-errors
+
+echo "Pushing docker image $DOCKER_TAG to ACR $ACR"
+
+# Push docker image to ACR
+docker push "$DOCKER_TAG"

--- a/test/infra/generate_cacert.py
+++ b/test/infra/generate_cacert.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import argparse
 
 from cryptography import x509

--- a/test/infra/generate_cacert.py
+++ b/test/infra/generate_cacert.py
@@ -1,15 +1,13 @@
 import argparse
+
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
-from x5chain_certificate_authority import X5ChainCertificateAuthority
 from loguru import logger
 
-def generate_ca_cert_and_key(
-    output_dir: str,
-    alg: str,
-    key_type: str,
-    ec_curve: str    
-):
+from .x5chain_certificate_authority import X5ChainCertificateAuthority
+
+
+def generate_ca_cert_and_key(output_dir: str, alg: str, key_type: str, ec_curve: str):
     # Create a new X5ChainCertificateAuthority instance
     untrusted_ca = X5ChainCertificateAuthority(kty=key_type)
 
@@ -24,6 +22,10 @@ def generate_ca_cert_and_key(
 
     # Write the ca cert to a file
     cert_bundle = b""
+
+    if not identity.x5c:
+        raise ValueError("No x5c field in identity")
+
     for cert in identity.x5c:
         pemcert = x509.load_pem_x509_certificate(cert.encode())
         cert_bundle += pemcert.public_bytes(serialization.Encoding.PEM)
@@ -33,19 +35,34 @@ def generate_ca_cert_and_key(
     with open(output_cacert_file, "wb") as f:
         f.write(cert_bundle)
 
+
 if __name__ == "__main__":
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description="Generate a sample pair of CA cert and associated private key.")
-    parser.add_argument("--output-dir", type=str, help="The directory to output the generated files to.")
-    parser.add_argument("--alg", type=str, help="The algorithm to use to generate the certificate chain.", default="ES256")
-    parser.add_argument("--key-type", type=str, help="The key type to use to generate the certificate chain", default="ec")
-    parser.add_argument("--ec-curve", type=str, help="The Elliptic Curve to use for the key.", default="P-256")
+    parser = argparse.ArgumentParser(
+        description="Generate a sample pair of CA cert and associated private key."
+    )
+    parser.add_argument(
+        "--output-dir", type=str, help="The directory to output the generated files to."
+    )
+    parser.add_argument(
+        "--alg",
+        type=str,
+        help="The algorithm to use to generate the certificate chain.",
+        default="ES256",
+    )
+    parser.add_argument(
+        "--key-type",
+        type=str,
+        help="The key type to use to generate the certificate chain",
+        default="ec",
+    )
+    parser.add_argument(
+        "--ec-curve",
+        type=str,
+        help="The Elliptic Curve to use for the key.",
+        default="P-256",
+    )
     args = parser.parse_args()
 
     # Generate the CA cert and key
-    generate_ca_cert_and_key(
-        args.output_dir,
-        args.alg,
-        args.key_type,
-        args.ec_curve
-    )
+    generate_ca_cert_and_key(args.output_dir, args.alg, args.key_type, args.ec_curve)

--- a/test/infra/generate_cacert.py
+++ b/test/infra/generate_cacert.py
@@ -1,0 +1,51 @@
+import argparse
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from x5chain_certificate_authority import X5ChainCertificateAuthority
+from loguru import logger
+
+def generate_ca_cert_and_key(
+    output_dir: str,
+    alg: str,
+    key_type: str,
+    ec_curve: str    
+):
+    # Create a new X5ChainCertificateAuthority instance
+    untrusted_ca = X5ChainCertificateAuthority(kty=key_type)
+
+    # Create a new identity with the input parameters
+    identity = untrusted_ca.create_identity(alg=alg, kty=key_type, ec_curve=ec_curve)
+
+    # Write the private key to a file
+    output_key_file = f"{output_dir}/cacert_privk.pem"
+    logger.info(f"Writing private key to {output_key_file}")
+    with open(output_key_file, "w") as f:
+        f.write(identity.private_key)
+
+    # Write the ca cert to a file
+    cert_bundle = b""
+    for cert in identity.x5c:
+        pemcert = x509.load_pem_x509_certificate(cert.encode())
+        cert_bundle += pemcert.public_bytes(serialization.Encoding.PEM)
+
+    output_cacert_file = f"{output_dir}/cacert.pem"
+    logger.info(f"Writing cacert to {output_cacert_file}")
+    with open(output_cacert_file, "wb") as f:
+        f.write(cert_bundle)
+
+if __name__ == "__main__":
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Generate a sample pair of CA cert and associated private key.")
+    parser.add_argument("--output-dir", type=str, help="The directory to output the generated files to.")
+    parser.add_argument("--alg", type=str, help="The algorithm to use to generate the certificate chain.", default="ES256")
+    parser.add_argument("--key-type", type=str, help="The key type to use to generate the certificate chain", default="ec")
+    parser.add_argument("--ec-curve", type=str, help="The Elliptic Curve to use for the key.", default="P-256")
+    args = parser.parse_args()
+
+    # Generate the CA cert and key
+    generate_ca_cert_and_key(
+        args.output_dir,
+        args.alg,
+        args.key_type,
+        args.ec_curve
+    )


### PR DESCRIPTION
- Add script to generate a signed COSE claim from a CA cert and key (alternative to using a DID document)
- Add script to generate sample CA cert and key for local testing
- Add demo script to set up governance in a SCITT CCF instance (e.g., activate member, open network, apply SCITT configuration)
- Add demo script to run client operations using the pyscitt CLI (e.g., submit claim and get receipt, visualize receipt, verify receipt) 
- Add script to push a SCITT docker image to ACR