### PR TITLE
Update to CCF 5.0.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.6
+FROM ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.7
 
 # Dependency of the virtual build of attested-fetch.
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
   checks:
     name: Format and License Checks
     runs-on: ubuntu-20.04
-    container: ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.6
+    container: ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.7
     steps:
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout repository
@@ -42,7 +42,7 @@ jobs:
             unit_tests_enabled: OFF
     runs-on: ${{ matrix.platform.nodes }}
     container:
-      image: ghcr.io/microsoft/ccf/app/dev/${{ matrix.platform.image }}:ccf-5.0.6
+      image: ghcr.io/microsoft/ccf/app/dev/${{ matrix.platform.image }}:ccf-5.0.7
       options: ${{ matrix.platform.options }}
       env:
         # Helps to distinguish between CI and local builds.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
     name: Analyze
     
     runs-on: ubuntu-latest
-    container: ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.6
+    container: ghcr.io/microsoft/ccf/app/dev/virtual:ccf-5.0.7
     
     permissions:
       actions: read

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -8,7 +8,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: CCF_VERSION
   displayName: Target CCF version to build for
   type: string
-  default: 5.0.6
+  default: 5.0.7
 
 variables:
   SCITT_CI: 1 # used in scitt builds and tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.1]
+
+### Changes
+* Upgrade to CCF 5.0.7 (#228)
+
+## [0.10.0]
+
+### Changes
+* Upgrade to CCF 5.0.6 (#223)
+* Add AMD SEV-SNP platform support (#224)
+* Add CI pipeline stages for the SNP platform (#225)
+
 ## [0.9.0]
 
 ### Changes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,10 +42,10 @@ It is expected that you have Ubuntu 20.04. Follow the steps below to setup your 
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-5.0.6.tar.gz
-    tar xvzf ccf-5.0.6.tar.gz
-    cd CCF-ccf-5.0.6/getting_started/setup_vm/
-    ./run.sh app-dev.yml -e ccf_ver=5.0.6 -e platform=<sgx|virtual|snp> -e clang_version=<11|15>
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-5.0.7.tar.gz
+    tar xvzf ccf-5.0.7.tar.gz
+    cd CCF-ccf-5.0.7/getting_started/setup_vm/
+    ./run.sh app-dev.yml -e ccf_ver=5.0.7 -e platform=<sgx|virtual|snp> -e clang_version=<11|15>
     ```
 
 ## Compiling

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -25,7 +25,7 @@ set(DID_WEB_RESOLVER_SCRIPT "/tmp/scitt/fetch-did-web-doc.py" CACHE STRING "Path
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 
-find_package(ccf_${COMPILE_TARGET} 5.0.6 REQUIRED)
+find_package(ccf_${COMPILE_TARGET} 5.0.7 REQUIRED)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/target_link_system_libraries.cmake)

--- a/docker/enclave.Dockerfile
+++ b/docker/enclave.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=5.0.6
+ARG CCF_VERSION=5.0.7
 FROM ghcr.io/microsoft/ccf/app/dev/sgx:ccf-${CCF_VERSION} as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docker/snp.Dockerfile
+++ b/docker/snp.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=5.0.6
+ARG CCF_VERSION=5.0.7
 FROM ghcr.io/microsoft/ccf/app/dev/snp:ccf-${CCF_VERSION}  as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION=5.0.6
+ARG CCF_VERSION=5.0.7
 FROM ghcr.io/microsoft/ccf/app/dev/virtual:ccf-${CCF_VERSION}  as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -39,13 +39,13 @@ To reproduce the same measurement do a docker build locally using the expected b
 
     ```
     $ cat docker/enclave.Dockerfile | grep CCF_VERSION=
-    ARG CCF_VERSION=5.0.6
+    ARG CCF_VERSION=5.0.7
     ```
 
 - Run a build inside of the CCF docker image and make sure to use a specific path (`__w/1/s`) to the sources as this is where our Azure build server copies the sources before building. If the build was done somewhere else, make sure to obtain the required path value:
 
     ```sh
-    $ export CCF_VERSION="5.0.6"
+    $ export CCF_VERSION="5.0.7"
     $ docker run -it --rm \
         -w /__w/1/s -v $(pwd):/__w/1/s \
         -v /var/run/docker.sock:/var/run/docker.sock \

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -25,7 +25,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==5.0.6",
+        "ccf==5.0.7",
         "cryptography==43.*",  # needs to match ccf
         "httpx",
         "cbor2==5.4.*",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,5 +3,5 @@ httpx
 pytest
 loguru
 aiotools
-ccf==5.0.6
+ccf==5.0.7
 cryptography==43.*


### PR DESCRIPTION
SNP deployments on Confidential ACI are failing due to an expired certificate in the UVM collateral. CCF 5.0.7 includes a fix for ignoring the expiration time in the endorsment validation; we need this to continue running SNP integration tests on the platform.