### PR TITLE
Temporarily disable flaky asan build

### DIFF
--- a/.pipelines/azure-pipelines.yml
+++ b/.pipelines/azure-pipelines.yml
@@ -85,24 +85,29 @@ stages:
             DOCKER: 1
             DOCKER_IN_DOCKER: 1
 
-      - template: common.yml
-        parameters:
-          Name: test_san
-          DisplayName: Test (Sanitizers, with prefix tree)
-          Platform: virtual
-          BuildCCF:
-            Version: ${{ parameters.CCF_VERSION }}
-            CMakeArgs: -DSAN=ON -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF
-          Environment:
-            CMAKE_BUILD_TYPE: Debug
-            ENABLE_PREFIX_TREE: ON
-            # Fast unwinder only gives us partial stack traces in LeakSanitzer
-            # Alloc/dealloc mismatch has been disabled in CCF: https://github.com/microsoft/CCF/pull/5157
-            ASAN_OPTIONS: fast_unwind_on_malloc=0:alloc_dealloc_mismatch=0
-
-          # faketime does not play well with ASAN so don't enable it here.
-          FunctionalTestArguments: '--enable-prefix-tree'
-          InstallPackages: [ libcurl4-openssl-dev ]
+      # Temporarily disable sanitizers build, as cchost randomly fails in functional tests with the following error:
+      # "UndefinedBehaviorSanitizer: undefined-behavior ../include/ccf/ds/logger.h:159:34: runtime error: -1.08502 is outside the range of representable values of type 'unsigned long'"
+      # Example build: https://msazure.visualstudio.com/One/_build/results?buildId=82290496&view=logs&j=18afa956-2433-54b9-a984-6a92e16f0b5b&t=d846f465-8944-5ee0-9403-de1d697ca3f0&l=482
+      # The problem seems to originate from the enclave offset being negative, which results in an unsigned long being negative: https://github.com/microsoft/CCF/blob/0e406e48409c819aea5139391a85f89dd090f0b5/include/ccf/ds/logger.h#L159
+      # The negative offset seems to be the result of the difference between the time known to the enclave and the time known to the host: https://github.com/microsoft/CCF/blob/0e406e48409c819aea5139391a85f89dd090f0b5/src/host/handle_ring_buffer.h#L76
+      # It is not clear yet if the problem originates from the CCF code or the SCITT code and will be investigated further in a future task.
+      # - template: common.yml
+      #   parameters:
+      #     Name: test_san
+      #     DisplayName: Test (Sanitizers, with prefix tree)
+      #     Platform: virtual
+      #     BuildCCF:
+      #       Version: ${{ parameters.CCF_VERSION }}
+      #       CMakeArgs: -DSAN=ON -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF
+      #     Environment:
+      #       CMAKE_BUILD_TYPE: Debug
+      #       ENABLE_PREFIX_TREE: ON
+      #       # Fast unwinder only gives us partial stack traces in LeakSanitzer
+      #       # Alloc/dealloc mismatch has been disabled in CCF: https://github.com/microsoft/CCF/pull/5157
+      #       ASAN_OPTIONS: fast_unwind_on_malloc=0:alloc_dealloc_mismatch=0
+      #     # faketime does not play well with ASAN so don't enable it here.
+      #     FunctionalTestArguments: '--enable-prefix-tree'
+      #     InstallPackages: [ libcurl4-openssl-dev ]
 
       - template: common.yml
         parameters:


### PR DESCRIPTION
The build job with address sanitizers enabled is very flaky and the functional tests often fail due to a `cchost` exception (more details in the comments). Moreover, the build job alone currently takes more than 30 minuets (~3x-4x more in duration compared to the other build jobs) due to the fact that CCF has to be built and installed from source with the ASAN compiler option enabled.

We temporarily disable this build job to avoid blocking the development work. An [issue](https://github.com/microsoft/scitt-ccf-ledger/issues/164) has been created and a task has been added to the backlog to further investigate the problem and re-enable the job once fixed. 