### PR TITLE
New cli argument allowing to specify receipt type to get after submission

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,18 +132,37 @@ Root CAs are used to validate COSE envelopes being submitted to the `/entries` e
 
 scitt-ccf-ledger has unit tests, covering individual components of the source code, and functional tests, covering end-to-end use cases of scitt-ccf-ledger.
 
-The unit tests can be run with:
+### Unit tests
+
+The unit tests can be run with `run_unit_tests.sh` script.
 
 ```sh
+PLATFORM="virtual" ./docker/build.sh
 ./run_unit_tests.sh
 ```
 
-All functional tests can be run with:
+### Functional (e2e) tests
 
-```sh
-./run_functional_tests.sh
-```
+To start the tests you need to use the script `run_functional_tests.sh`.
 
 Specific functional test can also be run by passing additional `pytest` arguments, e.g. `./run_functional_tests.sh -k test_use_cacert_submit_verify_x509_signature`
 
 Note: the functional tests will launch their own CCF network on a randomly assigned port. You do not need to start an instance beforehand.
+
+**Using Docker**
+
+The script will launch the built Docker image and will execute tests against it:
+
+```sh
+PLATFORM="virtual" ./docker/build.sh
+DOCKER=1 PLATFORM=virtual ./run_functional_tests.sh
+```
+
+**Using your host environment**
+
+```sh
+PLATFORM=virtual ./build.sh
+PLATFORM=virtual ./run_functional_tests.sh
+```
+
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See the `demo/` folder on how to interact with the application.
 
 ### Development setup
 
-See [DEVELOPMENT.md](DEVELOPMENT.md) for instructions on building, running, and testing scitt-ccf-ledger without Docker.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for instructions on building, running, and testing scitt-ccf-ledger.
 
 ### Using the CLI
 

--- a/demo/github/4-submit.sh
+++ b/demo/github/4-submit.sh
@@ -5,12 +5,10 @@
 set -ex
 
 SCITT_URL=${SCITT_URL:-"https://127.0.0.1:8000"}
-SCITT_TRUST_STORE=tmp/trust_store
 
 TMP_DIR=tmp/github
 
 scitt submit $TMP_DIR/claims.cose \
     --receipt $TMP_DIR/claims.receipt.cbor \
     --url "$SCITT_URL" \
-    --service-trust-store $SCITT_TRUST_STORE \
     --development

