### PR TITLE
Adds CA cert support to CLI for TLS verification

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,9 +10,31 @@ This means TEE hardware, here SGX, is required to run and test scitt-ccf-ledger 
 However, scitt-ccf-ledger also supports running in *virtual* mode which does not require TEE hardware
 and is generally sufficient for local development.
 
+### Run in Codespaces
+
 For *virtual* mode development only, instead of following the steps below, you can also use GitHub Codespaces and then continue with the "Building" section: 
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=562968818&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestEurope)
+
+### Run in a Docker image
+
+Similar to Codespaces you could just build and test the application within the running docker image:
+
+```sh
+docker build -t mytestimg -f .devcontainer/Dockerfile .
+
+# export your user details to use when running an
+export UID=$(id -u)
+export GID=$(id -g)
+docker run --rm -it --env PLATFORM=virtual --volume $(pwd):/opt/app --workdir /opt/app --entrypoint /bin/bash --user $UID:$GID mytestimg
+
+# workaround to make git happy in a docker image
+/opt/app# git config --global --add safe.directory "*"
+
+## ready to build and test now, see below commands
+```
+
+### Run on a machine
 
 Follow the steps below to setup your development environment, replacing `<sgx|virtual>` with either one, as desired:
 
@@ -69,10 +91,12 @@ The unit tests can be run with:
 ./run_unit_tests.sh
 ```
 
-The functional tests can be run with:
+All functional tests can be run with:
 
 ```sh
 ./run_functional_tests.sh
 ```
+
+Specific functional test can also be run by passing additional `pytest` arguments, e.g. `./run_functional_tests.sh -k test_use_cacert_submit_verify_x509_signature`
 
 Note: the functional tests will launch their own CCF network on a randomly assigned port. You do not need to start an instance beforehand.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ See the `demo/` folder on how to interact with the application.
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for instructions on building, running, and testing scitt-ccf-ledger without Docker.
 
+### Using the CLI
+
+To help with the configuration of an application or to be able to interact with its API you could leverage the available CLI.
+
+See [pyscitt](pyscitt/README.md)
+
 ### Reproducing builds
 
 See [reproducibility.md](./docs/reproducibility.md) for instructions.

--- a/docker/dev-config.tmpl.json
+++ b/docker/dev-config.tmpl.json
@@ -15,6 +15,14 @@
       }
     }
   },
+  "node_certificate": {
+    "subject_alt_names": [
+      "iPAddress:0.0.0.0",
+      "iPAddress:127.0.0.1",
+      "dNSName:ccf.dummy.com",
+      "dNSName:localhost"
+    ]
+  },
   "command": {
     "type": "Start",
     "service_certificate_file": "/host/service_cert.pem",

--- a/pyscitt/README.md
+++ b/pyscitt/README.md
@@ -1,0 +1,18 @@
+CCF SCITT CLI
+----------------
+
+The CLI is extensively used in functional tests and in demo scripts:
+
+- [Transparency service demo](../demo/cts_poc/README.md)
+- [GitHub hosted DID demo](../demo/github/README.md)
+- [CLI tests](../test/test_cli.py)
+
+## Installation
+
+CLI is written in Python and is distributed through the GitHub releases as a `wheel` file.
+
+- Download a release: `curl -LO https://github.com/microsoft/scitt-ccf-ledger/releases/download/0.5.0/pyscitt-0.0.1-py3-none-any.whl`
+- Install it: `pip install pyscitt-0.0.1-py3-none-any.whl`
+- Try it: `scitt --help`
+
+An alternative way is to clone the repository and just run [`./pyscitt.sh`](../pyscitt.sh), e.g. `./pyscitt.sh --help`

