### PR TITLE
CLI: extract payload from COSE envelopes

### DIFF
--- a/demo/cts_poc/3-client-demo.sh
+++ b/demo/cts_poc/3-client-demo.sh
@@ -36,39 +36,22 @@ curl -k -f "$SCITT_URL"/parameters/historic > "$SERVICE_PARAMS_FOLDER"/scitt.jso
 echo -e "\nSubmitting claim to the ledger and getting receipt for the committed transaction"
 RECEIPT_FOLDER="$OUTPUT_FOLDER"/receipts
 mkdir -p "$RECEIPT_FOLDER"
-RECEIPT_PATH="$RECEIPT_FOLDER"/claims.receipt.cbor
+RECEIPT_PATH="$RECEIPT_FOLDER"/embedded.receipt.cose
 
 # Submit signed claim
 scitt submit "$COSE_CLAIMS_PATH" \
     --receipt "$RECEIPT_PATH" \
+    --receipt-type embedded \
     --url "$SCITT_URL" \
     --development
 
-# Get entries with embedded receipts
-echo -e "\nGetting all entries with embedded receipts"
-scitt retrieve "$RECEIPT_FOLDER" \
-    --url "$SCITT_URL" \
-    --service-trust-store "$SERVICE_PARAMS_FOLDER" \
-    --development
-
-# View CBOR receipt
-echo -e "\nViewing decoded receipt content"
+# Preview receipt
+echo -e "\nViewing embedded receipt content"
 scitt pretty-receipt "$RECEIPT_PATH"
 
-# Verify CBOR receipt
+# Verify receipt
 echo -e "\nVerifying receipt"
-scitt validate "$COSE_CLAIMS_PATH" \
-    --receipt "$RECEIPT_PATH" \
+scitt validate "$RECEIPT_PATH" \
     --service-trust-store "$SERVICE_PARAMS_FOLDER"
-
-# Get a list of all the COSE claims inside the RECEIPT_FOLDER directory
-COSE_FILES=$(find "$RECEIPT_FOLDER" -type f -name "*.cose")
-
-# Verify entry with embedded receipt for each retrieved COSE claim
-for COSE_ENTRY in $COSE_FILES; do
-    echo -e "\nVerifying entry with embedded receipt for $COSE_ENTRY"
-    scitt validate "$COSE_ENTRY" \
-        --service-trust-store "$SERVICE_PARAMS_FOLDER"
-done
 
 echo -e "\nScript completed successfully"

