### PR TITLE
WIP fix pretty-receipt command for cose envelopes with embedded receipts

### DIFF
--- a/pyscitt.sh
+++ b/pyscitt.sh
@@ -8,7 +8,7 @@ if [ ! -f "venv/bin/activate" ]; then
     echo "Setting up python virtual environment."
     python3.8 -m venv "venv"
     source venv/bin/activate 
-    pip install --disable-pip-version-check -q -e ./pyscitt
+    pip install --disable-pip-version-check --quiet --editable ./pyscitt
 else
     source venv/bin/activate 
 fi

--- a/pyscitt/pyscitt/cli/pretty_receipt.py
+++ b/pyscitt/pyscitt/cli/pretty_receipt.py
@@ -1,41 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 import argparse
-import datetime
 import json
 from pathlib import Path
 from typing import Any
 import base64
 
 import cbor2
-from cbor2 import CBORError
 from pycose.messages import Sign1Message
-from ..receipt import Receipt, hdr_as_dict, display_cbor_val
-from ..crypto import COSE_HEADER_PARAM_SCITT_RECEIPTS
-
-
-def cbor_as_dict(cbor_obj: Any) -> dict:
-
-    # if is a list, return a list of pretty-printed items
-    if isinstance(cbor_obj, list):
-        return [cbor_as_dict(item) for item in cbor_obj]
-
-    # if is dict, return a dict of pretty-printed items
-    if isinstance(cbor_obj, dict):
-        return {display_cbor_val(k): cbor_as_dict(v) for k, v in cbor_obj.items()}
-    
-    # attempt to decode as a list
-    if type(cbor_obj) is bytes:
-        try:
-            decoded = cbor2.loads(cbor_obj)
-            print(f"Decoded {decoded} from {cbor_obj.hex()}")
-            return cbor_as_dict(decoded)
-        except (CBORError, UnicodeDecodeError):
-            print(f"Error decoding {cbor_obj.hex()}")
-            pass
-
-    # otherwise return as is
-    return display_cbor_val(cbor_obj)
+from ..receipt import Receipt, cbor_as_dict
 
 
 def prettyprint_receipt(receipt_path: Path):
@@ -46,20 +19,9 @@ def prettyprint_receipt(receipt_path: Path):
     if hasattr(cbor_obj, "tag"):
         assert cbor_obj.tag == 18  # COSE_Sign1
         parsed = Sign1Message.from_cose_obj(cbor_obj.value, True)
-        uhdr = cbor_as_dict(parsed.uhdr)
-        # 394 header contains receipts so decode them in a pretty way
-        if COSE_HEADER_PARAM_SCITT_RECEIPTS in parsed.uhdr:
-            uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS] = []
-            # for item in parsed.uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS]:
-            #     if type(item) is bytes:
-            #         header_receipt = Receipt.decode(item)
-            #     else:
-            #         header_receipt = Receipt.from_cose_obj(item)
-            #     print(f"Item: {item} {type(item)}")
-            #     uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS].append(header_receipt.as_dict())
         output_dict = {
-            "protected": hdr_as_dict(parsed.phdr), 
-            "unprotected": uhdr,
+            "protected": cbor_as_dict(parsed.phdr), 
+            "unprotected": cbor_as_dict(parsed.uhdr),
             "payload": base64.b64encode(parsed.payload).decode("ascii"),
         }
     else:

--- a/pyscitt/pyscitt/cli/pretty_receipt.py
+++ b/pyscitt/pyscitt/cli/pretty_receipt.py
@@ -1,17 +1,74 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 import argparse
+import datetime
 import json
 from pathlib import Path
+from typing import Any
+import base64
 
