### PR TITLE
Fix security vulnerabilities related to cryptography package

### DIFF
--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,7 +13,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==4.0.10", # We temporarily bump this to 4.0.10 instead of 4.0.7 (current CCF version) so that we can upgrade cryptography to a 41.* version, which fixes several security vulnerabilities.
+        "ccf==4.0.10",  # We temporarily bump this to 4.0.10 instead of 4.0.7 (current CCF version) so that we can upgrade cryptography to a 41.* version, which fixes several security vulnerabilities.
         "cryptography==41.*",  # needs to match ccf
         "httpx",
         "cbor2",

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -13,8 +13,8 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==4.0.7",
-        "cryptography==40.*",  # needs to match ccf
+        "ccf==4.0.10", # We temporarily bump this to 4.0.10 instead of 4.0.7 (current CCF version) so that we can upgrade cryptography to a 41.* version, which fixes several security vulnerabilities.
+        "cryptography==41.*",  # needs to match ccf
         "httpx",
         "cbor2",
         # TODO: remove this once pycose >= 1.0.2 is released

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,5 +3,5 @@ httpx
 pytest
 loguru
 aiotools
-ccf==4.0.7
-cryptography==40.*
+ccf==4.0.10 # We temporarily bump this to 4.0.10 instead of 4.0.7 (current CCF version) so that we can upgrade cryptography to a 41.* version, which fixes several security vulnerabilities.
+cryptography==41.*


### PR DESCRIPTION
See https://github.com/microsoft/scitt-ccf-ledger/security/dependabot.

We temporarily bump the `ccf` python package to 4.0.10 instead of 4.0.7 (current CCF version) so that we can upgrade cryptography to a 41.* version, which fixes the above security vulnerabilities.