### PR TITLE
Add CI pipeline stages for the SNP platform

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,6 +35,11 @@ jobs:
             nodes: [self-hosted, 1ES.Pool=gha-sgx-scitt-pool]
             options: --user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provision:/dev/sgx_provision 
             unit_tests_enabled: OFF
+          - name: snp
+            image: snp
+            nodes: ubuntu-20.04
+            options: --user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
+            unit_tests_enabled: OFF
     runs-on: ${{ matrix.platform.nodes }}
     container:
       image: ghcr.io/microsoft/ccf/app/dev/${{ matrix.platform.image }}:ccf-5.0.6
@@ -70,8 +75,9 @@ jobs:
       - run: apt-get update && apt-get install -y libcurl4-openssl-dev faketime clang-tidy-10
       - run: ./build.sh
       - run: ./run_unit_tests.sh
-        if: "${{ matrix.platform.name != 'sgx' }}"
+        if: "${{ matrix.platform.name == 'virtual' }}"
       - run: ./run_functional_tests.sh --enable-faketime
+        if: "${{ matrix.platform.name != 'snp' }}"
       - name: "Upload logs for ${{ matrix.platform.name }}"
         uses: actions/upload-artifact@v4
         if: success() || failure()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,7 +77,7 @@ jobs:
       - run: ./run_unit_tests.sh
         if: "${{ matrix.platform.name == 'virtual' }}"
       - run: ./run_functional_tests.sh --enable-faketime
-        if: "${{ matrix.platform.name != 'snp' }}"
+        if: "${{ matrix.platform.name != 'snp' }}" # Functional tests are not supported on SNP platform for the moment
       - name: "Upload logs for ${{ matrix.platform.name }}"
         uses: actions/upload-artifact@v4
         if: success() || failure()

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -231,6 +231,10 @@ extends:
             fetchTags: true
             fetchDepth: 0
             lfs: false
+          - script: |
+              sudo apt-get update
+              sudo apt-get install -y libcurl4-openssl-dev
+            displayName: Install additional packages
           - script: ./build.sh
             displayName: Build snp
             env:
@@ -241,6 +245,8 @@ extends:
       - job: snp_docker_build
         pool:
           type: linux
+          isCustom: true
+          name: scitt-dc-pool
         variables:
           ob_outputDirectory: $(Build.SourcesDirectory)/out
           PLATFORM: snp

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -239,6 +239,7 @@ extends:
             displayName: Build snp
             env:
               PLATFORM: snp
+              BUILD_TESTS: OFF
     
     - stage: snp_docker_build
       jobs:

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -212,3 +212,48 @@ extends:
               PLATFORM: sgx
               DOCKER: 1
               ELEVATE_PRIVILEGES: true # needs privileged access to run did server on 443 port
+
+    - stage: snp_build
+      jobs:
+      - job: snp_build
+        pool:
+          type: linux
+        variables:
+          ob_outputDirectory: $(Build.SourcesDirectory)/out
+          PLATFORM: snp
+          CXXFLAGS: -ferror-limit=0
+          NINJA_FLAGS: -k 0 
+          LinuxContainerImage: 'ghcr.io/microsoft/ccf/app/dev/snp:ccf-${{ parameters.CCF_VERSION }}'
+        steps:
+          - checkout: SCITT
+            path: s/
+            submodules: recursive
+            fetchTags: true
+            fetchDepth: 0
+            lfs: false
+          - script: ./build.sh
+            displayName: Build snp
+            env:
+              PLATFORM: snp
+    
+    - stage: snp_docker_build
+      jobs:
+      - job: snp_docker_build
+        pool:
+          type: linux
+        variables:
+          ob_outputDirectory: $(Build.SourcesDirectory)/out
+          PLATFORM: snp
+          CXXFLAGS: -ferror-limit=0
+          NINJA_FLAGS: -k 0 
+        steps:
+          - checkout: SCITT
+            path: s/
+            submodules: recursive
+            fetchTags: true
+            fetchDepth: 0
+            lfs: false
+          - script: ./docker/build.sh
+            displayName: Build snp with Docker
+            env:
+              PLATFORM: snp

--- a/docker/snp.Dockerfile
+++ b/docker/snp.Dockerfile
@@ -46,4 +46,7 @@ COPY --from=builder /usr/src/app/attested-fetch /tmp/scitt/
 
 WORKDIR /host/node
 
+COPY start-app.sh start-app.sh
+RUN ["chmod", "+x", "start-app.sh"]
+
 ENTRYPOINT [ "cchost" ]

--- a/docker/snp.Dockerfile
+++ b/docker/snp.Dockerfile
@@ -46,7 +46,7 @@ COPY --from=builder /usr/src/app/attested-fetch /tmp/scitt/
 
 WORKDIR /host/node
 
-COPY start-app.sh start-app.sh
+COPY docker/start-app.sh start-app.sh
 RUN ["chmod", "+x", "start-app.sh"]
 
 ENTRYPOINT [ "cchost" ]

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # This script just runs cchost with some input arguments. Due to SNP cce policy limitations, we cannot
 # express a container command containing an environment variable as the value is dynamic. By

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script just runs cchost with some input arguments. Due to SNP cce policy limitations, we cannot
+# express a container command containing an environment variable as the value is dynamic. By
+# "hiding" the environment variable usage, the policy can hardcode a static startup command of
+# ./start-app.sh.
+
+# Usage:
+# ./start-app.sh $CONFIG_ROOT $CONFIG_FILE_NAME $ADDITIONAL_ARGS
+
+# Use exec to replace the shell process with cchost, so that cchost receives signals sent to the main process.
+# Since we replace the shell process, it is not possible to run any additional logic in this script after this command is executed.
+# At the moment, this is not a problem as this script is only used to run cchost at the end. If we ever need in the future to run additional
+# logic after cchost completes, we will need a different solution (e.g., https://unix.stackexchange.com/a/146770).
+exec cchost --config="${1}/${NODE_NAME}/${2}" "${@:3}"


### PR DESCRIPTION
Related to https://github.com/microsoft/scitt-ccf-ledger/pull/224.

Adds CI pipeline stages to build SCITT on SNP platform without running functional tests, so that we can at least ensure that SNP images are valid. Support to run functional tests in the CI will be added in a future PR.  

Also adds a startup script required to run the container image with a dynamically-generated security policy in SNP. 