### PR TITLE
Add sample scripts for signing SCITT claims with certificates in Azure Key Vault

### DIFF
--- a/demo/cts_poc/README.md
+++ b/demo/cts_poc/README.md
@@ -76,24 +76,25 @@ All the commands must be run from the root of the repository.
 
     For running the script, you can provide the following environment variables:
 
-    - One of the following, mutually-exclusive variables: 
-        - `CACERT_PATH`: To sign with a local x509 certificate. This should be the path to a valid CA certificate PEM file.
-        - `DID_DOC_PATH`: To sign with a DID. This should be the path to a valid DID document.
-        - `AKV_CONFIG_PATH`: To sign with a certificate and key in Azure Key Vault. This should be a path to a valid JSON file with the following format:
+    - `SIGNING_METHOD`: The signing method to use for signing the claim. The supported values are `did` (to sign with a DID document and private key) `cacert` (to sign with a local x509 CA certificate and private key) and `akv` (to sign with a certificate in AKV).
+    
+    - `CACERT_PATH`: Path to a valid x509 CA certificate PEM file.
+    
+    - `DID_DOC_PATH`: Path to a valid DID document. 
+    
+    - `AKV_CONFIG_PATH`: Path to a valid JSON file with the following format:
 
-            ```json
-            {
-                "keyVaultName": "<name>",
-                "certificateName": "<key_name>",
-                "certificateVersion": "<key_version>"
-            }
-            ```
+        ```json
+        {
+            "keyVaultName": "<name>",
+            "certificateName": "<key_name>",
+            "certificateVersion": "<key_version>"
+        }
+        ```
 
-            The configuration file must contain the name of the Azure Key Vault instance, the name of the certificate to use for signing, and the version of the certificate to use for signing.
+        The configuration file must contain the name of the Azure Key Vault instance, the name of the certificate to use for signing, and the version of the certificate to use for signing.
 
-            Please make sure that a valid x509 certificate chain (in PEM format) is available in Azure Key Vault.
-
-    - `PRIVATE_KEY_PATH`: Path to the Private key PEM file. This is not required if signing with Azure Key Vault.
+    - `PRIVATE_KEY_PATH`: Path to the private key PEM file.
 
     - `CLAIM_CONTENT_PATH`: Path to the JSON/text file containing the claim content. For example:
 
@@ -110,7 +111,7 @@ All the commands must be run from the root of the repository.
     Example command:
 
     ```bash
-    CACERT_PATH="demo-poc/x509_roots/cacert.pem" PRIVATE_KEY_PATH="demo-poc/x509_roots/cacert_privk.pem" CLAIM_CONTENT_PATH="demo-poc/claims/claims.json" COSE_CLAIMS_OUTPUT_PATH="demo-poc/claims/claims.cose" ./demo/cts_poc/claim-generator.sh
+    SIGNING_METHOD="cacert" CACERT_PATH="demo-poc/x509_roots/cacert.pem" PRIVATE_KEY_PATH="demo-poc/x509_roots/cacert_privk.pem" CLAIM_CONTENT_PATH="demo-poc/claims/claims.json" COSE_CLAIMS_OUTPUT_PATH="demo-poc/claims/claims.cose" ./demo/cts_poc/claim-generator.sh
     ```
 
 2. Submit the COSE claim to the SCITT ledger and verify a receipt for the committed transaction by running the [`client-demo.sh`](client-demo.sh) script.

--- a/demo/cts_poc/README.md
+++ b/demo/cts_poc/README.md
@@ -6,7 +6,7 @@ This demo provides a simple and generic Proof of Concept for a Code Transparency
 
 - A Certificate Authority (CA) certificate and private key are required to configure the SCITT instance. The CA certificate and private key must be provided by the SCITT Operator. For getting a sample pair for testing purposes, you can use the script [cacerts-generator.sh](./cacerts-generator.sh).
 
-    For running the script, you are required to provide the following environment variables:
+    For running the script, you can provide the following environment variables:
 
     - `CACERT_OUTPUT_DIR`: Path to the output directory where the CA certificate and private key files will be stored
 