--- a/pyscitt/pyscitt/cli/main.py
+++ b/pyscitt/pyscitt/cli/main.py
@@ -10,6 +10,7 @@ from . import (
     pretty_receipt,
     retrieve_signed_claims,
     sign_claims,
+    split_payload,
     submit_signed_claims,
     upload_did_web_doc_to_github,
     validate_cose,
@@ -21,6 +22,7 @@ COMMANDS = [
     ("sign", sign_claims),
     ("submit", submit_signed_claims),
     ("retrieve", retrieve_signed_claims),
+    ("split-payload", split_payload),
     ("pretty-receipt", pretty_receipt),
     ("embed-receipt", embed_receipt_in_cose),
     ("validate", validate_cose),
@@ -34,7 +36,7 @@ def main(argv=None):
     # https://github.com/python/cpython/issues/67037
     # https://docs.python.org/3/library/argparse.html#sub-commands
     sub = parser.add_subparsers(
-        metavar="{submit,retrieve,pretty-receipt,embed-receipt,validate}",
+        metavar="{submit,retrieve,pretty-receipt,embed-receipt,validate,split-payload}",
         help="""Choose one of the available commands to run. 
                                 Use the --help flag to see the options for each command.
                                 For instance 'scitt submit --help' will show the options for the submit command.

--- a/pyscitt/pyscitt/cli/main.py
+++ b/pyscitt/pyscitt/cli/main.py
@@ -30,7 +30,16 @@ COMMANDS = [
 
 def main(argv=None):
     parser = argparse.ArgumentParser()
-    sub = parser.add_subparsers()
+    # Hide commands used for testing through metavar
+    # https://github.com/python/cpython/issues/67037
+    # https://docs.python.org/3/library/argparse.html#sub-commands
+    sub = parser.add_subparsers(
+        metavar="{submit,retrieve,pretty-receipt,embed-receipt,validate}",
+        help="""Choose one of the available commands to run. 
+                                Use the --help flag to see the options for each command.
+                                For instance 'scitt submit --help' will show the options for the submit command.
+                                """,
+    )
     for name, module in COMMANDS:
         getattr(module, "cli")(lambda *args, **kw: sub.add_parser(name, *args, **kw))
     args = parser.parse_args(argv)

--- a/pyscitt/pyscitt/cli/split_payload.py
+++ b/pyscitt/pyscitt/cli/split_payload.py
@@ -3,11 +3,12 @@
 import argparse
 import base64
 from pathlib import Path
+from typing import Optional
 
 from pycose.messages import Sign1Message
- 
 
-def split_payload(cose_path: Path, output: Path = None):
+
+def split_payload(cose_path: Path, output: Optional[Path] = None):
     """Extract the payload from a COSE file and write it to a file or print it to stdout."""
     cose = cose_path.read_bytes()
     decoded = Sign1Message.decode(cose)
@@ -21,10 +22,12 @@ def split_payload(cose_path: Path, output: Path = None):
 
 def cli(fn):
     parser = fn(description="Extract payload from a COSE file")
+    parser.add_argument("cose", type=Path, help="Path to a COSE file")
     parser.add_argument(
-        "cose", type=Path, help="Path to a COSE file"
+        "--out",
+        type=Path,
+        help="Output path, e.g. payload.txt. If not provided, the base64 encoded payload will be printed to stdout.",
     )
-    parser.add_argument("--out", type=Path, help="Output path, e.g. payload.txt. If not provided, the base64 encoded payload will be printed to stdout.")
 
     def cmd(args):
         split_payload(args.cose, args.output)

--- a/pyscitt/pyscitt/cli/split_payload.py
+++ b/pyscitt/pyscitt/cli/split_payload.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import argparse
+import base64
+from pathlib import Path
+
+from pycose.messages import Sign1Message
+ 
+
+def split_payload(cose_path: Path, output: Path = None):
+    """Extract the payload from a COSE file and write it to a file or print it to stdout."""
+    cose = cose_path.read_bytes()
+    decoded = Sign1Message.decode(cose)
+    if not decoded.payload:
+        raise ValueError("COSE object does not contain a payload")
+    if not output:
+        print(base64.b64encode(decoded.payload).decode("ascii"))
+    else:
+        output.write_bytes(decoded.payload)
+
+
+def cli(fn):
+    parser = fn(description="Extract payload from a COSE file")
+    parser.add_argument(
+        "cose", type=Path, help="Path to a COSE file"
+    )
+    parser.add_argument("--out", type=Path, help="Output path, e.g. payload.txt. If not provided, the base64 encoded payload will be printed to stdout.")
+
+    def cmd(args):
+        split_payload(args.cose, args.output)
+
+    parser.set_defaults(func=cmd)
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = cli(argparse.ArgumentParser)
+    args = parser.parse_args()
+    args.func(args)

--- a/pyscitt/pyscitt/cli/split_payload.py
+++ b/pyscitt/pyscitt/cli/split_payload.py
@@ -30,7 +30,7 @@ def cli(fn):
     )
 
     def cmd(args):
-        split_payload(args.cose, args.output)
+        split_payload(args.cose, args.out)
 
     parser.set_defaults(func=cmd)
 

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -6,7 +6,7 @@ from os import path
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "pyscitt"
-PACKAGE_VERSION = "0.4.0"
+PACKAGE_VERSION = "0.5.0"
 
 path_here = path.abspath(path.dirname(__file__))
 
@@ -37,8 +37,10 @@ setup(
     license="Apache License 2.0",
     author="SCITT CCF Team",
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "Intended Audience :: Science/Research",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
     ],


### PR DESCRIPTION
One of the challenges is how to do end-to-end verifications of the payloads that were signed into COSE, then got registered in SCITT. CBOR by nature is not a popular nor it is a user friendly format when using it in a terminal. It is important to be able to inspect the payload after the receipt/signature verification to understand what is inside and to further compare it against expectations. 

- Bumped up CLI version
- Added a new command
- Suppressed test command visibility for end users to avoid confusion around the support of did, signing, etc.
- Simplified CTS client demo script to avoid the confusing retrieval command 