### PR TITLE
defaults to did resolver if service params not passed when validating

### DIFF
--- a/pyscitt/pyscitt/cli/validate_cose.py
+++ b/pyscitt/pyscitt/cli/validate_cose.py
@@ -4,7 +4,7 @@ import argparse
 from pathlib import Path
 from typing import Optional
 
-from ..verify import StaticTrustStore, DIDResolverTrustStore, verify_receipt
+from ..verify import DIDResolverTrustStore, StaticTrustStore, TrustStore, verify_receipt
 
 
 def validate_cose_with_receipt(
@@ -19,6 +19,7 @@ def validate_cose_with_receipt(
     else:
         receipt = receipt_path.read_bytes()
 
+    service_trust_store: TrustStore
     if service_trust_store_path is None:
         service_trust_store = DIDResolverTrustStore()
     else:

--- a/pyscitt/pyscitt/cli/validate_cose.py
+++ b/pyscitt/pyscitt/cli/validate_cose.py
@@ -20,7 +20,7 @@ def validate_cose_with_receipt(
         receipt = receipt_path.read_bytes()
 
     service_trust_store: TrustStore
-    if service_trust_store_path is None:
+    if not service_trust_store_path:
         service_trust_store = DIDResolverTrustStore()
     else:
         service_trust_store = StaticTrustStore.load(service_trust_store_path)

--- a/pyscitt/pyscitt/cli/validate_cose.py
+++ b/pyscitt/pyscitt/cli/validate_cose.py
@@ -4,20 +4,25 @@ import argparse
 from pathlib import Path
 from typing import Optional
 
-from ..verify import StaticTrustStore, verify_receipt
+from ..verify import StaticTrustStore, DIDResolverTrustStore, verify_receipt
 
 
 def validate_cose_with_receipt(
-    cose_path: Path, receipt_path: Optional[Path], service_trust_store_path: Path
+    cose_path: Path,
+    receipt_path: Optional[Path],
+    service_trust_store_path: Optional[Path],
 ):
-    service_trust_store = StaticTrustStore.load(service_trust_store_path)
-
     cose = cose_path.read_bytes()
 
     if receipt_path is None:
         receipt = None
     else:
         receipt = receipt_path.read_bytes()
+
+    if service_trust_store_path is None:
+        service_trust_store = DIDResolverTrustStore()
+    else:
+        service_trust_store = StaticTrustStore.load(service_trust_store_path)
 
     verify_receipt(cose, service_trust_store, receipt)
     print(f"COSE document is valid: {cose_path}")
@@ -33,9 +38,9 @@ def cli(fn):
     )
     parser.add_argument(
         "--service-trust-store",
-        required=True,
         type=Path,
-        help="Folder containing JSON parameter files of SCITT services to trust",
+        help="""Optional folder containing JSON parameter files of SCITT services to trust,
+        otherwise use DID resolver and expect DID in receipt""",
     )
 
     def cmd(args):

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -558,7 +558,7 @@ def embed_receipt_in_cose(buf: bytes, receipt: bytes) -> bytes:
     outer = cbor2.loads(buf)
     if hasattr(outer, "tag"):
         assert outer.tag == 18  # COSE_Sign1
-        val = outer.value
+        val = outer.value  # type: ignore[attr-defined]
     else:
         val = outer
     [_, uhdr, _, _] = val

--- a/pyscitt/pyscitt/prefix_tree.py
+++ b/pyscitt/pyscitt/prefix_tree.py
@@ -104,7 +104,7 @@ class ReadReceipt:
 
     @classmethod
     def decode(cls, data: bytes):
-        return cls.from_cose_obj(cbor2.loads(data))
+        return cls.from_cose_obj(cbor2.loads(data))  # type: ignore[arg-type]
 
     def verify(
         self, claim: Union[Sign1Message, bytes], service_params: ServiceParameters
@@ -171,10 +171,10 @@ class TreeReceipt:
     @classmethod
     def decode(cls, data: bytes) -> "TreeReceipt":
         cose_obj = cbor2.loads(data)
-        headers_encoded = cose_obj.pop(0)
+        headers_encoded = cose_obj.pop(0)  # type: ignore[attr-defined]
         headers = CoseBase._parse_header(cbor2.loads(headers_encoded), True)
-        root = cose_obj.pop(0)
-        receipt_contents = ReceiptContents.from_cose_obj(headers, cose_obj.pop(0))
+        root = cose_obj.pop(0)  # type: ignore[attr-defined]
+        receipt_contents = ReceiptContents.from_cose_obj(headers, cose_obj.pop(0))  # type: ignore[attr-defined]
         return TreeReceipt(headers_encoded, headers, root, receipt_contents)
 
     @property

--- a/pyscitt/pyscitt/receipt.py
+++ b/pyscitt/pyscitt/receipt.py
@@ -162,7 +162,7 @@ class Receipt:
 
     @classmethod
     def decode(cls, data: bytes) -> "Receipt":
-        return cls.from_cose_obj(cbor2.loads(data))
+        return cls.from_cose_obj(cbor2.loads(data))  # type: ignore[arg-type]
 
     def countersign_structure(self, claim: Sign1Message) -> bytes:
         context = "CounterSignatureV2"

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -16,7 +16,7 @@ setup(
         "ccf==4.0.10",  # We temporarily bump this to 4.0.10 instead of 4.0.7 (current CCF version) so that we can upgrade cryptography to a 41.* version, which fixes several security vulnerabilities.
         "cryptography==41.*",  # needs to match ccf
         "httpx",
-        "cbor2",
+        "cbor2==5.4.*",
         # TODO: remove this once pycose >= 1.0.2 is released
         "pycose @ git+https://github.com/TimothyClaeys/pycose@94db358eda640966c0e0e9148110b6c66763f9e5#egg=pycose",
         "pyjwt",

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -3,7 +3,6 @@
 
 import os
 
-import pycose.headers
 import pytest
 
 from pyscitt import crypto, governance

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -9,8 +9,8 @@ import pycose
 import pytest
 from pycose.messages import Sign1Message
 
-from pyscitt import crypto, governance
-from pyscitt.client import Client, ServiceError
+from pyscitt import crypto
+from pyscitt.client import Client
 from pyscitt.crypto import cert_pem_to_der
 from pyscitt.verify import verify_receipt
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -18,7 +18,7 @@ from .infra.assertions import service_error
 from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 
 
-class NonCanonicalEncoder(cbor2.encoder.CBOREncoder):
+class NonCanonicalEncoder(cbor2.encoder.CBOREncoder):  # type: ignore[name-defined]
     """
     A variant of cbor2's encoder that introduces deliberate non-canonical
     encodings.
@@ -154,8 +154,8 @@ class TestNonCanonicalEncoding:
         tx = client.submit_claim(claim).tx
         embedded = client.get_claim(tx, embed_receipt=True)
 
-        original_pieces = cbor2.loads(claim).value
-        updated_pieces = cbor2.loads(embedded).value
+        original_pieces = cbor2.loads(claim).value  # type: ignore[attr-defined]
+        updated_pieces = cbor2.loads(embedded).value  # type: ignore[attr-defined]
 
         # Any part of the message that is cryptographically bound needs to be preserved.
         # These are respectively, the protected header, the payload and the signature.

--- a/test/test_tracing.py
+++ b/test/test_tracing.py
@@ -3,8 +3,6 @@
 
 import re
 
-import pytest
-
 from pyscitt.client import Client
 
 from .infra.assertions import service_error


### PR DESCRIPTION
Currently ledger can issue receipts with DID but the CLI cannot validate them using the DID resolver. The CLI expects service params to be present.

Adding a fallback to use the DID resolver if the service params are not provided when validating the receipt