### PR TITLE
Add configurable policy via sandboxed JS execution

### DIFF
--- a/app/constitution/scitt.js
+++ b/app/constitution/scitt.js
@@ -24,6 +24,8 @@ actions.set("set_scitt_configuration",
             checkType(alg, "string", `configuration.policy.accepted_did_issuers[${i}]`);
           }
         }
+
+        // TODO: Validate type of policy_script
       }
 
       checkType(args.configuration.authentication, "object?", "configuration.authentication");

--- a/app/constitution/scitt.js
+++ b/app/constitution/scitt.js
@@ -24,8 +24,7 @@ actions.set("set_scitt_configuration",
             checkType(alg, "string", `configuration.policy.accepted_did_issuers[${i}]`);
           }
         }
-
-        // TODO: Validate type of policy_script
+        checkType(args.configuration.policy.policy_script, "string?", "configuration.policy.policy_script");
       }
 
       checkType(args.configuration.authentication, "object?", "configuration.authentication");

--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -32,6 +32,8 @@ namespace scitt
     const std::string NoPrefixTree = "NoPrefixTree";
     const std::string NotFound = "NotFound";
     const std::string OperationExpired = "OperationExpired";
+    const std::string PolicyError = "PolicyError";
+    const std::string PolicyFailed = "PolicyFailed";
   } // namespace errors
 
 } // namespace scitt

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "did/document.h"
 #include "odata_error.h"
+#include "policy_engine.h"
 #include "signature_algorithms.h"
 
 #include <ccf/crypto/hash_provider.h>
@@ -116,6 +117,11 @@ namespace scitt
        */
       std::optional<std::vector<std::string>> accepted_did_issuers;
 
+      /**
+       * Script defining executable policy to be applied to each incoming entry.
+       */
+      std::optional<PolicyScript> policy_script;
+
       std::vector<std::string> get_accepted_algorithms() const
       {
         if (accepted_algorithms.has_value())
@@ -169,7 +175,10 @@ namespace scitt
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration::Policy);
   DECLARE_JSON_REQUIRED_FIELDS(Configuration::Policy);
   DECLARE_JSON_OPTIONAL_FIELDS(
-    Configuration::Policy, accepted_algorithms, accepted_did_issuers);
+    Configuration::Policy,
+    accepted_algorithms,
+    accepted_did_issuers,
+    policy_script);
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration::Authentication::JWT);
   DECLARE_JSON_REQUIRED_FIELDS(Configuration::Authentication::JWT);

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -253,14 +253,24 @@ namespace scitt
 
       if (cfg.policy.policy_script.has_value())
       {
-        if (!scitt::run_policy_engine(
-              cfg.policy.policy_script.value(),
-              "configured_policy",
-              claim_profile,
-              phdr))
+        SCITT_DEBUG("Applying policy");
+        const auto policy_violation_reason = check_for_policy_violations(
+          cfg.policy.policy_script.value(),
+          "configured_policy",
+          claim_profile,
+          phdr);
+        if (policy_violation_reason.has_value())
         {
-          throw BadRequestError(errors::PolicyFailed, "Policy was not met");
+          throw BadRequestError(
+            errors::PolicyFailed,
+            fmt::format(
+              "Policy was not met: {}", policy_violation_reason.value()));
         }
+        SCITT_DEBUG("Policy check passed");
+      }
+      else
+      {
+        SCITT_DEBUG("No policy applied");
       }
 
       // TODO: Apply further acceptance policies.

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -263,6 +263,8 @@ namespace scitt
         }
       }
 
