### PR TITLE
Update build status badges on readme [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # scitt-ccf-ledger
 
-[![Build/test (virtual)](https://github.com/microsoft/scitt-ccf-ledger/actions/workflows/build-test-virtual.yml/badge.svg)](https://github.com/microsoft/scitt-ccf-ledger/actions/workflows/build-test-virtual.yml)
-
-[![Build/test (all platforms)](https://msazure.visualstudio.com/One/_apis/build/status%2FCustom%2FSCITT%2Fmicrosoft.scitt-ccf-ledger?branchName=main)](https://msazure.visualstudio.com/One/_build/latest?definitionId=332749&branchName=main)
+[![Build and test](https://github.com/microsoft/scitt-ccf-ledger/actions/workflows/build-test.yml/badge.svg)](https://github.com/microsoft/scitt-ccf-ledger/actions/workflows/build-test.yml) [![Build Status](https://github-private.visualstudio.com/microsoft/_apis/build/status%2FOneBranch%2Fscitt-ccf-ledger-wrapper%2Fscitt-ccf-ledger-wrapper-Official?repoName=scitt-ccf-ledger-wrapper&branchName=master)](https://github-private.visualstudio.com/microsoft/_build/latest?definitionId=716&repoName=scitt-ccf-ledger-wrapper&branchName=master)
 
 This repository contains the source code for scitt-ccf-ledger, an application
 that runs on top of [CCF](https://github.com/microsoft/CCF) implementing draft standards developed within the [IETF SCITT WG](https://datatracker.ietf.org/wg/scitt/about/). Its purpose is to provide provenance for artefacts in digital supply chains, increasing trust in those artefacts. scitt-ccf-ledger achieves this by allowing signed claims about artefacts to be submitted to a secure immutable ledger, and returning receipts which prove claims have been stored and registration policies applied.


### PR DESCRIPTION
- update GHA badge
- fix outdated Azure Pipelines badge to point to newer OneBranch builds