### PR TITLE
Azure DevOps to use private feeds for Python deps

### DIFF
--- a/.pipelines/ado_pipauth.yml
+++ b/.pipelines/ado_pipauth.yml
@@ -2,4 +2,4 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate to private feed'
   inputs:
-    artifactFeeds: 'ConfidentialLedger/external-dependencies'
+    artifactFeeds: accl-cts-ccf-external-dependencies

--- a/.pipelines/ado_pipauth.yml
+++ b/.pipelines/ado_pipauth.yml
@@ -1,0 +1,4 @@
+- task: PipAuthenticate@1
+  displayName: 'Pip Authenticate to private feed'
+  inputs:
+    artifactFeeds: 'ConfidentialLedger/external-dependencies'

--- a/.pipelines/ado_pipauth.yml
+++ b/.pipelines/ado_pipauth.yml
@@ -1,3 +1,4 @@
+steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate to private feed'
   inputs:

--- a/.pipelines/local_virtual_build.yml
+++ b/.pipelines/local_virtual_build.yml
@@ -61,6 +61,8 @@ jobs:
         condition: ${{ parameters.RunTests }}
         displayName: Run Unit tests
 
+      - template: ado_pipauth.yml@self
+
       - script: ./run_functional_tests.sh ${{ parameters.FunctionalTestArguments }}
         condition: ${{ parameters.RunTests }}
         displayName: Run Functional Tests

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -72,12 +72,6 @@ extends:
 
     - stage: test_virtual_vm_build
       jobs:
-
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: 'ConfidentialLedger/external-dependencies'
-
       - job: format
         displayName: Code Formatting
         pool:
@@ -89,6 +83,7 @@ extends:
           path: s/
           submodules: recursive
           lfs: false
+        - template: .pipelines/ado_pipauth.yml@self
         - script: $(Build.SourcesDirectory)/scripts/ci-checks.sh
           displayName: "CI checks"
 

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -73,6 +73,11 @@ extends:
     - stage: test_virtual_vm_build
       jobs:
 
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: 'ConfidentialLedger/external-dependencies'
+
       - job: format
         displayName: Code Formatting
         pool:

--- a/.pipelines/python.yml
+++ b/.pipelines/python.yml
@@ -9,3 +9,4 @@ steps:
     sudo rm -rf /var/lib/apt/lists/*
     sudo rm -rf /tmp/*
   displayName: Install python dependencies
+- template: ado_pipauth.yml@self


### PR DESCRIPTION
Consume Python dependencies though the internal feeds as opposed to public ones when building PRs in Azure DevOps pipelines. This should solve governance alerts but it does not really change the way dependencies are ingested in the case when publishing to pypi.