@@ -42,7 +42,7 @@ All the commands must be run from the root of the repository.
 
 2. Run the [`operator-demo.sh`](operator-demo.sh) script to activate the CCF member, configure the SCITT instance, and open the CCF network (all operations are idempotent and can be run on an already-configured instance, if needed).
 
-    For running the script, you are required to provide the following environment variables:
+    For running the script, you can provide the following environment variables:
 
     - `MEMBER_CERT_PATH`: Path to the member certificate PEM file.
 
@@ -70,11 +70,14 @@ All the commands must be run from the root of the repository.
 
 ### CTS client
 
-1. [You can skip this step, if you already have a valid COSE claim to submit] Generate a valid COSE claim to submit to the SCITT ledger by running the [`claim-generator.sh`](claim-generator.sh) script.
+1. You can skip this step, if you already have a valid COSE claim to submit. Generate a valid COSE claim to submit to the SCITT ledger by running the [`claim-generator.sh`](claim-generator.sh) script.
 
-    For running the script, you are required to provide the following environment variables:
+    > **Note**: if you want to generate a signed claim for a container image, you can use the [notary-sign.sh](notary-sign.sh) script. Please refer to the [Notary signing](#notary-signing) section for more details.
+
+    For running the script, you can provide the following environment variables:
 
     - `CACERT_PATH`: Path to the CA certificate PEM file.
+        - Alternatively, if you prefer to specify a DID document to generate the signed claim, you can pass it through the `DID_DOC` variable.
 
     - `PRIVATE_KEY_PATH`: Path to the CA private key PEM file.
 
@@ -100,7 +103,7 @@ All the commands must be run from the root of the repository.
 
     The script will submit the COSE claim to the SCITT ledger and will wait for a receipt to be generated. Once the receipt is generated, the script will print the CBOR receipt in a readable format, and verify the receipt validity.
 
-    For running the script, you are required to provide the following environment variables:
+    For running the script, you can provide the following environment variables:
 
     - `COSE_CLAIMS_PATH`: Path to the COSE file containing the signed claim.
 
@@ -111,3 +114,20 @@ All the commands must be run from the root of the repository.
     ```bash
     COSE_CLAIMS_PATH="demo-poc/claims/claims.cose" OUTPUT_FOLDER="test-folder" ./demo/cts_poc/client-demo.sh
     ```
+
+### Notary signing
+
+If you want to generate a signature with a self-signed certificate in Azure Key Vault for a container image present in an Azure Container Registry, you can use the [notary-sign.sh](notary-sign.sh) script. The script uses [Notation](https://github.com/notaryproject/notation) to create the image signature in ACR using the input Key Vault certificate. It then uses [ORAS](https://oras.land/) to fetch the image signature as a COSE object, ready to be submitted to a SCITT ledger.
+
+The process to sign a container image with Notation and Azure Key Vault using a self-signed certificate is documented [here](https://learn.microsoft.com/azure/container-registry/container-registry-tutorial-sign-build-push). Please note that a pre-requisite for this script is to have a Key Vault instance with a self-signed certificate compatible with the [Notary Project certificate requirements](https://github.com/notaryproject/specifications/blob/main/specs/signature-specification.md#certificate-requirements). You can find more information on how to create a compatible self-signed certificate in AKV [here](https://learn.microsoft.com/azure/container-registry/container-registry-tutorial-sign-build-push#create-a-self-signed-certificate-in-akv-azure-cli). 
+
+For running the script, you can provide the following environment variables:
+
+- `AKV_NAME`: Name of the Azure Key Vault instance where the certificate is stored.
+- `CERTIFICATE_NAME`: Name of the certificate stored in the Azure Key Vault instance.
+- `CERTIFICATE_VERSION`: Version of the certificate stored in the Azure Key Vault instance.
+- `ACR_NAME`: Name of the Azure Container Registry instance where the image is stored.
+- `IMAGE_REPOSITORY`: ACR repository of the image to sign.
+- `IMAGE_TAG`: Tag of the image to sign.
+- `IMAGE_DIGEST`: Digest of the image to sign.
+- `SIGNATURE_OUTPUT_PATH`: Path to the output file where the COSE file containing the image signature will be stored.

--- a/demo/cts_poc/README.md
+++ b/demo/cts_poc/README.md
@@ -76,10 +76,22 @@ All the commands must be run from the root of the repository.
 
     For running the script, you can provide the following environment variables:
 
-    - `CACERT_PATH`: Path to the CA certificate PEM file.
-        - Alternatively, if you prefer to specify a DID document to generate the signed claim, you can pass it through the `DID_DOC` variable.
+    - One of the following, mutually-exclusive variables: 
+        - `CACERT_PATH`: To sign with a local x509 certificate. This should be the path to a valid CA certificate PEM file.
+        - `DID_DOC_PATH`: To sign with a DID. This should be the path to a valid DID document.
+        - `AKV_CONFIGURATION_PATH`: To sign with a certificate and key in Azure Key Vault. This should be a path to a valid JSON file with the following format:
 
-    - `PRIVATE_KEY_PATH`: Path to the CA private key PEM file.
+            ```json
+            {
+                "keyVaultName": "<name>",
+                "certificateName": "<key_name>",
+                "certificateVersion": "<key_version>"
+            }
+            ```
+
+            The configuration file must contain the name of the Azure Key Vault instance, the name of the certificate to use for signing, and the version of the certificate to use for signing. 
+
+    - `PRIVATE_KEY_PATH`: Path to the Private key PEM file. This is not required if signing with Azure Key Vault.
 
     - `CLAIM_CONTENT_PATH`: Path to the JSON/text file containing the claim content. For example:
 

--- a/demo/cts_poc/README.md
+++ b/demo/cts_poc/README.md
@@ -89,7 +89,9 @@ All the commands must be run from the root of the repository.
             }
             ```
 
-            The configuration file must contain the name of the Azure Key Vault instance, the name of the certificate to use for signing, and the version of the certificate to use for signing. 
+            The configuration file must contain the name of the Azure Key Vault instance, the name of the certificate to use for signing, and the version of the certificate to use for signing.
+
+            Please make sure that a valid x509 certificate chain (in PEM format) is available in Azure Key Vault.
 
     - `PRIVATE_KEY_PATH`: Path to the Private key PEM file. This is not required if signing with Azure Key Vault.
 

--- a/demo/cts_poc/README.md
+++ b/demo/cts_poc/README.md
@@ -79,7 +79,7 @@ All the commands must be run from the root of the repository.
     - One of the following, mutually-exclusive variables: 
         - `CACERT_PATH`: To sign with a local x509 certificate. This should be the path to a valid CA certificate PEM file.
         - `DID_DOC_PATH`: To sign with a DID. This should be the path to a valid DID document.
-        - `AKV_CONFIGURATION_PATH`: To sign with a certificate and key in Azure Key Vault. This should be a path to a valid JSON file with the following format:
+        - `AKV_CONFIG_PATH`: To sign with a certificate and key in Azure Key Vault. This should be a path to a valid JSON file with the following format:
 
             ```json
             {

--- a/demo/cts_poc/claim-generator.sh
+++ b/demo/cts_poc/claim-generator.sh
@@ -7,11 +7,12 @@
 set -e
 
 # Variables
-: "${PRIVATE_KEY_PATH:?"variable not set. Please define the path to the private key PEM file"}"
 : "${CLAIM_CONTENT_PATH:?"variable not set. Please define the path to the json/txt file to use as content for the claim"}"
 : "${COSE_CLAIMS_OUTPUT_PATH:?"variable not set. Please define the path where the COSE claim will be saved to"}"
 
 CLAIM_CONTENT_TYPE=${CLAIM_CONTENT_TYPE:-"application/json"}
+
+PRIVATE_KEY_PATH=${PRIVATE_KEY_PATH:-""}
 
 # Either provide a DID document, a local x509 certificate, or an AKV configuration file for signing
 DID_DOC_PATH=${DID_DOC_PATH:-""}
@@ -22,6 +23,14 @@ AKV_CONFIG_PATH=${AKV_CONFIG_PATH:-""}
 if [ -z "$CACERT_PATH" ] && [ -z "$DID_DOC_PATH" ] && [ -z "$AKV_CONFIG_PATH" ]; then
     echo "Either CACERT_PATH or DID_DOC_PATH or AKV_CONFIG_PATH must be provided"
     exit 1
+fi
+
+# Check that PRIVATE_KEY_PATH is set when using DID document or local CA certificate
+if [ -n "$DID_DOC_PATH" ] || [ -n "$CACERT_PATH" ]; then
+    if [ -z "$PRIVATE_KEY_PATH" ]; then
+        echo "PRIVATE_KEY_PATH must be provided when using DID_DOC_PATH or CACERT_PATH"
+        exit 1
+    fi
 fi
 
 echo -e "\nSetting up environment"

--- a/demo/cts_poc/claim-generator.sh
+++ b/demo/cts_poc/claim-generator.sh
@@ -2,17 +2,26 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-### Simple script to generate a signed claim to submit to the SCITT ledger
+### Simple script to generate a signed claim to submit to the SCITT ledger, either using a DID document or a x509 CA certificate.
 
 set -e
 
 # Variables
-: "${CACERT_PATH:?"variable not set. Please define the path to the CA certificate PEM file"}"
 : "${PRIVATE_KEY_PATH:?"variable not set. Please define the path to the private key PEM file"}"
 : "${CLAIM_CONTENT_PATH:?"variable not set. Please define the path to the json/txt file to use as content for the claim"}"
 : "${COSE_CLAIMS_OUTPUT_PATH:?"variable not set. Please define the path where the COSE claim will be saved to"}"
 
 CLAIM_CONTENT_TYPE=${CLAIM_CONTENT_TYPE:-"application/json"}
+
+# Either provide the DID document or the CA certificate to use for signing
+CACERT_PATH=${CACERT_PATH:-""}
+DID_DOC=${DID_DOC:-""}
+
+# Validate that either the DID document or the CA certificate is provided
+if [ -z "$CACERT_PATH" ] && [ -z "$DID_DOC" ]; then
+    echo "Either CACERT_PATH or DID_DOC must be provided"
+    exit 1
+fi
 
 echo -e "\nSetting up environment"
 if [ ! -f "venv/bin/activate" ]; then
@@ -30,6 +39,7 @@ scitt sign \
     --content-type "$CLAIM_CONTENT_TYPE" \
     --key "$PRIVATE_KEY_PATH" \
     --x5c "$CACERT_PATH" \
+    --did-doc "$DID_DOC" \
     --out "$COSE_CLAIMS_OUTPUT_PATH"
 
 echo -e "\nScript completed successfully"

--- a/demo/cts_poc/claim-generator.sh
+++ b/demo/cts_poc/claim-generator.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-### Simple script to generate a signed claim to submit to the SCITT ledger, either using a DID document or a x509 CA certificate.
+### Simple, generic script to generate a signed claim to submit to the SCITT ledger using various methods.
 
 set -e
 

--- a/demo/cts_poc/notary-sign.sh
+++ b/demo/cts_poc/notary-sign.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+### Simple script to generate a container image signature to submit to a SCITT ledger using Notation and a self-signed certificate in Azure Key Vault.
+### The script assumes that the user is already logged in to Azure, has proper access and permissions to the given Key Vault and Contaner Registry.
+### It is also assumed that the referenced container image is already present in the given Container Registry and that the certificate is present in the given Key Vault.
+### Please make sure that the certificate complies with the Notary certificate requirements: https://github.com/notaryproject/specifications/blob/v1.0.0/specs/signature-specification.md#certificate-requirements
+
+set -e
+
+# Variables
+: "${AKV_NAME:?"variable not set. Please define the Azure Key Vault name where the self-signed certificate is located"}"
+: "${CERTIFICATE_NAME:?"variable not set. Please define the name of the self-signed certificate in Azure Key Vault"}"
+: "${CERTIFICATE_VERSION:?"variable not set. Please define the version of the self-signed certificate in Azure Key Vault"}"
+: "${ACR_NAME:?"variable not set. Please define the name of the Azure Container Registry where the container image to sign should be found"}"
+: "${IMAGE_REPOSITORY:?"variable not set. Please define the image repository in the Azure Container Registry where the container image to sign should be found"}"
+: "${SIGNATURE_OUTPUT_PATH:?"variable not set. Please define the path where the COSE signature will be saved to"}"
+
+# Optional variables
+IMAGE_TAG=${IMAGE_TAG:-""}
+IMAGE_DIGEST=${IMAGE_DIGEST:-""}
+
+# Check if the image tag or digest is provided
+if [ -z "$IMAGE_TAG" ] && [ -z "$IMAGE_DIGEST" ]; then
+    echo "Either IMAGE_TAG or IMAGE_DIGEST must be provided"
+    exit 1
+fi
+
+echo -e "\nInstall ORAS CLI"
+
+# Install ORAS CLI
+ORAS_VERSION="1.1.0"
+curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+mkdir -p oras-install/
+tar -zxf oras_${ORAS_VERSION}_*.tar.gz -C oras-install/
+mv oras-install/oras /usr/local/bin/
+rm -rf oras_${ORAS_VERSION}_*.tar.gz oras-install/
+
+echo -e "\nInstall Notation CLI"
+
+# Download, extract, and install notation
+NOTATION_VERSION="1.0.1"
+curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v${NOTATION_VERSION}/notation_${NOTATION_VERSION}_linux_amd64.tar.gz
+mkdir -p ~/temp_notation_dir
+tar xzf notation.tar.gz -C ~/temp_notation_dir
+
+# Copy the Notation binary to the desired bin directory in your $PATH, for example
+mv ~/temp_notation_dir/notation /usr/local/bin
+rm -rf notation.tar.gz ~/temp_notation_dir
+
+echo -e "\nInstall Notation Azure Key Vault plugin"
+
+# Create a directory for the plugin
+mkdir -p ~/.config/notation/plugins/azure-kv
+
+# Download the plugin
+curl -Lo notation-azure-kv.tar.gz \
+    https://github.com/Azure/notation-azure-kv/releases/download/v${NOTATION_VERSION}/notation-azure-kv_${NOTATION_VERSION}_linux_amd64.tar.gz 
+
+# Extract to the plugin directory
+tar xzf notation-azure-kv.tar.gz -C ~/.config/notation/plugins/azure-kv
+rm -rf notation-azure-kv.tar.gz
+
+echo -e "\nSign container image with Notation"
+
+# Get the KID of the certificate in Azure Key Vault
+KEY_ID=$(az keyvault certificate show -n "$CERTIFICATE_NAME" --vault-name "$AKV_NAME" --version "$CERTIFICATE_VERSION" --query 'kid' -o tsv)
+
+# Login to ACR
+az acr login --name "$ACR_NAME"
+
+REGISTRY="$ACR_NAME".azurecr.io
+
+# Concatenate the image repository to either the image tag or digest
+if [ -n "$IMAGE_TAG" ]; then
+    TBS_IMAGE="$IMAGE_REPOSITORY:$IMAGE_TAG"
+else
+    TBS_IMAGE="$IMAGE_REPOSITORY@$IMAGE_DIGEST"
+fi
+
+IMAGE=$REGISTRY/$TBS_IMAGE
+
+# Sign the image with Notation
+notation sign --signature-format cose --id "$KEY_ID" --plugin azure-kv --plugin-config self_signed=true "$IMAGE"
+
+echo -e "\nDownload the image signature from ACR"
+
+# Login to ACR with ORAS using an access token
+USER_NAME="00000000-0000-0000-0000-000000000000"
+PASSWORD=$(az acr login --name "$ACR_NAME" --expose-token --output tsv --query accessToken)
+oras login "$REGISTRY" --username "$USER_NAME" --password "$PASSWORD"
+
+# Find and download the image signature
+SIG_MANIFEST_DIGEST=$(oras discover "$IMAGE" --artifact-type application/vnd.cncf.notary.signature -o json | jq -r ".manifests[0].digest")
+SIG_BLOB_DIGEST=$(oras manifest fetch "$REGISTRY"/"$IMAGE_REPOSITORY"@"$SIG_MANIFEST_DIGEST" | jq -r ".layers[0].digest")
+oras blob fetch --output "$SIGNATURE_OUTPUT_PATH" "$REGISTRY"/"$IMAGE_REPOSITORY"@"$SIG_BLOB_DIGEST"
+
+echo -e "\nScript completed successfully"

--- a/demo/cts_poc/notary-sign.sh
+++ b/demo/cts_poc/notary-sign.sh
@@ -25,6 +25,7 @@ IMAGE_DIGEST=${IMAGE_DIGEST:-""}
 # Optionally set to true if the certificate in AKV is self-signed
 IS_SELF_SIGNED_CERT=${IS_SELF_SIGNED_CERT:-""}
 # Optionally specify the path to the CA certificates PEM file if the certificate in AKV does not contain the full certificate chain
+# or if you don't have AKV get_secrets permission (required by the AKV Notation plugin to fetch the full certificate chain) 
 CA_CERTS_PEM_FILE_PATH=${CA_CERTS_PEM_FILE_PATH:-""}
 
 # Check if the image tag or digest is provided

--- a/demo/cts_poc/notary-sign.sh
+++ b/demo/cts_poc/notary-sign.sh
@@ -22,9 +22,9 @@ IMAGE_TAG=${IMAGE_TAG:-""}
 IMAGE_DIGEST=${IMAGE_DIGEST:-""}
 
 # Optional variables for Notation signing
-# Specify true or false whether the certificate in AKV is a self-signed one or not
+# Optionally set to true if the certificate in AKV is self-signed
 IS_SELF_SIGNED_CERT=${IS_SELF_SIGNED_CERT:-""}
-# Specify the path to the CA certificates PEM file if the certificate in AKV does not contain the full certificate chain
+# Optionally specify the path to the CA certificates PEM file if the certificate in AKV does not contain the full certificate chain
 CA_CERTS_PEM_FILE_PATH=${CA_CERTS_PEM_FILE_PATH:-""}
 
 # Check if the image tag or digest is provided

--- a/demo/cts_poc/notary-sign.sh
+++ b/demo/cts_poc/notary-sign.sh
@@ -37,36 +37,24 @@ echo -e "\nInstall ORAS CLI"
 
 # Install ORAS CLI
 ORAS_VERSION="1.1.0"
-curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
-mkdir -p oras-install/
-tar -zxf oras_${ORAS_VERSION}_*.tar.gz -C oras-install/
-mv oras-install/oras /usr/local/bin/
-rm -rf oras_${ORAS_VERSION}_*.tar.gz oras-install/
+oras_tempdir=$(mktemp -d)
+curl -sL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" | tar xz -C "$oras_tempdir"
+mv "$oras_tempdir"/oras /usr/local/bin/
 
 echo -e "\nInstall Notation CLI"
 
 # Download, extract, and install notation
 NOTATION_VERSION="1.0.1"
-curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v${NOTATION_VERSION}/notation_${NOTATION_VERSION}_linux_amd64.tar.gz
-mkdir -p ~/temp_notation_dir
-tar xzf notation.tar.gz -C ~/temp_notation_dir
-
-# Copy the Notation binary to the desired bin directory in your $PATH, for example
-mv ~/temp_notation_dir/notation /usr/local/bin
-rm -rf notation.tar.gz ~/temp_notation_dir
+notation_tempdir=$(mktemp -d)
+curl -sL https://github.com/notaryproject/notation/releases/download/v${NOTATION_VERSION}/notation_${NOTATION_VERSION}_linux_amd64.tar.gz | tar xz -C "$notation_tempdir"
+mv "$notation_tempdir"/notation /usr/local/bin
 
 echo -e "\nInstall Notation Azure Key Vault plugin"
 
 # Create a directory for the plugin
-mkdir -p ~/.config/notation/plugins/azure-kv
-
-# Download the plugin
-curl -Lo notation-azure-kv.tar.gz \
-    https://github.com/Azure/notation-azure-kv/releases/download/v${NOTATION_VERSION}/notation-azure-kv_${NOTATION_VERSION}_linux_amd64.tar.gz 
-
-# Extract to the plugin directory
-tar xzf notation-azure-kv.tar.gz -C ~/.config/notation/plugins/azure-kv
-rm -rf notation-azure-kv.tar.gz
+akv_plugin_dir=~/.config/notation/plugins/azure-kv
+mkdir -p "$akv_plugin_dir"
+curl -sL https://github.com/Azure/notation-azure-kv/releases/download/v${NOTATION_VERSION}/notation-azure-kv_${NOTATION_VERSION}_linux_amd64.tar.gz | tar xz -C "$akv_plugin_dir"
 
 echo -e "\nSign container image with Notation"
 

--- a/demo/cts_poc/notary-sign.sh
+++ b/demo/cts_poc/notary-sign.sh
@@ -73,10 +73,10 @@ az acr login --name "$ACR_NAME"
 REGISTRY="$ACR_NAME".azurecr.io
 
 # Concatenate the image repository to either the image tag or digest
-if [ -n "$IMAGE_TAG" ]; then
-    TBS_IMAGE="$IMAGE_REPOSITORY:$IMAGE_TAG"
-else
+if [ -n "$IMAGE_DIGEST" ]; then
     TBS_IMAGE="$IMAGE_REPOSITORY@$IMAGE_DIGEST"
+else
+    TBS_IMAGE="$IMAGE_REPOSITORY:$IMAGE_TAG"
 fi
 
 IMAGE=$REGISTRY/$TBS_IMAGE

--- a/demo/cts_poc/operator-demo.sh
+++ b/demo/cts_poc/operator-demo.sh
@@ -51,7 +51,7 @@ scitt governance propose_configuration \
     --member-cert "$MEMBER_CERT_PATH" \
     --development
 
-echo -e "\Opening the network"
+echo -e "\nOpening the network"
 
 # Get current service certificate
 SERVICE_CERT_PATH="service_cert.pem"

--- a/pyscitt/pyscitt/cli/client_arguments.py
+++ b/pyscitt/pyscitt/cli/client_arguments.py
@@ -79,7 +79,7 @@ def add_client_arguments(
         parser.add_argument(
             "--akv-configuration",
             type=Path,
-            help="Path to CCF member Azure key vault configuration file",
+            help="Path to an Azure key vault configuration file. The configuration is a JSON file containing the following fields: keyVaultName, certificateName, certificateVersion.",
         )
 
     if with_auth_token:

--- a/pyscitt/pyscitt/cli/sign_claims.py
+++ b/pyscitt/pyscitt/cli/sign_claims.py
@@ -137,6 +137,11 @@ def sign_claims(
         # We need to use SecretClient to get the full certificate chain from Key Vault,
         # as we need to add it to the COSE payload in the x5c header.
         # The CertificateClient only fetches the leaf certificate.
+        # There is no official documentation suggesting that, but different sources point
+        # to the same conclusion:
+        # - https://learn.microsoft.com/en-us/answers/questions/441132/retrieving-certificate-with-complete-chain-from-az
+        # - https://stackoverflow.com/questions/74486473/c-retrieving-certificate-with-full-chain-from-azure-keyvault
+        # - https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/keyvault/azure-keyvault-certificates/samples/parse_certificate.py
         secret_client = SecretClient(
             vault_url=vault_url, credential=DefaultAzureCredential()
         )

--- a/pyscitt/pyscitt/cli/sign_claims.py
+++ b/pyscitt/pyscitt/cli/sign_claims.py
@@ -174,9 +174,9 @@ def cli(fn):
 
     # Signing with a Key Vault certificate
     parser.add_argument(
-        "--akv-configuration-path",
+        "--akv-configuration",
         type=Path,
-        help="Path to an Azure key vault configuration file",
+        help="Path to an Azure key vault configuration file. The configuration is a JSON file containing the following fields: keyVaultName, certificateName, certificateVersion.",
     )
 
     # Signing with an existing DID document
@@ -217,7 +217,7 @@ def cli(fn):
             args.feed,
             args.registration_info,
             args.x5c,
-            args.akv_configuration_path,
+            args.akv_configuration,
         )
     )
 

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -6,7 +6,7 @@ from os import path
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "pyscitt"
-PACKAGE_VERSION = "0.1.0"
+PACKAGE_VERSION = "0.2.0"
 
 path_here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
- Update `pyscitt` to support signing claims with Azure Key Vault given an input configuration file
- Update demo README and scripts to show to how to sign claims with AKV
- Add sample script to generate a container image signature (in ACR) that can be submitted to SCITT using Notation and AKV