### PR TITLE
[Draft] Update transparency configuration/service identity

### DIFF
--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -1,10 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+import os
+from pathlib import Path
+
 import pytest
 
 from pyscitt import crypto
 from pyscitt.client import Client
-from pyscitt.verify import verify_transparent_statement
+from pyscitt.verify import StaticTrustStore, verify_transparent_statement
 
 
 @pytest.mark.parametrize(
@@ -34,12 +37,15 @@ def test_make_signed_statement_transparent(
 
 
 @pytest.mark.isolated_test
-def test_recovery(client, trusted_ca, restart_service):
+def test_recovery(client, trusted_ca, trust_store, restart_service, tmp_path):
     identity = trusted_ca.create_identity(alg="PS384", kty="rsa")
 
-    client.register_signed_statement(
-        crypto.sign_json_statement(identity, {"foo": "bar"})
-    )
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"})
+
+    transparent_statement = client.register_signed_statement(
+        signed_statement
+    ).response_bytes
+    verify_transparent_statement(transparent_statement, trust_store, signed_statement)
 
     old_network = client.get("/node/network").json()
     assert old_network["recovery_count"] == 0
@@ -50,7 +56,15 @@ def test_recovery(client, trusted_ca, restart_service):
     assert new_network["recovery_count"] == 1
     assert new_network["service_certificate"] != old_network["service_certificate"]
 
-    # Check that the service is still operating correctly
-    client.register_signed_statement(
-        crypto.sign_json_statement(identity, {"foo": "hello"})
+    with open(tmp_path / "params.json", "w") as f:
+        f.write(client.get("/parameters").text)
+    new_trust_store = StaticTrustStore.load(tmp_path)
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "baz"})
+
+    transparent_statement = client.register_signed_statement(
+        signed_statement
+    ).response_bytes
+    verify_transparent_statement(
+        transparent_statement, new_trust_store, signed_statement
     )


### PR DESCRIPTION
Follow up to #230, expand test_recovery, and start moving towards recent transparency configuration draft

- [ ] Implement new transparency-configuration endpoint
- [ ] Update test TrustStore logic accordingly