-from ..receipt import Receipt
+import cbor2
+from cbor2 import CBORError
+from pycose.messages import Sign1Message
+from ..receipt import Receipt, hdr_as_dict, display_cbor_val
+from ..crypto import COSE_HEADER_PARAM_SCITT_RECEIPTS
+
+
+def cbor_as_dict(cbor_obj: Any) -> dict:
+
+    # if is a list, return a list of pretty-printed items
+    if isinstance(cbor_obj, list):
+        return [cbor_as_dict(item) for item in cbor_obj]
+
+    # if is dict, return a dict of pretty-printed items
+    if isinstance(cbor_obj, dict):
+        return {display_cbor_val(k): cbor_as_dict(v) for k, v in cbor_obj.items()}
+    
+    # attempt to decode as a list
+    if type(cbor_obj) is bytes:
+        try:
+            decoded = cbor2.loads(cbor_obj)
+            print(f"Decoded {decoded} from {cbor_obj.hex()}")
+            return cbor_as_dict(decoded)
+        except (CBORError, UnicodeDecodeError):
+            print(f"Error decoding {cbor_obj.hex()}")
+            pass
+
+    # otherwise return as is
+    return display_cbor_val(cbor_obj)
 
 
 def prettyprint_receipt(receipt_path: Path):
     with open(receipt_path, "rb") as f:
         receipt = f.read()
-    parsed = Receipt.decode(receipt)
-    print(json.dumps(parsed.as_dict(), indent=2))
+
+    cbor_obj = cbor2.loads(receipt)
+    if hasattr(cbor_obj, "tag"):
+        assert cbor_obj.tag == 18  # COSE_Sign1
+        parsed = Sign1Message.from_cose_obj(cbor_obj.value, True)
+        uhdr = cbor_as_dict(parsed.uhdr)
+        # 394 header contains receipts so decode them in a pretty way
+        if COSE_HEADER_PARAM_SCITT_RECEIPTS in parsed.uhdr:
+            uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS] = []
+            # for item in parsed.uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS]:
+            #     if type(item) is bytes:
+            #         header_receipt = Receipt.decode(item)
+            #     else:
+            #         header_receipt = Receipt.from_cose_obj(item)
+            #     print(f"Item: {item} {type(item)}")
+            #     uhdr[COSE_HEADER_PARAM_SCITT_RECEIPTS].append(header_receipt.as_dict())
+        output_dict = {
+            "protected": hdr_as_dict(parsed.phdr), 
+            "unprotected": uhdr,
+            "payload": base64.b64encode(parsed.payload).decode("ascii"),
+        }
+    else:
+        parsed = Receipt.decode(receipt)
+        output_dict = parsed.as_dict()
+
+    print(output_dict)
+
+    print(json.dumps(output_dict, indent=2))
 
 
 def cli(fn):

--- a/pyscitt/pyscitt/cli/pretty_receipt.py
+++ b/pyscitt/pyscitt/cli/pretty_receipt.py
@@ -12,6 +12,7 @@ from ..receipt import Receipt, cbor_as_dict
 
 
 def prettyprint_receipt(receipt_path: Path):
+    """Pretty-print a SCITT receipt file and detect both embedded COSE_Sign1 and standalone receipt formats"""
     with open(receipt_path, "rb") as f:
         receipt = f.read()
 
@@ -20,7 +21,7 @@ def prettyprint_receipt(receipt_path: Path):
         assert cbor_obj.tag == 18  # COSE_Sign1
         parsed = Sign1Message.from_cose_obj(cbor_obj.value, True)
         output_dict = {
-            "protected": cbor_as_dict(parsed.phdr), 
+            "protected": cbor_as_dict(parsed.phdr),
             "unprotected": cbor_as_dict(parsed.uhdr),
             "payload": base64.b64encode(parsed.payload).decode("ascii"),
         }
@@ -28,14 +29,12 @@ def prettyprint_receipt(receipt_path: Path):
         parsed = Receipt.decode(receipt)
         output_dict = parsed.as_dict()
 
-    print(output_dict)
-
     print(json.dumps(output_dict, indent=2))
 
 
 def cli(fn):
     parser = fn(description="Pretty-print a SCITT receipt")
-    parser.add_argument("receipt", type=Path, help="Path to SCITT receipt file")
+    parser.add_argument("receipt", type=Path, help="Path to SCITT receipt file (embedded or standalone)")
 
     def cmd(args):
         prettyprint_receipt(args.receipt)

