### PR TITLE
Fix CBOR encoder buffer overflow for large claims

### DIFF
--- a/app/src/cbor.h
+++ b/app/src/cbor.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "tracing.h"
+
 #include <ccf/ccf_assert.h>
 #include <ccf/crypto/hash_provider.h>
 #include <ccf/crypto/sha256_hash.h>
@@ -75,6 +77,10 @@ namespace scitt::cbor
       QCBORError err = QCBOREncode_Finish(&context, &result);
       if (err != QCBOR_SUCCESS)
       {
+        SCITT_FAIL(
+          "Failed encoding CBOR with QCBOR error code {}. Refer to the QCBOR "
+          "documentation for more details on this error code.",
+          err);
         throw std::runtime_error("Error encoding CBOR");
       }
       buffer.resize(result.len);

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -744,7 +744,12 @@ namespace scitt::cose
     auto x5chain = uhdr.x5chain;
 
     // Serialize COSE_Sign1 with new unprotected header.
-    cbor::encoder encoder;
+    // We set the encoder buffer size to the sum of the sizes of the entry and
+    // the receipt, plus a bit of arbitrary extra space to be safe. This should
+    // be a bit larger than the actual size needed as the final vector does not
+    // include the full unprotected header. Nonetheless, we prefer to
+    // overestimate to avoid possible buffer overflows.
+    cbor::encoder encoder(cose_sign1.size() + receipt.size() + (1024 * 10));
 
     QCBOREncode_AddTag(encoder, CBOR_TAG_COSE_SIGN1);
 

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -501,13 +501,15 @@ namespace scitt
           {
             SCITT_DEBUG("Build SCITT receipt");
             receipt = serialize_receipt(entry_info, ccf_receipt_ptr);
+
+            SCITT_DEBUG("Embed SCITT receipt into the entry response");
+            entry_out = cose::embed_receipt(entry.value(), receipt);
           }
           catch (const ReceiptProcessingError& e)
           {
+            SCITT_FAIL("Failed to embed receipt: {}", e.what());
             throw InternalError(e.what());
           }
-          SCITT_DEBUG("Embed SCITT receipt into the entry response");
-          entry_out = cose::embed_receipt(entry.value(), receipt);
         }
         else
         {

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -16,6 +16,7 @@ def retrieve_signed_claimsets(
     from_seqno: Optional[int],
     to_seqno: Optional[int],
     service_trust_store_path: Optional[Path],
+    dont_embed_receipt: bool = False,
 ):
     base_path.mkdir(parents=True, exist_ok=True)
 
@@ -25,7 +26,7 @@ def retrieve_signed_claimsets(
         service_trust_store = None
 
     for tx in client.enumerate_claims(start=from_seqno, end=to_seqno):
-        claim = client.get_claim(tx, embed_receipt=True)
+        claim = client.get_claim(tx, embed_receipt=(not dont_embed_receipt))
         path = base_path / f"{tx}.cose"
 
         if service_trust_store:
@@ -52,11 +53,22 @@ def cli(fn):
         type=Path,
         help="Folder containing JSON parameter files of SCITT services to trust",
     )
+    parser.add_argument(
+        "--dont-embed-receipt",
+        action="store_true",
+        default=False,
+        help="Whether to not return the signed claimsets with the receipt embedded. Default is False.",
+    )
 
     def cmd(args):
         client = create_client(args)
         retrieve_signed_claimsets(
-            client, args.path, args.from_seqno, args.to_seqno, args.service_trust_store
+            client,
+            args.path,
+            args.from_seqno,
+            args.to_seqno,
+            args.service_trust_store,
+            args.dont_embed_receipt,
         )
 
     parser.set_defaults(func=cmd)

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -16,7 +16,7 @@ def retrieve_signed_claimsets(
     from_seqno: Optional[int],
     to_seqno: Optional[int],
     service_trust_store_path: Optional[Path],
-    dont_embed_receipt: bool = False,
+    embed_receipt: bool = False,
 ):
     base_path.mkdir(parents=True, exist_ok=True)
 
@@ -26,7 +26,7 @@ def retrieve_signed_claimsets(
         service_trust_store = None
 
     for tx in client.enumerate_claims(start=from_seqno, end=to_seqno):
-        claim = client.get_claim(tx, embed_receipt=(not dont_embed_receipt))
+        claim = client.get_claim(tx, embed_receipt=embed_receipt)
         path = base_path / f"{tx}.cose"
 
         if service_trust_store:
@@ -54,10 +54,10 @@ def cli(fn):
         help="Folder containing JSON parameter files of SCITT services to trust",
     )
     parser.add_argument(
-        "--dont-embed-receipt",
+        "--embed-receipt",
         action="store_true",
         default=False,
-        help="Whether to not return the signed claimsets with the receipt embedded. Default is False.",
+        help="Whether to include the receipt in the signed claimset under the unprotected header. Default is False.",
     )
 
     def cmd(args):
@@ -68,7 +68,7 @@ def cli(fn):
             args.from_seqno,
             args.to_seqno,
             args.service_trust_store,
-            args.dont_embed_receipt,
+            args.embed_receipt,
         )
 
     parser.set_defaults(func=cmd)

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -6,7 +6,7 @@ from os import path
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "pyscitt"
-PACKAGE_VERSION = "0.3.0"
+PACKAGE_VERSION = "0.3.1"
 
 path_here = path.abspath(path.dirname(__file__))
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -163,7 +163,7 @@ class TestNonCanonicalEncoding:
         assert original_pieces[2] == updated_pieces[2]
         assert original_pieces[3] == updated_pieces[3]
 
-    def test_embed_receipt_with_large_claim(self, client: Client, did_web):
+    def test_no_buffer_overflow_when_embedding_receipt(self, client: Client, did_web):
         """
         When embedding a receipt in a claim, we should have a sufficiently large buffer
         to accommodate the claim and the receipt. This test creates a claim that is


### PR DESCRIPTION
Fetching a large claim with an embedded receipt can result in an error if the size of the claim + the size of the receipt payload exceeds the size allocated to the CBOR encoder buffer (default to 10KB).

This PR fixes the issue by initializing a dynamic buffer size proportionally to the size of the claim and the receipt when embedding a receipt into a claim entry. Other relevant changes included:

- Added a functional test to reproduce the bug and validate the fix.
- Added a flag in the `pyscitt retrieve_signed_claims` command to allow users to optionally embed receipts in claims.
- Added more logging to make the debugging and investigation of similar problems easier in the future.