### PR TITLE
Allow svn parameter in the protected header

### DIFF
--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -64,6 +64,8 @@ namespace scitt::cose
   static constexpr const char* NOTARY_HEADER_PARAM_EXPIRY =
     "io.cncf.notary.expiry";
 
+  static constexpr const char* SVN_HEADER_PARAM = "svn";
+
   static const std::set<std::variant<int64_t, std::string>>
     NOTARY_HEADER_PARAMS{
       NOTARY_HEADER_PARAM_SIGNING_SCHEME,
@@ -89,6 +91,7 @@ namespace scitt::cose
     std::optional<std::string> kid;
     std::optional<std::string> issuer;
     std::optional<std::string> feed;
+    std::optional<int64_t> svn;
     std::optional<std::variant<int64_t, std::string>> cty;
     std::optional<std::vector<std::vector<uint8_t>>> x5chain;
 
@@ -296,6 +299,7 @@ namespace scitt::cose
       CRIT_INDEX,
       ISSUER_INDEX,
       FEED_INDEX,
+      SVN_INDEX,
       KID_INDEX,
       CTY_INDEX,
       X5CHAIN_INDEX,
@@ -322,6 +326,10 @@ namespace scitt::cose
     header_items[FEED_INDEX].label.int64 = COSE_HEADER_PARAM_FEED;
     header_items[FEED_INDEX].uLabelType = QCBOR_TYPE_INT64;
     header_items[FEED_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
+
+    header_items[SVN_INDEX].label.string = UsefulBuf_FromSZ(SVN_HEADER_PARAM);
+    header_items[SVN_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+    header_items[SVN_INDEX].uDataType = QCBOR_TYPE_INT64;
 
     header_items[KID_INDEX].label.int64 = COSE_HEADER_PARAM_KID;
     header_items[KID_INDEX].uLabelType = QCBOR_TYPE_INT64;
@@ -424,6 +432,10 @@ namespace scitt::cose
     if (header_items[FEED_INDEX].uDataType != QCBOR_TYPE_NONE)
     {
       parsed.feed = cbor::as_string(header_items[FEED_INDEX].val.string);
+    }
+    if (header_items[SVN_INDEX].uDataType != QCBOR_TYPE_NONE)
+    {
+      parsed.svn = header_items[SVN_INDEX].val.int64;
     }
 
     if (header_items[CTY_INDEX].uDataType == QCBOR_TYPE_TEXT_STRING)

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -92,6 +92,11 @@ namespace scitt
           obj.set("feed", ctx.new_string(phdr.feed.value()));
         }
 
+        if (phdr.svn.has_value())
+        {
+          obj.set_int64("svn", phdr.svn.value());
+        }
+
         if (phdr.cty.has_value())
         {
           if (std::holds_alternative<int64_t>(phdr.cty.value()))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,6 +125,7 @@ JS code that determines whether an entry should be accepted. Should export an `a
 - kid (String)
 - issuer (String)
 - feed (String)
+- svn (Number)
 - cty (Number or String)
 - x5chain (Array of String values)
 - notary_signing_scheme (String)

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -685,10 +685,13 @@ def sign_claimset(
     content_type: str,
     feed: Optional[str] = None,
     registration_info: RegistrationInfo = {},
+    svn: Optional[int] = None,
 ) -> bytes:
     headers: dict = {}
     headers[pycose.headers.Algorithm] = signer.algorithm
     headers[pycose.headers.ContentType] = content_type
+    if svn is not None:
+        headers["svn"] = svn
 
     if signer.x5c is not None:
         headers[pycose.headers.X5chain] = [cert_pem_to_der(x5) for x5 in signer.x5c]
@@ -711,9 +714,14 @@ def sign_json_claimset(
     claims: Any,
     content_type: str = "application/vnd.dummy+json",
     feed: Optional[str] = None,
+    svn: Optional[int] = None,
 ) -> bytes:
     return sign_claimset(
-        signer, json.dumps(claims).encode("ascii"), content_type=content_type, feed=feed
+        signer,
+        json.dumps(claims).encode("ascii"),
+        content_type=content_type,
+        feed=feed,
+        svn=svn,
     )
 
 


### PR DESCRIPTION
Allow a string parameter "svn" in the protected header, allowing submissions to express a security version number for registration policies and relying parties to consume.