+      // TODO: Apply further acceptance policies.
+
       auto service = ctx.tx.template ro<ccf::Service>(ccf::Tables::SERVICE);
       auto service_info = service->get().value();
       auto service_cert = service_info.cert;

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -253,7 +253,6 @@ namespace scitt
 
       if (cfg.policy.policy_script.has_value())
       {
-        SCITT_DEBUG("Applying policy");
         const auto policy_violation_reason = check_for_policy_violations(
           cfg.policy.policy_script.value(),
           "configured_policy",
@@ -261,6 +260,8 @@ namespace scitt
           phdr);
         if (policy_violation_reason.has_value())
         {
+          SCITT_DEBUG(
+            "Policy check failed: {}", policy_violation_reason.value());
           throw BadRequestError(
             errors::PolicyFailed,
             fmt::format(

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -154,14 +154,6 @@ namespace scitt
       return obj;
     }
 
-    static constexpr auto sample_js_policy = R"!!!(
-export function apply(profile, phdr) {
-  console.log(`Calling apply function`);
-  console.log(`ClaimProfile is: ${profile}`);
-  console.log(`phdr is: ${JSON.stringify(phdr)}`);
-}
-)!!!";
-
     static inline bool apply_js_policy(
       const PolicyScript& script,
       const std::string& policy_name,

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -180,7 +180,15 @@ namespace scitt
       const auto result = interpreter.call_with_rt_options(
         apply_func,
         {profile_val, phdr_val},
-        std::nullopt, // TODO: add runtime limits (heap, stack, time)
+        ccf::JSRuntimeOptions{
+          10 * 1024 * 1024, // max_heap_bytes (10MB)
+          1024 * 1024, // max_stack_bytes (1MB)
+          1000, // max_execution_time_ms (1s)
+          true, // log_exception_details
+          false, // return_exception_details
+          0, // max_cached_interpreters
+        },
+        // Limits defined explicitly above
         ccf::js::core::RuntimeLimitsPolicy::NONE);
 
       if (result.is_exception())

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -41,7 +41,7 @@ namespace scitt
       }
     }
 
-    static inline ccf::js::core::JSWrappedValue protected_headers_to_js_val(
+    static inline ccf::js::core::JSWrappedValue protected_header_to_js_val(
       ccf::js::core::Context& ctx, const scitt::cose::ProtectedHeader& phdr)
     {
       auto obj = ctx.new_obj();
@@ -175,7 +175,7 @@ namespace scitt
       }
 
       auto profile_val = claim_profile_to_js_val(interpreter, claim_profile);
-      auto phdr_val = protected_headers_to_js_val(interpreter, phdr);
+      auto phdr_val = protected_header_to_js_val(interpreter, phdr);
 
       const auto result = interpreter.call_with_rt_options(
         apply_func,

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -113,9 +113,10 @@ namespace scitt
           auto x5_array = ctx.new_array();
           size_t i = 0;
 
-          for (const auto& e : phdr.x5chain.value())
+          for (const auto& der_cert : phdr.x5chain.value())
           {
-            x5_array.set_at_index(i++, ctx.new_array_buffer_copy(e));
+            auto pem = ccf::crypto::cert_der_to_pem(der_cert);
+            x5_array.set_at_index(i++, ctx.new_string(pem.str()));
           }
 
           obj.set("x5chain", std::move(x5_array));

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cose.h"
+#include "http_error.h"
+#include "profiles.h"
+#include "tracing.h"
+
+#include <ccf/js/common_context.h>
+#include <string>
+
+namespace scitt
+{
+  using PolicyScript = std::string;
+
+  namespace js
+  {
+    static inline ccf::js::core::JSWrappedValue claim_profile_to_js_val(
+      ccf::js::core::Context& ctx, ClaimProfile claim_profile)
+    {
+      switch (claim_profile)
+      {
+        case ClaimProfile::IETF:
+        {
+          return ctx.new_string("IETF");
+          break;
+        }
+        case ClaimProfile::X509:
+        {
+          return ctx.new_string("X509");
+          break;
+        }
+        case ClaimProfile::Notary:
+        {
+          return ctx.new_string("Notary");
+          break;
+        }
+        default:
+        {
+          throw std::logic_error("Unhandled ClaimProfile value");
+        }
+      }
+    }
+
+    static inline ccf::js::core::JSWrappedValue protected_headers_to_js_val(
+      ccf::js::core::Context& ctx, const scitt::cose::ProtectedHeader& phdr)
+    {
+      auto obj = ctx.new_obj();
+
+      // Vanilla SCITT protected header parameters
+      {
+        if (phdr.alg.has_value())
+        {
+          obj.set_int64("alg", phdr.alg.value());
+        }
+
+        if (phdr.crit.has_value())
+        {
+          auto crit_array = ctx.new_array();
+          size_t i = 0;
+
+          for (const auto& e : phdr.crit.value())
+          {
+            if (std::holds_alternative<int64_t>(e))
+            {
+              crit_array.set_at_index(
+                i++,
+                ccf::js::core::JSWrappedValue(
+                  ctx, JS_NewInt64(ctx, std::get<int64_t>(e))));
+            }
+            else if (std::holds_alternative<std::string>(e))
+            {
+              crit_array.set_at_index(
+                i++, ctx.new_string(std::get<std::string>(e)));
+            }
+          }
+
+          obj.set("crit", std::move(crit_array));
+        }
+
+        if (phdr.kid.has_value())
+        {
+          obj.set("kid", ctx.new_string(phdr.kid.value()));
+        }
+
+        if (phdr.issuer.has_value())
+        {
+          obj.set("issuer", ctx.new_string(phdr.issuer.value()));
+        }
+
+        if (phdr.feed.has_value())
+        {
+          obj.set("feed", ctx.new_string(phdr.feed.value()));
+        }
+
+        if (phdr.cty.has_value())
+        {
+          if (std::holds_alternative<int64_t>(phdr.cty.value()))
+          {
+            obj.set_int64("cty", std::get<int64_t>(phdr.cty.value()));
+          }
+          else if (std::holds_alternative<std::string>(phdr.cty.value()))
+          {
+            obj.set(
+              "cty", ctx.new_string(std::get<std::string>(phdr.cty.value())));
+          }
+        }
+
+        if (phdr.x5chain.has_value())
+        {
+          auto x5_array = ctx.new_array();
+          size_t i = 0;
+
+          for (const auto& e : phdr.x5chain.value())
+          {
+            x5_array.set_at_index(i++, ctx.new_array_buffer_copy(e));
+          }
+
+          obj.set("x5chain", std::move(x5_array));
+        }
+      }
+
+      // Extra Notary protected header parameters.
+      {
+        if (phdr.notary_signing_scheme.has_value())
+        {
+          obj.set(
+            "notary_signing_scheme",
+            ctx.new_string(phdr.notary_signing_scheme.value()));
+        }
+
+        if (phdr.notary_signing_time.has_value())
+        {
+          obj.set_int64(
+            "notary_signing_time", phdr.notary_signing_time.value());
+        }
+
+        if (phdr.notary_authentic_signing_time.has_value())
+        {
+          obj.set_int64(
+            "notary_authentic_signing_time",
+            phdr.notary_authentic_signing_time.value());
+        }
+
+        if (phdr.notary_expiry.has_value())
+        {
+          obj.set_int64("notary_expiry", phdr.notary_expiry.value());
+        }
+      }
+
+      return obj;
+    }
+
+    static constexpr auto sample_js_policy = R"!!!(
+export function apply(profile, phdr) {
+  console.log(`Calling apply function`);
+  console.log(`ClaimProfile is: ${profile}`);
+  console.log(`phdr is: ${JSON.stringify(phdr)}`);
+}
+)!!!";
+
+    static inline bool apply_js_policy(
+      const PolicyScript& script,
+      const std::string& policy_name,
+      ClaimProfile claim_profile,
+      const scitt::cose::ProtectedHeader& phdr)
+    {
+      // Allow the policy to access common globals (including shims for
+      // builtins) like "console", "ccf.crypto"
+      ccf::js::CommonContext interpreter(ccf::js::TxAccess::APP_RO);
+
+      ccf::js::core::JSWrappedValue apply_func;
+      try
+      {
+        apply_func =
+          interpreter.get_exported_function(script, "apply", policy_name);
+      }
+      catch (const std::exception& e)
+      {
+        throw BadRequestError(
+          scitt::errors::PolicyError,
+          fmt::format("Invalid policy module: {}", e.what()));
+      }
+
+      auto profile_val = claim_profile_to_js_val(interpreter, claim_profile);
+      auto phdr_val = protected_headers_to_js_val(interpreter, phdr);
+
+      const auto result = interpreter.call_with_rt_options(
+        apply_func,
+        {profile_val, phdr_val},
+        std::nullopt,
+        ccf::js::core::RuntimeLimitsPolicy::NONE);
+
+      if (result.is_exception())
+      {
+        auto [reason, trace] = interpreter.error_message();
+
+        throw BadRequestError(
+          scitt::errors::PolicyError,
+          fmt::format(
+            "Error while applying policy: {}\n{}",
+            reason,
+            trace.value_or("<no trace>")));
+      }
+
+      // JS-style semantics - anything truthy becomes true
+      return result.is_true();
+    }
+  }
+
+  static inline bool run_policy_engine(
+    const PolicyScript& script,
+    const std::string& policy_name,
+    ClaimProfile claim_profile,
+    const cose::ProtectedHeader& phdr)
+  {
+    return js::apply_js_policy(script, policy_name, claim_profile, phdr);
+  }
+}

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -25,17 +25,14 @@ namespace scitt
         case ClaimProfile::IETF:
         {
           return ctx.new_string("IETF");
-          break;
         }
         case ClaimProfile::X509:
         {
           return ctx.new_string("X509");
-          break;
         }
         case ClaimProfile::Notary:
         {
           return ctx.new_string("Notary");
-          break;
         }
         default:
         {

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -180,7 +180,7 @@ namespace scitt
       const auto result = interpreter.call_with_rt_options(
         apply_func,
         {profile_val, phdr_val},
-        std::nullopt,
+        std::nullopt, // TODO: add runtime limits (heap, stack, time)
         ccf::js::core::RuntimeLimitsPolicy::NONE);
 
       if (result.is_exception())

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -321,13 +321,15 @@ namespace scitt::verifier
       return PublicKey(cert, std::nullopt);
     }
 
-    ClaimProfile verify_claim(
+    std::tuple<ClaimProfile, cose::ProtectedHeader, cose::UnprotectedHeader>
+    verify_claim(
       const std::vector<uint8_t>& data,
       ccf::kv::ReadOnlyTx& tx,
       ::timespec current_time,
       std::chrono::seconds resolution_cache_expiry,
       const Configuration& configuration)
     {
+      ClaimProfile profile;
       cose::ProtectedHeader phdr;
       cose::UnprotectedHeader uhdr;
       try
@@ -356,7 +358,7 @@ namespace scitt::verifier
             throw VerificationError(e.what());
           }
 
-          return ClaimProfile::Notary;
+          profile = ClaimProfile::Notary;
         }
         else if (phdr.issuer.has_value())
         {
@@ -373,7 +375,7 @@ namespace scitt::verifier
             throw VerificationError(e.what());
           }
 
-          return ClaimProfile::IETF;
+          profile = ClaimProfile::IETF;
         }
         else if (phdr.x5chain.has_value())
         {
@@ -389,7 +391,7 @@ namespace scitt::verifier
             throw VerificationError(e.what());
           }
 
-          return ClaimProfile::X509;
+          profile = ClaimProfile::X509;
         }
         else
         {
@@ -401,6 +403,8 @@ namespace scitt::verifier
       {
         throw VerificationError(e.what());
       }
+
+      return std::make_tuple(profile, phdr, uhdr);
     }
 
     /**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,27 @@ Example `set_scitt_configuration` snippet:
 ```
 
 ### Policy script
-JS code that determines whether an entry should be accepted. Should export an `apply` function taking 2 arguments `(claim_profile, protected_headers)`, and return true if the entry should be accepted or a string describing why the entry has failed the policy
+JS code that determines whether an entry should be accepted. Should export an `apply` function taking 2 arguments `(claim_profile, protected_header)`, and return true if the entry should be accepted or a string describing why the entry has failed the policy.
+
+`claim_profile` is a string representation of a [`scitt::ClaimProfile`](https://github.com/microsoft/scitt-ccf-ledger/blob/main/app/src/profiles.h#L10) value, mapped through [`scitt::js::claim_profile_to_js_val()`](https://github.com/microsoft/scitt-ccf-ledger/blob/main/app/src/policy_engine.h#L20).
+
+`protected_header` is an object representation of the subset of COSE protected header parameters parsed by scitt-ccf-ledger, namely:
+
+- alg (Number)
+- crit (Array containing values of type Number or String)
+- kid (String)
+- issuer (String)
+- feed (String)
+- cty (Number or String)
+- x5chain (Array of String values)
+- notary_signing_scheme (String)
+- notary_signing_time (String)
+- notary_authentic_signing_time (String)
+- notary_expiry (Number)
+
+The mapping takes place in [`scitt::js::protected_header_to_js_val()`](https://github.com/microsoft/scitt-ccf-ledger/blob/main/app/src/policy_engine.h#L44).
+
+Policy scripts are executed by the [CCF JavaScript runtime](https://github.com/microsoft/CCF/blob/main/include/ccf/js/core/runtime.h), which wraps and extends [QuickJS](https://bellard.org/quickjs/). Most ES2023 features are [supported](https://test262.fyi/#|qjs).
 
 Example `set_scitt_configuration` snippet:
 ```json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,9 +53,9 @@ Until a JWT provider is configured or API authentication is disabled, the initia
 If API authentication is disabled then requests won't require any form of authentication. (Claims submitted via the API are still validated.)
 
 Example `set_scitt_configuration` snippet:
-```
+```json
 "authentication": {
-  "allow_unauthenticated": True
+  "allow_unauthenticated": true
 }
 ```
 
@@ -66,13 +66,12 @@ If JWT authentication is enabled then API requests must include a header contain
 Extra `required_claims` can be configured which must then be present in an API request's JWT for authentication to succeed.
 
 To enable JWT authentication in SCITT, add the following config to a `set_scitt_configuration` action:
-```
+```json
 "authentication": {
-  "allow_unauthenticated": False,
+  "allow_unauthenticated": false,
   "jwt": {
     "required_claims": {
       "foo": "bar",
-        ...
     }
   }
 }
@@ -83,32 +82,44 @@ The long-term stable identifier of this service, as a DID.
 If set, it will be used to populate the issuer field of receipts.
 
 Example `set_scitt_configuration` snippet:
-```
+```json
 "service_identifier": "did:web:example.com:scitt"
 ```
 
-## Accepted algorithms
+## Policy object
+
+### Accepted algorithms
 List of accepted COSE signature algorithms when verifying signatures in submitted claims.
 If not set, the default accepted algorithms are shown in the example snippet below.
 - Note: Items in the accepted algorithms list are case sensitive.
 
 Example `set_scitt_configuration` snippet:
-```
+```json
 "accepted_algorithms": ["ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "EDDSA"]
 ```
 
-## Accepted DID issuers
+### Accepted DID issuers
 List of accepted signers of a given COSE_Sign1 payload if DID is used in that case.
 
 **Note:** TLS roots (`did_web_tls_roots`) need to be set up as well for the service to be able to resolve DIDs from the accepted issuers, see "Trust stores" below.
 
 Example `set_scitt_configuration` snippet:
-```
+```json
 "policy": {
   "accepted_did_issuers": [
     "did:web:firstallowedsubmitter.com",
     "did:web:secondallowedsubmitter.com"
   ]
+}
+```
+
+### Policy script
+JS code that determines whether an entry should be accepted. Should export an `apply` function taking 2 arguments `(claim_profile, protected_headers)`, and return true if the entry should be accepted or a string describing why the entry has failed the policy
+
+Example `set_scitt_configuration` snippet:
+```json
+"policy": {
+  "policy_script": "export function apply(profile, phdr) {\n  if (profile === \"X509\") { return true; }\n  return \"Only X509 claim profile is allowed\";\n}"
 }
 ```
 
@@ -119,13 +130,13 @@ SCITT has two trust stores that can be configured: `x509_roots` and `did_web_tls
 CA certificates which are used as trusted roots during verification of submitted claims which use an X509 certificate for identity rather than a DID.
 
 Example governance proposal:
-```
+```json
 {
   "actions": [
     {
       "name": "set_ca_cert_bundle",
       "args": {
-        "name": x509_roots,
+        "name": "x509_roots",
         "cert_bundle": "-----BEGIN CERTIFICATE-----\nMI...<Omitted for brevity>...Eo\n-----END CERTIFICATE-----\n"
       }
     }
@@ -139,13 +150,13 @@ CA certificates which are used as trusted roots during DID web resolution (as pa
 **Note:** this applies to the trusted issuers configured through `policy.accepted_did_issuers`
 
 Example governance proposal:
-```
+```json
 {
   "actions": [
     {
       "name": "set_ca_cert_bundle",
       "args": {
-        "name": did_web_tls_roots,
+        "name": "did_web_tls_roots",
         "cert_bundle": "-----BEGIN CERTIFICATE-----\nMI...<Omitted for brevity>...Eo\n-----END CERTIFICATE-----\n"
       }
     }

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -207,20 +207,12 @@ export function apply(profile, phdr) {{
     // really be basedon a stable issuer ID
     if (phdr.feed === "{feeds[0]}") {{
         if (phdr.x5chain[0] !== `{identities[0].x5c[0]}`) {{
-            console.warn(`MISMATCH`);
-            console.warn(`For feed: {feeds[0]}`);
-            console.warn(`Found: ${{phdr.x5chain[0]}}`);
-            console.warn(`Expected: {identities[0].x5c[0]}`);
             return false;
         }}
     }}
 
     if (phdr.feed === "{feeds[1]}") {{
         if (phdr.x5chain[0] !== `{identities[1].x5c[0]}`) {{
-            console.warn(`MISMATCH`);
-            console.warn(`For feed: {feeds[1]}`);
-            console.warn(`Found: ${{phdr.x5chain[0]}}`);
-            console.warn(`Expected: {identities[1].x5c[0]}`);
             return false;
         }}
     }}

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -275,7 +275,11 @@ export function apply(profile, phdr) {{
         self, client: Client, configure_service, signed_claimset
     ):
         configure_service(
-            {"policy": {"policy_script": "export function apply() { return `All entries are refused`; }"}}
+            {
+                "policy": {
+                    "policy_script": "export function apply() { return `All entries are refused`; }"
+                }
+            }
         )
 
         with service_error("Policy was not met"):

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -14,6 +14,7 @@ from pyscitt.verify import DIDResolverTrustStore, verify_receipt
 
 from .infra.assertions import service_error
 from .infra.did_web_server import DIDWebServer
+from .infra.x5chain_certificate_authority import X5ChainCertificateAuthority
 
 
 class TestAcceptedAlgorithms:
@@ -108,6 +109,182 @@ class TestAcceptedDIDIssuers:
             {"policy": {"accepted_did_issuers": [identity.issuer, "else"]}}
         )
         client.submit_claim(claims)
+
+
+class TestPolicyEngine:
+    @pytest.fixture(scope="class")
+    def signed_claimset(self, trusted_ca: X5ChainCertificateAuthority):
+        identity = trusted_ca.create_identity(alg="ES256", kty="ec")
+        return crypto.sign_json_claimset(identity, {"foo": "bar"})
+
+    def test_x509_policy(
+        self,
+        client: Client,
+        configure_service,
+        trusted_ca: X5ChainCertificateAuthority,
+        did_web,
+    ):
+        # We will apply a policy that only allows feed[0] to be edited
+        # by identity[0], and feed[1] by identity[1]. All other feeds are unprotected
+        identities = [
+            trusted_ca.create_identity(alg="ES256", kty="ec"),
+            trusted_ca.create_identity(alg="ES256", kty="ec"),
+            trusted_ca.create_identity(alg="ES256", kty="ec"),
+        ]
+        feeds = ["MyFirstFeed", "SomeOtherFeed", "AnyOtherValue"]
+
+        claims = {"foo": "bar"}
+
+        permitted_signed_claims = [
+            # Protected feed for first identity
+            crypto.sign_json_claimset(
+                identities[0],
+                claims,
+                feed=feeds[0],
+            ),
+            # Protected feed for second identity
+            crypto.sign_json_claimset(
+                identities[1],
+                claims,
+                feed=feeds[1],
+            ),
+            # Unprotected feed
+            crypto.sign_json_claimset(
+                identities[0],
+                claims,
+                feed=feeds[2],
+            ),
+            crypto.sign_json_claimset(
+                identities[1],
+                claims,
+                feed=feeds[2],
+            ),
+            crypto.sign_json_claimset(
+                identities[2],
+                claims,
+                feed=feeds[2],
+            ),
+        ]
+
+        refused_signed_claims = [
+            # No others can publish to first feed
+            crypto.sign_json_claimset(
+                identities[1],
+                claims,
+                feed=feeds[0],
+            ),
+            crypto.sign_json_claimset(
+                identities[2],
+                claims,
+                feed=feeds[0],
+            ),
+            # No others can publish to second feed
+            crypto.sign_json_claimset(
+                identities[0],
+                claims,
+                feed=feeds[1],
+            ),
+            crypto.sign_json_claimset(
+                identities[2],
+                claims,
+                feed=feeds[1],
+            ),
+            # Other claim profiles are refused
+            crypto.sign_json_claimset(
+                did_web.create_identity(),
+                claims,
+            ),
+        ]
+
+        policy_script = f"""
+export function apply(profile, phdr) {{
+    // Only accept x509 submissions with a feed
+    if (profile !== "X509") {{ return false; }}
+    if (!("feed" in phdr)) {{ return false; }}
+
+    // Protect access to the first feed
+    // Note this is doing direct cert comparison for simplicity, should
+    // really be basedon a stable issuer ID
+    if (phdr.feed === "{feeds[0]}") {{
+        if (phdr.x5chain[0] !== `{identities[0].x5c[0]}`) {{
+            console.warn(`MISMATCH`);
+            console.warn(`For feed: {feeds[0]}`);
+            console.warn(`Found: ${{phdr.x5chain[0]}}`);
+            console.warn(`Expected: {identities[0].x5c[0]}`);
+            return false;
+        }}
+    }}
+
+    if (phdr.feed === "{feeds[1]}") {{
+        if (phdr.x5chain[0] !== `{identities[1].x5c[0]}`) {{
+            console.warn(`MISMATCH`);
+            console.warn(`For feed: {feeds[1]}`);
+            console.warn(`Found: ${{phdr.x5chain[0]}}`);
+            console.warn(`Expected: {identities[1].x5c[0]}`);
+            return false;
+        }}
+    }}
+
+    return true;
+}}"""
+
+        configure_service({"policy": {"policy_script": policy_script}})
+
+        for signed_claimset in permitted_signed_claims:
+            client.submit_claim(signed_claimset)
+
+        for signed_claimset in refused_signed_claims:
+            with service_error("Policy was not met"):
+                client.submit_claim(signed_claimset)
+
+    def test_trivial_true_policy(
+        self, client: Client, configure_service, signed_claimset
+    ):
+        configure_service(
+            {"policy": {"policy_script": "export function apply() { return true }"}}
+        )
+
+        client.submit_claim(signed_claimset)
+
+    def test_trivial_false_policy(
+        self, client: Client, configure_service, signed_claimset
+    ):
+        configure_service(
+            {"policy": {"policy_script": "export function apply() { return false }"}}
+        )
+
+        with service_error("Policy was not met"):
+            client.submit_claim(signed_claimset)
+
+    def test_exceptional_policy(
+        self, client: Client, configure_service, signed_claimset
+    ):
+        configure_service(
+            {
+                "policy": {
+                    "policy_script": 'export function apply() { throw new Error("Boom"); }'
+                }
+            }
+        )
+
+        with service_error("Error while applying policy"):
+            client.submit_claim(signed_claimset)
+
+    @pytest.mark.parametrize(
+        "script",
+        [
+            "",
+            "return true",
+            "function apply() {}",
+        ],
+    )
+    def test_invalid_policy(
+        self, client: Client, configure_service, signed_claimset, script
+    ):
+        configure_service({"policy": {"policy_script": script}})
+
+        with service_error("Invalid policy module"):
+            client.submit_claim(signed_claimset)
 
 
 def test_service_identifier(

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -305,12 +305,13 @@ export function apply(profile, phdr) {{
             "",
             "return true",
             "function apply() {}",
+            "function apply() { not valid javascript }",
         ],
     )
     def test_invalid_policy(
         self, client: Client, configure_service, signed_claimset, script
     ):
-        configure_service({"policy": {"policy_script": script}})
+        proposal = configure_service({"policy": {"policy_script": script}})
 
         with service_error("Invalid policy module"):
             client.submit_claim(signed_claimset)

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -262,7 +262,7 @@ export function apply(profile, phdr) {{
                 with service_error(err):
                     client.submit_claim(signed_claimset)
 
-    def test_trivial_true_policy(
+    def test_trivial_pass_policy(
         self, client: Client, configure_service, signed_claimset
     ):
         configure_service(
@@ -271,11 +271,11 @@ export function apply(profile, phdr) {{
 
         client.submit_claim(signed_claimset)
 
-    def test_trivial_false_policy(
+    def test_trivial_fail_policy(
         self, client: Client, configure_service, signed_claimset
     ):
         configure_service(
-            {"policy": {"policy_script": "export function apply() { return false }"}}
+            {"policy": {"policy_script": "export function apply() { return `All entries are refused`; }"}}
         )
 
         with service_error("Policy was not met"):

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -236,7 +236,7 @@ export function apply(profile, phdr) {{
 
     // Protect access to the first feed
     // Note this is doing direct cert comparison for simplicity, should
-    // really be basedon a stable issuer ID
+    // really be based on a stable issuer ID
     if (phdr.feed === "{feeds[0]}") {{
         if (phdr.x5chain[0] !== `{cert_0}`) {{
             return "{feed_0_error}";

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -196,6 +196,11 @@ class TestPolicyEngine:
             ),
         ]
 
+        assert identities[0].x5c is not None
+        assert identities[1].x5c is not None
+        cert_0 = identities[0].x5c[0]
+        cert_1 = identities[1].x5c[0]
+
         policy_script = f"""
 export function apply(profile, phdr) {{
     // Only accept x509 submissions with a feed
@@ -206,13 +211,13 @@ export function apply(profile, phdr) {{
     // Note this is doing direct cert comparison for simplicity, should
     // really be basedon a stable issuer ID
     if (phdr.feed === "{feeds[0]}") {{
-        if (phdr.x5chain[0] !== `{identities[0].x5c[0]}`) {{
+        if (phdr.x5chain[0] !== `{cert_0}`) {{
             return false;
         }}
     }}
 
     if (phdr.feed === "{feeds[1]}") {{
-        if (phdr.x5chain[0] !== `{identities[1].x5c[0]}`) {{
+        if (phdr.x5chain[0] !== `{cert_1}`) {{
             return false;
         }}
     }}


### PR DESCRIPTION
Demonstrating how the JS interpreter API added in CCF 5 could be used to implement dynamic/customisable policy.

In short:

- The (governance-populated) `Configuration::Policy` struct now has an optional `policy_script` field
- If this is present, we execute it as a JS script:
  - look for an `apply()` function
  - pass the protected headers extracted from the COSE envelope
  - expect it to return a bool indicating whether submission should be accepted
- If the policy exists and fails, return an error

Includes some tests of the error paths, and of a simple sample policy which protects some feeds so they can only be claimed by a given issuer. These feeds and issuers are currently literals within the policy script, but they could also be read from the KV.