--- a/pyscitt/pyscitt/prefix_tree.py
+++ b/pyscitt/pyscitt/prefix_tree.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from .client import BaseClient
 
 from .crypto import COSE_HEADER_PARAM_FEED, COSE_HEADER_PARAM_ISSUER
-from .receipt import ReceiptContents, hdr_as_dict
+from .receipt import ReceiptContents, cbor_as_dict
 from .verify import ServiceParameters
 
 
@@ -151,8 +151,8 @@ class ReadReceipt:
 
     def as_dict(self) -> dict:
         return {
-            "tree_headers": hdr_as_dict(self.tree_headers),
-            "leaf_headers": hdr_as_dict(self.leaf_headers),
+            "tree_headers": cbor_as_dict(self.tree_headers),
+            "leaf_headers": cbor_as_dict(self.leaf_headers),
             "proof": {
                 "positions": self.proof.positions.hex(),
                 "hashes": [h.hex() for h in self.proof.hashes],

--- a/pyscitt/pyscitt/receipt.py
+++ b/pyscitt/pyscitt/receipt.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import base64
+import datetime
 import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -23,21 +24,24 @@ HEADER_PARAM_TREE_ALGORITHM = "tree_alg"
 TREE_ALGORITHM_CCF = "CCF"
 
 
+def display_cbor_val(item):
+    print(f"Displaying {type(item)} {item}")
+    if hasattr(item, "__name__"):
+        return item.__name__
+    if type(item) is bytes:
+        return item.hex()
+    if type(item) is datetime:
+        return item.isoformat()
+    return item
+
+
 def hdr_as_dict(phdr: dict) -> dict:
     """
     Return a representation of a list of COSE header parameters that
     is amenable to pretty-printing.
     """
-
-    def display(item):
-        if hasattr(item, "__name__"):
-            return item.__name__
-        if type(item) is bytes:
-            return item.hex()
-        return item
-
     # Decode KID into a 'readable' text string if present.
-    hdr_dict = {display(k): display(v) for k, v in phdr.items()}
+    hdr_dict = {display_cbor_val(k): display_cbor_val(v) for k, v in phdr.items()}
     if hdr_dict.get("KID"):
         hdr_dict["KID"] = bytes.fromhex(hdr_dict["KID"]).decode()
 

--- a/pyscitt/pyscitt/receipt.py
+++ b/pyscitt/pyscitt/receipt.py
@@ -79,7 +79,14 @@ def cbor_as_dict(cbor_obj: Any, cbor_obj_key: Any = None) -> Any:
 
     if hasattr(cbor_obj_key, "identifier"):
         if cbor_obj_key.identifier == SCITTReceipts.identifier:
-            return [Receipt.decode(receipt).as_dict() for receipt in cbor_obj]
+            parsed_receipts = []
+            for item in cbor_obj:
+                if type(item) is bytes:
+                    receipt_as_dict = Receipt.decode(item).as_dict()
+                else:
+                    receipt_as_dict = Receipt.from_cose_obj(item).as_dict()
+            parsed_receipts.append(receipt_as_dict)
+            return parsed_receipts
         if cbor_obj_key.identifier == X5chain.identifier:
             return [base64.b64encode(cert).decode("ascii") for cert in cbor_obj]
         if cbor_obj_key.identifier == KID.identifier:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -135,6 +135,9 @@ def test_smoke_test(run, client, tmp_path: Path):
             tmp_path / "claims.embedded.cose",
         )
 
+        # make sure preview works for embedded receipts as well
+        run("pretty-receipt", tmp_path / "claims.embedded.cose")
+
         run(
             "validate",
             tmp_path / "claims.cose",


### PR DESCRIPTION
`pretty-receipt` CLI command fails when presented with the receipt embedded in the cose envelope. Fixing it here to make the command more resilient when parsing arbitrary CBOR. I am fairly sure there is an edge case that is not handled properly at the moment though as JSON encoder does not like pycose objects.