### PR TITLE
Fixes the path to runtime version of the docker image

### DIFF
--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir /tmp/app-build && \
 WORKDIR /usr/src/app
 RUN /opt/openenclave/bin/oesign dump -e lib/libscitt.enclave.so.signed | sed -n "s/mrenclave=//p" > mrenclave.txt
 
-FROM ghcr.io/microsoft/ccf/app/dev/sgx:ccf-${CCF_VERSION}
+FROM ghcr.io/microsoft/ccf/app/run/sgx:ccf-${CCF_VERSION}
 ARG CCF_VERSION
 
 RUN apt update && apt install -y python3 wget

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -55,16 +55,17 @@ sed -i "s/%CCF_PORT%/$CCF_PORT/g" "$WORKSPACE"/dev-config.json
 
 cp -r ./app/constitution "$WORKSPACE"
 
+echo "Generate keys"
 KEYGEN=$(pwd)/docker/keygenerator.sh
 pushd "$WORKSPACE"
 $KEYGEN --name member0 --gen-enc-key
 popd
 
-# Create a volume to store the workspace
+echo "Create a volume to store the workspace"
 # This works reliably on host as well as Docker-in-Docker
 docker volume create "$VOLUME_NAME"
 
-# Copy the workspace to the volume
+echo "Copy the workspace to the volume"
 # Note that this requires running a temporary container
 # https://stackoverflow.com/a/56085040
 tar -C "$WORKSPACE" -c . | docker run --rm \
@@ -85,7 +86,7 @@ else
     )
 fi
 
-# Run CCF
+echo "Run CCF with name $CONTAINER_NAME, flags ${DOCKER_FLAGS[*]}, volume name $VOLUME_NAME, and tag $DOCKER_TAG"
 docker run --name "$CONTAINER_NAME" \
     -d \
     "${DOCKER_FLAGS[@]}" \

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir /tmp/app-build && \
     /tmp/app && \
     ninja && ninja install
 
-FROM ghcr.io/microsoft/ccf/app/dev/virtual:ccf-${CCF_VERSION}
+FROM ghcr.io/microsoft/ccf/app/run/virtual:ccf-${CCF_VERSION}
 ARG CCF_VERSION
 
 RUN apt-get update && apt-get install -y python3 \


### PR DESCRIPTION
The path to the runtime docker image was set as: `ghcr.io/microsoft/ccf/app/dev/*` instead `ghcr.io/microsoft/ccf/app/run/` which prevented the final image from starting as there was no `cchost` binary found on path