### PR TITLE
Update CCF constitution to be compatible with the new ccf.crypto package

### DIFF
--- a/app/constitution/actions.js
+++ b/app/constitution/actions.js
@@ -130,7 +130,13 @@ function checkJwks(value, field) {
 }
 
 function checkX509CertBundle(value, field) {
-  if (!ccf.isValidX509CertBundle(value)) {
+  let check_func = ccf.crypto.isValidX509CertBundle;
+  // Remove after upgrade to 4.x
+  if (check_func === undefined) {
+    check_func = ccf.isValidX509CertBundle;
+  }
+
+  if (!check_func(value)) {
     throw new Error(
       `${field} must be a valid X509 certificate (bundle) in PEM format`
     );


### PR DESCRIPTION
In some of the latest CCF versions (>=5.0.0-dev0 and >=4.0.12), the `ccf.isValidX509CertBundle` function was changed to `ccf.crypto.isValidX509CertBundle`. This change caused some CCF apps (already at 4.0.12) to fail governance calls, since they didn't have an updated constitution compatible with the corresponding CCF version.

This PR applies the [same fix](https://github.com/microsoft/CCF/pull/5824) (i.e., make the constitution compatible with different CCF package versions) to the bundled SCITT constitution. This way, we avoid running into the same problem whenever we decide to upgrade SCITT to CCF 4.0.12 or higher.