--- a/pyscitt/pyscitt/cli/client_arguments.py
+++ b/pyscitt/pyscitt/cli/client_arguments.py
@@ -40,7 +40,11 @@ def add_client_arguments(
     """
 
     parser.add_argument("--url", help="CCF service URL", default=CCF_URL_DEFAULT)
-    parser.add_argument("--cacert", help="Path to certificate file (must be in PEM format) to verify the CCF service", default=None)
+    parser.add_argument(
+        "--cacert",
+        help="Path to certificate file (must be in PEM format) to verify the CCF service",
+        default=None,
+    )
     if development_only:
         # We always add a hidden --development flag that defaults to True.
         # This helps provide a uniform interface for scripts and tests.

--- a/pyscitt/pyscitt/cli/client_arguments.py
+++ b/pyscitt/pyscitt/cli/client_arguments.py
@@ -40,6 +40,7 @@ def add_client_arguments(
     """
 
     parser.add_argument("--url", help="CCF service URL", default=CCF_URL_DEFAULT)
+    parser.add_argument("--cacert", help="Path to certificate file (must be in PEM format) to verify the CCF service", default=None)
     if development_only:
         # We always add a hidden --development flag that defaults to True.
         # This helps provide a uniform interface for scripts and tests.
@@ -89,6 +90,7 @@ def create_client(args: argparse.Namespace):
     """
     kwargs = {
         "url": args.url,
+        "cacert": args.cacert,
         "development": args.development,
     }
 

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -248,9 +248,9 @@ class BaseClient:
 
         development:
             If true, the TLS certificate of the server will not be verified.
-        
+
         cacert:
-            If set and development is False, will be used in TLS verification instead of the default bundle. 
+            If set and development is False, will be used in TLS verification instead of the default bundle.
         """
 
         # Even though these are passed to the httpx.Client and not used
@@ -276,7 +276,9 @@ class BaseClient:
         else:
             self.member_http_sig = None
 
-        tls_verification: Union[str, bool] = cacert if cacert is not None else not development
+        tls_verification: Union[str, bool] = (
+            cacert if cacert is not None else not development
+        )
 
         self.session = httpx.Client(
             base_url=url, headers=headers, verify=tls_verification

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -276,7 +276,7 @@ class BaseClient:
         else:
             self.member_http_sig = None
 
-        tls_verification = cacert if cacert is not None else not development
+        tls_verification: Union[str, bool] = cacert if cacert is not None else not development
 
         self.session = httpx.Client(
             base_url=url, headers=headers, verify=tls_verification

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -176,6 +176,7 @@ class DIDDocumentTrustStore(TrustStore):
 
         method = did.find_assertion_method(self.document, kid)
         jwk = method["publicKeyJwk"]
+        # TODO parse jwk without using x5c as well
         if len(jwk.get("x5c", [])) < 1:
             raise ValueError("Missing x5c parameter in service JWK")
         certificate = base64.b64decode(jwk["x5c"][0])

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pyscitt",
-    version="0.0.1",
+    version="0.1.0",
     description="Tools to sign claims and interact with a SCITT CCF Ledger",
     packages=find_packages(),
     entry_points={

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -355,6 +355,14 @@ class CCHost(EventLoopThread):
                     "bind_address": f"0.0.0.0:{self.listen_node_port}"
                 },
             },
+            "node_certificate": {
+                "subject_alt_names": [
+                    "iPAddress:0.0.0.0",
+                    "iPAddress:127.0.0.1",
+                    "dNSName:ccf.dummy.com",
+                    "dNSName:localhost",
+                ]
+            },
             "logging": {"format": "Json", "host_level": "Info"},
             "output_files": {
                 "rpc_addresses_file": str(self.workspace / "rpc_addresses.json"),

--- a/test/infra/generate_cacert.py
+++ b/test/infra/generate_cacert.py
@@ -10,7 +10,14 @@ from loguru import logger
 from .x5chain_certificate_authority import X5ChainCertificateAuthority
 
 
-def generate_ca_cert_and_key(output_dir: str, alg: str, key_type: str, ec_curve: str, key_filename: str = "cacert_privk.pem", cacert_filename = "cacert.pem"):
+def generate_ca_cert_and_key(
+    output_dir: str,
+    alg: str,
+    key_type: str,
+    ec_curve: str,
+    key_filename: str = "cacert_privk.pem",
+    cacert_filename="cacert.pem",
+):
     # Create a new X5ChainCertificateAuthority instance
     untrusted_ca = X5ChainCertificateAuthority(kty=key_type)
 

--- a/test/infra/generate_cacert.py
+++ b/test/infra/generate_cacert.py
@@ -10,7 +10,7 @@ from loguru import logger
 from .x5chain_certificate_authority import X5ChainCertificateAuthority
 
 
-def generate_ca_cert_and_key(output_dir: str, alg: str, key_type: str, ec_curve: str):
+def generate_ca_cert_and_key(output_dir: str, alg: str, key_type: str, ec_curve: str, key_filename: str = "cacert_privk.pem", cacert_filename = "cacert.pem"):
     # Create a new X5ChainCertificateAuthority instance
     untrusted_ca = X5ChainCertificateAuthority(kty=key_type)
 
@@ -18,7 +18,7 @@ def generate_ca_cert_and_key(output_dir: str, alg: str, key_type: str, ec_curve:
     identity = untrusted_ca.create_identity(alg=alg, kty=key_type, ec_curve=ec_curve)
 
     # Write the private key to a file
-    output_key_file = f"{output_dir}/cacert_privk.pem"
+    output_key_file = f"{output_dir}/{key_filename}"
     logger.info(f"Writing private key to {output_key_file}")
     with open(output_key_file, "w") as f:
         f.write(identity.private_key)
@@ -33,7 +33,7 @@ def generate_ca_cert_and_key(output_dir: str, alg: str, key_type: str, ec_curve:
         pemcert = x509.load_pem_x509_certificate(cert.encode())
         cert_bundle += pemcert.public_bytes(serialization.Encoding.PEM)
 
-    output_cacert_file = f"{output_dir}/cacert.pem"
+    output_cacert_file = f"{output_dir}/{cacert_filename}"
     logger.info(f"Writing cacert to {output_cacert_file}")
     with open(output_cacert_file, "wb") as f:
         f.write(cert_bundle)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -168,7 +168,7 @@ def test_use_cacert_submit_verify_x509_signature(run, client, tmp_path: Path):
 
     # Setup signing keys imitating how third party might do it
     generate_ca_cert_and_key(
-        tmp_path,
+        f"{tmp_path}",
         "ES256",
         "ec",
         "P-256",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -234,9 +234,7 @@ def test_use_cacert_submit_verify_x509_signature(run, client, tmp_path: Path):
 
     trust_store_path = tmp_path / "store"
     trust_store_path.mkdir()
-    (trust_store_path / "service.json").write_text(
-        json.dumps(service_params)
-    )
+    (trust_store_path / "service.json").write_text(json.dumps(service_params))
     run(
         "validate",
         tmp_path / "claims.embedded.cose",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -213,10 +213,8 @@ def test_use_cacert_submit_verify_x509_signature(run, client, tmp_path: Path):
         tmp_path / "tlscacert.pem",
         tmp_path / "claims.cose",
         "--url",
-        # TLS cert does not have 127.0.0.1 set in SAN but 0.0.0.0 and the verification fails
-        # it does not happen in practice against a live running instance as SAN will contain
-        # the public ip and the dns entries
-        client.url.replace("127.0.0.1", "0.0.0.0"),
+        # TLS cert SAN entries come from config node_certificate.subject_alt_names
+        client.url,
         "--receipt",
         tmp_path / "receipt.cbor",
     )


### PR DESCRIPTION
* `--development` flag is used extensively and there should be a way to avoid it
* `--cacert` flag is introduced which will pass the cert pem file to `httpx.Client` as a `verify` attribute 
* additional test added to check if `cacert` validates self signed test tls connection
* some minor documentation was also added to point attention to the CLI
* expanded test/dev CCF config to make sure CA cert has multiple expected SAN values for the purpose of testing TLS