### PR TITLE
Relax CCF version in Python dependencies in Pyscitt library

### DIFF
--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -25,7 +25,7 @@ setup(
     },
     python_requires=">=3.8",
     install_requires=[
-        "ccf==5.0.10",
+        "ccf==5.*",
         "cryptography==43.*",  # needs to match ccf
         "httpx",
         "cbor2==5.4.*",


### PR DESCRIPTION
Relax CCF version in Python dependencies in Pyscitt library

instead of using a specific one that changes fairly regularly, e.g. 5.0.7 use 5.* as the changes in CCF version do not always translate to their python library