### PR TITLE
Resolve Codeql complaints

### DIFF
--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -44,7 +44,7 @@ from cryptography.hazmat.primitives.serialization import (
 )
 from cryptography.x509 import load_der_x509_certificate, load_pem_x509_certificate
 from cryptography.x509.oid import NameOID
-from pycose.keys.curves import P256, P384, P521, CoseCurve, Ed25519
+from pycose.keys.curves import P256, P384, P521, Ed25519
 from pycose.keys.ec2 import EC2Key
 from pycose.keys.keyparam import (
     EC2KpCurve,
@@ -100,11 +100,11 @@ def ec_curve_from_name(name: str) -> EllipticCurve:
 
 
 def cose_curve_from_ec(curve: EllipticCurve) -> CoseCurveType:
-    if curve == ec.SECP256R1():
+    if isinstance(curve, ec.SECP256R1):
         return ("P-256", P256)
-    elif curve == ec.SECP384R1():
+    elif isinstance(curve, ec.SECP384R1):
         return ("P-384", P384)
-    elif curve == ec.SECP521R1():
+    elif isinstance(curve, ec.SECP521R1):
         return ("P-521", P521)
     else:
         raise ValueError(f"Unsupported EC curve: {curve}")

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -616,7 +616,7 @@ def get_last_embedded_receipt_from_cose(buf: bytes) -> Union[bytes, None]:
 
 
 def load_private_key(key_path: Path) -> Pem:
-    with open(key_path) as f:
+    with open(key_path, encoding="utf-8") as f:
         key_priv_pem = f.read()
     if is_ssh_private_key(key_priv_pem):
         key_priv_pem = ssh_private_key_to_pem(key_priv_pem)
@@ -715,7 +715,7 @@ def sign_claimset(
     claims: bytes,
     content_type: str,
     feed: Optional[str] = None,
-    registration_info: RegistrationInfo = {},
+    registration_info: RegistrationInfo = None,
     svn: Optional[int] = None,
     cwt: bool = False,
 ) -> bytes:

--- a/pyscitt/pyscitt/crypto.py
+++ b/pyscitt/pyscitt/crypto.py
@@ -8,7 +8,7 @@ import json
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from uuid import uuid4
 
 warnings.filterwarnings("ignore", category=Warning)
@@ -44,7 +44,7 @@ from cryptography.hazmat.primitives.serialization import (
 )
 from cryptography.x509 import load_der_x509_certificate, load_pem_x509_certificate
 from cryptography.x509.oid import NameOID
-from pycose.keys.curves import P256, P384, P521, Ed25519, CoseCurve
+from pycose.keys.curves import P256, P384, P521, CoseCurve, Ed25519
 from pycose.keys.ec2 import EC2Key
 from pycose.keys.keyparam import (
     EC2KpCurve,
@@ -84,6 +84,8 @@ CWT_SVN = "svn"
 
 RegistrationInfoValue = Union[str, bytes, int]
 RegistrationInfo = Dict[str, RegistrationInfoValue]
+CoseCurveTypes = Union[Type[P256], Type[P384], Type[P521]]
+CoseCurveType = Tuple[str, CoseCurveTypes]
 
 
 def ec_curve_from_name(name: str) -> EllipticCurve:
@@ -97,7 +99,7 @@ def ec_curve_from_name(name: str) -> EllipticCurve:
         raise ValueError(f"Unsupported EC curve: {name}")
 
 
-def cose_curve_from_ec(curve: EllipticCurve) -> Tuple[str, CoseCurve]:
+def cose_curve_from_ec(curve: EllipticCurve) -> CoseCurveType:
     if curve == ec.SECP256R1():
         return ("P-256", P256)
     elif curve == ec.SECP384R1():
@@ -713,7 +715,7 @@ def sign_claimset(
     claims: bytes,
     content_type: str,
     feed: Optional[str] = None,
-    registration_info: RegistrationInfo = None,
+    registration_info: Optional[RegistrationInfo] = None,
     svn: Optional[int] = None,
     cwt: bool = False,
 ) -> bytes:

--- a/pyscitt/pyscitt/key_vault_sign_client.py
+++ b/pyscitt/pyscitt/key_vault_sign_client.py
@@ -17,12 +17,6 @@ from pyscitt.client import MemberAuthenticationMethod
 
 from . import crypto
 
-ALGORITHMS = {
-    256: ("ES256", "sha256"),
-    384: ("ES384", "sha384"),
-    521: ("ES512", "sha384"),
-}
-
 
 class KeyVaultSignClient(MemberAuthenticationMethod):
     """MemberIdentity implementation that uses Azure Key Vault."""
@@ -120,7 +114,15 @@ class KeyVaultSignClient(MemberAuthenticationMethod):
         pub_key = cert.public_key()
         assert isinstance(pub_key, (EllipticCurvePublicKey))
         key_size = pub_key.curve.key_size
-        signature_algorithm, hash_algorithm = ALGORITHMS[key_size]
+
+        if key_size == 256:
+            signature_algorithm, hash_algorithm = ("ES256", "sha256")
+        elif key_size == 384:
+            signature_algorithm, hash_algorithm = ("ES384", "sha384")
+        elif key_size == 521:
+            signature_algorithm, hash_algorithm = ("ES512", "sha384")
+        else:
+            raise ValueError(f"Unsupported EC size: {key_size}")
 
         digest_to_sign = hashlib.new(hash_algorithm, data).digest()
         sign_result = crypto_client.sign(

--- a/pyscitt/pyscitt/key_vault_sign_client.py
+++ b/pyscitt/pyscitt/key_vault_sign_client.py
@@ -120,7 +120,7 @@ class KeyVaultSignClient(MemberAuthenticationMethod):
         elif key_size == 384:
             signature_algorithm, hash_algorithm = ("ES384", "sha384")
         elif key_size == 521:
-            signature_algorithm, hash_algorithm = ("ES512", "sha384")
+            signature_algorithm, hash_algorithm = ("ES512", "sha512")
         else:
             raise ValueError(f"Unsupported EC size: {key_size}")
 

--- a/test/infra/did_web_server.py
+++ b/test/infra/did_web_server.py
@@ -99,7 +99,7 @@ class DIDWebServer(AbstractContextManager):
             self.port = self.httpd.server_address[1]
             self.base_url = f"https://{self.host}:{self.port}"
 
-        tls_key_pem, _ = crypto.generate_rsa_keypair(2048)
+        tls_key_pem, _ = crypto.generate_rsa_keypair()
         self.tls_cert_pem = crypto.generate_cert(tls_key_pem, cn=host)
 
         context = _create_tls_context(self.tls_cert_pem, tls_key_pem)

--- a/test/infra/jwt_issuer.py
+++ b/test/infra/jwt_issuer.py
@@ -9,7 +9,7 @@ from pyscitt import crypto
 class JwtIssuer:
     def __init__(self, name="example.com"):
         self.name = name
-        self.key, _ = crypto.generate_rsa_keypair(2048)
+        self.key, _ = crypto.generate_rsa_keypair()
         self.cert = crypto.generate_cert(self.key, cn=name)
         self.key_id = crypto.get_cert_fingerprint(self.cert)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -347,7 +347,7 @@ def test_local_development(run, service_url, tmp_path: Path):
 
 
 def test_create_ssh_did_web(run, tmp_path: Path):
-    private_key, public_key = crypto.generate_rsa_keypair(2048)
+    private_key, public_key = crypto.generate_rsa_keypair()
     ssh_private_key = crypto.private_key_pem_to_ssh(private_key)
     ssh_public_key = crypto.pub_key_pem_to_ssh(public_key)
 
@@ -401,7 +401,7 @@ def test_create_ssh_did_web(run, tmp_path: Path):
 
 
 def test_adhoc_signer(run, tmp_path: Path):
-    private_key, public_key = crypto.generate_rsa_keypair(2048)
+    private_key, public_key = crypto.generate_rsa_keypair()
     (tmp_path / "key.pem").write_text(private_key)
     (tmp_path / "key_pub.pem").write_text(public_key)
     (tmp_path / "claims.json").write_text(json.dumps({"foo": "bar"}))
@@ -519,7 +519,7 @@ def test_prefix_tree(run, tmp_path: Path):
 
 
 def test_registration_info(run, tmp_path: Path):
-    private_key, public_key = crypto.generate_rsa_keypair(2048)
+    private_key, public_key = crypto.generate_rsa_keypair()
     (tmp_path / "key.pem").write_text(private_key)
     (tmp_path / "claims.json").write_text(json.dumps({"foo": "bar"}))
 


### PR DESCRIPTION
- CodeQL flagged some Python implementation
- This is known to be false positives and I've opened an issue in a respective repo but this did not have any attention so far
- Given we do not want to explain to every person these flags are false positives it is easier to just refactor the code a bit
- RSA key is now hardcoded to be of size 2048, this is used in tests
- EC hash algorithms and keys sizes were also changed to use explicit lookup functions instead of indirect dict that referenced types and values in 3rd party cose library 

To verify if this was resolved I went through hell and fire of reading the CodeQL docs and running it locally:
- Download [CodeQL CLI with all the bells and whistles](https://docs.github.com/en/code-security/codeql-cli/getting-started-with-the-codeql-cli/setting-up-the-codeql-cli)
- Create db from the source files `~/codeql/codeql database create workspace/codeql-dbs --source-root=pyscitt/pyscitt --db-cluster --language=python --overwrite`
- Generate temp token from the GitHub org that has the specific CodeQL queries and set it up in the env vars `export GITHUB_TOKEN=...`
- Run analysis which will fetch the queries using the above token `~/codeql/codeql database analyze workspace/codeql-dbs/python/ microsoft-sdl/python-queries --format=sarif-latest --output=python-results.sarif`
- View the sarif file `python-results.sarif` to see if there are still any issues