--- a/pyscitt/pyscitt/cli/submit_signed_claims.py
+++ b/pyscitt/pyscitt/cli/submit_signed_claims.py
@@ -21,9 +21,9 @@ def submit_signed_claimset(
     if path.suffix != ".cose":
         raise ValueError("unsupported file extension, must end with .cose")
 
-    if receipt_type == "raw":
+    if receipt_type == ReceiptType.RAW.value:
         r_type = ReceiptType.RAW
-    elif receipt_type == "embedded":
+    elif receipt_type == ReceiptType.EMBEDDED.value:
         r_type = ReceiptType.EMBEDDED
     else:
         raise ValueError(f"unsupported receipt type {receipt_type}")
@@ -73,8 +73,8 @@ def cli(fn):
     )
     parser.add_argument(
         "--receipt-type",
-        choices=["embedded", "raw"],
-        default="raw",  # default to raw for backwards compatibility
+        choices=[ReceiptType.EMBEDDED.value, ReceiptType.RAW.value],
+        default=ReceiptType.RAW.value,  # default to raw for backwards compatibility
         help="""
         Downloads the receipt of a given type where raw means a countersignature (CBOR) binary 
         and embedded means the original claimset (COSE) with the raw receipt added to the unprotected header

--- a/pyscitt/pyscitt/cli/submit_signed_claims.py
+++ b/pyscitt/pyscitt/cli/submit_signed_claims.py
@@ -73,7 +73,7 @@ def cli(fn):
     )
     parser.add_argument(
         "--receipt-type",
-        choices=[ReceiptType.EMBEDDED.value, ReceiptType.RAW.value],
+        choices=[e.value for e in ReceiptType],
         default=ReceiptType.RAW.value,  # default to raw for backwards compatibility
         help="""
         Downloads the receipt of a given type where raw means a countersignature (CBOR) binary 

--- a/pyscitt/pyscitt/cli/submit_signed_claims.py
+++ b/pyscitt/pyscitt/cli/submit_signed_claims.py
@@ -15,7 +15,6 @@ def submit_signed_claimset(
     path: Path,
     receipt_path: Optional[Path],
     receipt_type: str,
-    service_trust_store_path: Optional[Path],
     skip_confirmation: bool,
 ):
     if path.suffix != ".cose":
@@ -49,14 +48,6 @@ def submit_signed_claimset(
             f.write(submission.receipt_bytes)
         print(f"Received {receipt_path}")
 
-    if service_trust_store_path:
-        service_trust_store = StaticTrustStore.load(service_trust_store_path)
-        verify_receipt(
-            signed_claimset,
-            receipt=submission.receipt,
-            service_trust_store=service_trust_store,
-        )
-
 
 def cli(fn):
     parser = fn(
@@ -80,11 +71,6 @@ def cli(fn):
         and embedded means the original claimset (COSE) with the raw receipt added to the unprotected header
         """,
     )
-    parser.add_argument(
-        "--service-trust-store",
-        type=Path,
-        help="Folder containing JSON parameter files of SCITT services to trust, used to verify the claim",
-    )
 
     def cmd(args):
         client = create_client(args)
@@ -93,7 +79,6 @@ def cli(fn):
             args.path,
             args.receipt,
             args.receipt_type,
-            args.service_trust_store,
             args.skip_confirmation,
         )
 

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -38,8 +38,8 @@ class SigningType(Enum):
 class ReceiptType(Enum):
     """Receipt types supported by the ledger."""
 
-    EMBEDDED = "EMBEDDED"
-    RAW = "RAW"
+    EMBEDDED = "embedded"
+    RAW = "raw"
 
 
 class MemberAuthenticationMethod(ABC):

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -574,6 +574,7 @@ def sha256_file(path: Path) -> str:
 
 
 def embed_receipt_in_cose(buf: bytes, receipt: bytes) -> bytes:
+    """Append the receipt to an unprotected header in a COSE_Sign1 message."""
     # Need to parse the receipt to avoid wrapping it in a bstr.
     parsed_receipt = cbor2.loads(receipt)
 
@@ -589,6 +590,23 @@ def embed_receipt_in_cose(buf: bytes, receipt: bytes) -> bytes:
         uhdr[key] = []
     uhdr[key].append(parsed_receipt)
     return cbor2.dumps(outer)
+
+
+def get_last_embedded_receipt_from_cose(buf: bytes) -> Union[bytes, None]:
+    """Extract the last receipt from the unprotected header of a COSE_Sign1 message."""
+    outer = cbor2.loads(buf)
+    if hasattr(outer, "tag"):
+        assert outer.tag == 18  # COSE_Sign1
+        val = outer.value  # type: ignore[attr-defined]
+    else:
+        val = outer
+    [_, uhdr, _, _] = val
+    key = COSE_HEADER_PARAM_SCITT_RECEIPTS
+    if key in uhdr:
+        parsed_receipts = uhdr[key]
+        if isinstance(parsed_receipts, list) and parsed_receipts:
+            return cbor2.dumps(parsed_receipts[-1])
+    return None
 
 
 def load_private_key(key_path: Path) -> Pem:

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -92,7 +92,7 @@ def verify_receipt(
     else:
         if receipt is None:
             embedded_receipt = crypto.get_last_embedded_receipt_from_cose(buf)
-            if embedded_receipt is None:
+            if not embedded_receipt:
                 raise ValueError("No embedded receipt found in COSE message")
             parsed_receipt = cbor2.loads(embedded_receipt)
         else:

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -91,10 +91,10 @@ def verify_receipt(
         decoded_receipt = receipt
     else:
         if receipt is None:
-            parsed_receipts = msg.uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS]
-            # For now, assume there is only one receipt
-            assert len(parsed_receipts) == 1
-            parsed_receipt = parsed_receipts[0]
+            embedded_receipt = crypto.get_last_embedded_receipt_from_cose(buf)
+            if embedded_receipt is None:
+                raise ValueError("No embedded receipt found in COSE message")
+            parsed_receipt = cbor2.loads(embedded_receipt)
         else:
             parsed_receipt = cbor2.loads(receipt)
 

--- a/test/load_test/locustfile.py
+++ b/test/load_test/locustfile.py
@@ -59,7 +59,9 @@ class Submitter(ScittUser):
         claim = self._claims[random.randrange(len(self._claims))]
         self.trace(
             "submit_claim",
-            lambda: self.client.submit_claim(
-                claim, skip_confirmation=self.skip_confirmation
+            lambda: (
+                self.client.submit_claim(claim)
+                if self.skip_confirmation
+                else self.client.submit_claim_and_confirm(claim)
             ),
         )

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -43,7 +43,7 @@ class TestAuthentication:
     @pytest.fixture
     def submit(self, client: Client, claim: bytes):
         def f(**kwargs):
-            client.replace(**kwargs).submit_claim(claim)
+            client.replace(**kwargs).submit_claim_and_confirm(claim)
 
         return f
 

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -34,7 +34,7 @@ def test_submit_claim(client: Client, did_web, trust_store, params):
 
     # Sign and submit a dummy claim using our new identity
     claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
-    receipt = client.submit_claim(claims).raw_receipt
+    receipt = client.submit_claim_and_confirm(claims).receipt_bytes
     verify_receipt(claims, trust_store, receipt)
 
     embedded = crypto.embed_receipt_in_cose(claims, receipt)
@@ -72,14 +72,14 @@ def test_default_did_port(client: Client, trust_store, tmp_path):
 
         # Sign and submit a dummy claim using our new identity
         claims = crypto.sign_json_claimset(identity, {"foo": "bar"})
-        receipt = client.submit_claim(claims).receipt
+        receipt = client.submit_claim_and_confirm(claims).receipt
         verify_receipt(claims, trust_store, receipt)
 
 
 @pytest.mark.isolated_test
 def test_recovery(client, did_web, restart_service):
     identity = did_web.create_identity()
-    client.submit_claim(crypto.sign_json_claimset(identity, {"foo": "bar"}))
+    client.submit_claim_and_confirm(crypto.sign_json_claimset(identity, {"foo": "bar"}))
 
     old_network = client.get("/node/network").json()
     assert old_network["recovery_count"] == 0
@@ -91,4 +91,6 @@ def test_recovery(client, did_web, restart_service):
     assert new_network["service_certificate"] != old_network["service_certificate"]
 
     # Check that the service is still operating correctly
-    client.submit_claim(crypto.sign_json_claimset(identity, {"foo": "hello"}))
+    client.submit_claim_and_confirm(
+        crypto.sign_json_claimset(identity, {"foo": "hello"})
+    )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -241,6 +241,93 @@ def test_use_cacert_submit_verify_x509_signature(run, client, tmp_path: Path):
     )
 
 
+def test_use_cacert_submit_verify_x509_embedded(run, client, tmp_path: Path):
+    # Add basic service config
+    (tmp_path / "config.json").write_text(
+        json.dumps({"authentication": {"allow_unauthenticated": True}})
+    )
+    run(
+        "governance",
+        "propose_configuration",
+        "--configuration",
+        tmp_path / "config.json",
+        with_service_url=True,
+        with_member_auth=True,
+    )
+
+    # Get the CA cert from the service params
+    # Once in production this value can come from other trusted places
+    service_params = client.get_parameters().as_dict()
+    (tmp_path / "tlscacert.pem").write_text(
+        f"-----BEGIN CERTIFICATE-----\n{service_params.get('serviceCertificate')}\n-----END CERTIFICATE-----\n"
+    )
+
+    # Setup signing keys imitating how third party might do it
+    generate_ca_cert_and_key(
+        f"{tmp_path}",
+        "ES256",
+        "ec",
+        "P-256",
+        key_filename="signerkey.pem",
+        cacert_filename="signerca.pem",
+    )
+
+    # Configure SCITT policy to accept the message if it was signed
+    # by the given key
+    run(
+        "governance",
+        "propose_ca_certs",
+        "--name",
+        "x509_roots",
+        "--ca-certs",
+        tmp_path / "signerca.pem",
+        with_service_url=True,
+        with_member_auth=True,
+    )
+
+    # Prepare an x509 cose file to submit to the service
+    (tmp_path / "claims.json").write_text(json.dumps({"foo": "bar"}))
+    run(
+        "sign",
+        "--key",
+        tmp_path / "signerkey.pem",
+        "--claims",
+        tmp_path / "claims.json",
+        "--content-type",
+        "application/json",
+        "--x5c",
+        tmp_path / "signerca.pem",
+        "--out",
+        tmp_path / "claims.cose",
+    )
+
+    # Submit cose and make sure TLS verification is enabled
+    # this should exit without error
+    run(
+        "submit",
+        "--cacert",
+        tmp_path / "tlscacert.pem",
+        tmp_path / "claims.cose",
+        "--url",
+        # TLS cert SAN entries come from config node_certificate.subject_alt_names
+        client.url,
+        "--receipt",
+        tmp_path / "claims.embedded.cose",
+        "--receipt-type",
+        "embedded",
+    )
+
+    trust_store_path = tmp_path / "store"
+    trust_store_path.mkdir()
+    (trust_store_path / "service.json").write_text(json.dumps(service_params))
+    run(
+        "validate",
+        tmp_path / "claims.embedded.cose",
+        "--service-trust-store",
+        trust_store_path,
+    )
+
+
 def test_local_development(run, service_url, tmp_path: Path):
     # This is not particularly useful to run tests against, since it uses Mozilla CA roots, meaning
     # we can't issue any DID web that would validate, but at least we check that the command doesn't

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -143,7 +143,7 @@ class TestNonCanonicalEncoding:
 
     def test_submit_claim(self, client: Client, trust_store, claim):
         """The ledger should accept claims even if not canonically encoded."""
-        receipt = client.submit_claim(claim).receipt
+        receipt = client.submit_claim_and_confirm(claim).receipt
         verify_receipt(claim, trust_store, receipt)
 
     def test_embed_receipt(self, client: Client, trust_store, claim):
@@ -151,7 +151,7 @@ class TestNonCanonicalEncoding:
         When embedding a receipt in a claim, the ledger should not affect the
         encoding of byte-string pieces.
         """
-        tx = client.submit_claim(claim).tx
+        tx = client.submit_claim_and_confirm(claim).tx
         embedded = client.get_claim(tx, embed_receipt=True)
 
         original_pieces = cbor2.loads(claim).value  # type: ignore[attr-defined]
@@ -177,7 +177,7 @@ class TestNonCanonicalEncoding:
         size = int(1024 * 1024 * 0.5)
         claim = crypto.sign_claimset(identity, bytes(size), "binary/octet-stream")
 
-        tx = client.submit_claim(claim).tx
+        tx = client.submit_claim_and_confirm(claim).tx
         embedded = client.get_claim(tx, embed_receipt=True)
 
         original_claim_array = cbor2.loads(claim).value  # type: ignore[attr-defined]
@@ -197,7 +197,7 @@ class TestHeaderParameters:
     @pytest.fixture(scope="class")
     def submit(self, client, identity):
         def f(parameters, *, signer=identity):
-            return client.submit_claim(sign(signer, b"Hello", parameters))
+            return client.submit_claim_and_confirm(sign(signer, b"Hello", parameters))
 
         return f
 

--- a/test/test_faketime.py
+++ b/test/test_faketime.py
@@ -39,5 +39,5 @@ def test_faketime(
     # attested-fetch from starting up.
     identity = did_web.create_identity()
     claim = crypto.sign_json_claimset(identity, "Payload")
-    receipt = client.submit_claim(claim).receipt
+    receipt = client.submit_claim_and_confirm(claim).receipt
     verify_receipt(claim, trust_store, receipt)

--- a/test/test_historical.py
+++ b/test/test_historical.py
@@ -18,7 +18,7 @@ class TestHistorical:
         result = []
         for i in range(COUNT):
             claim = crypto.sign_json_claimset(identity, {"value": i})
-            submission = client.submit_claim(claim)
+            submission = client.submit_claim_and_confirm(claim)
             result.append(
                 SimpleNamespace(
                     claim=claim,

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -26,10 +26,10 @@ def test_purge_old_operations(
 
     # Create two operations, such that one will be old enough to be purged but
     # not the other.
-    tx1 = client.submit_claim(claim).operation_tx
+    tx1 = client.submit_claim_and_confirm(claim).operation_tx
     cchost.advance_time(seconds=constants.OPERATION_EXPIRY_SECONDS // 2)
 
-    tx2 = client.submit_claim(claim).operation_tx
+    tx2 = client.submit_claim_and_confirm(claim).operation_tx
     cchost.advance_time(seconds=constants.OPERATION_EXPIRY_SECONDS // 2)
 
     # Just moving time forward doesn't actually do anything yet.
@@ -40,7 +40,7 @@ def test_purge_old_operations(
 
     # Submit a claim again, just to get the indexing strategy
     # to run. This is what actually triggers a purge.
-    client.submit_claim(claim)
+    client.submit_claim_and_confirm(claim)
 
     # Now the first operation has actually been purged, but not the second,
     # since that one is only half as old.

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -43,11 +43,11 @@ class TestPerf:
 
         # Test did:web performance (uncached resolution).
         latency_did_web_uncached_submit_s = measure_latency(
-            lambda claim: client.submit_claim(claim, skip_confirmation=True),
+            lambda claim: client.submit_claim(claim),
             lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
         )
         latency_did_web_uncached_submit_and_receipt_s = measure_latency(
-            lambda claim: client.submit_claim(claim, skip_confirmation=False),
+            lambda claim: client.submit_claim_and_confirm(claim),
             lambda: crypto.sign_json_claimset(did_web.create_identity(), payload),
         )
 
@@ -56,13 +56,13 @@ class TestPerf:
         claim = crypto.sign_json_claimset(identity, payload)
 
         # Make sure DID document is cached.
-        client.submit_claim(claim)
+        client.submit_claim_and_confirm(claim)
 
         latency_did_web_cached_submit_s = measure_latency(
-            lambda _: client.submit_claim(claim, skip_confirmation=True)
+            lambda _: client.submit_claim(claim)
         )
         latency_did_web_cached_submit_and_receipt_s = measure_latency(
-            lambda _: client.submit_claim(claim, skip_confirmation=False)
+            lambda _: client.submit_claim_and_confirm(claim)
         )
 
         # Test x5c performance.
@@ -71,11 +71,9 @@ class TestPerf:
         )
         claim = crypto.sign_json_claimset(identity, payload)
 
-        latency_x5c_submit_s = measure_latency(
-            lambda _: client.submit_claim(claim, skip_confirmation=True)
-        )
+        latency_x5c_submit_s = measure_latency(lambda _: client.submit_claim(claim))
         latency_x5c_submit_and_receipt_s = measure_latency(
-            lambda _: client.submit_claim(claim, skip_confirmation=False)
+            lambda _: client.submit_claim_and_confirm(claim)
         )
 
         # Time-to-receipt depends on the configured signature interval of

--- a/test/test_prefix_tree.py
+++ b/test/test_prefix_tree.py
@@ -16,7 +16,7 @@ def test_prefix_tree(did_web, client):
     service_parameters = client.get_parameters()
 
     first_claims = crypto.sign_json_claimset(identity, {"value": "first"}, feed=feed)
-    first_submit = client.submit_claim(first_claims)
+    first_submit = client.submit_claim_and_confirm(first_claims)
 
     pt = client.prefix_tree
 
@@ -36,7 +36,7 @@ def test_prefix_tree(did_web, client):
     # Submit a new claim to the same feed. The sequence numbers reflect the submission
     # ordering.
     second_claims = crypto.sign_json_claimset(identity, {"value": "second"}, feed=feed)
-    second_submit = client.submit_claim(second_claims)
+    second_submit = client.submit_claim_and_confirm(second_claims)
     assert second_submit.seqno > first_submit.seqno
 
     # Get a read receipt again - this will still reference the first claim,
@@ -60,7 +60,7 @@ def test_prefix_tree(did_web, client):
     # We submit a final claim, but to a different feed.
     # This should not affect read receipts for the original feed.
     third_claims = crypto.sign_json_claimset(identity, {"value": "third"}, feed="other")
-    third_submit = client.submit_claim(third_claims)
+    third_submit = client.submit_claim_and_confirm(third_claims)
     pt.flush()
 
     receipt = pt.get_read_receipt(identity.issuer, feed)


### PR DESCRIPTION
- New argument `--receipt-type` with options `raw` (default), `embedded`, when calling `submit` action to allow the download of the embedded receipt in one step without going through `embed-receipt` command. This mitigates unwanted side effects when `embed-receipt` logic differs from the server logic; also, this will yield better user experience without the need to explain how to embed receipt in a separate step. It defaults to `raw` to avoid any breaking surprises for those who use the cli already.
- New method `get_last_embedded_receipt_from_cose` which allows extracting the last receipt from a cose header. Used in receipt verification step when only signature with embedded receipt is provided.
- Minor doc improvements