### PR TITLE
Adds ASAN build to GH actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -84,5 +84,6 @@ jobs:
         with:
           name: logs-${{ matrix.platform.name }}
           path: |
-            out
-          if-no-files-found: ignore
+            /tmp/pytest-of-root/*current/*current/*.{out,err}
+            /tmp/pytest-of-root/*current/*current/config.json
+          if-no-files-found: warn

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -50,6 +50,6 @@ jobs:
         with:
           name: logs-asan
           path: |
-          /tmp/pytest-of-root/*current/*current/*.{out,err}
-          /tmp/pytest-of-root/*current/*current/config.json
+            /tmp/pytest-of-root/*current/*current/*.{out,err}
+            /tmp/pytest-of-root/*current/*current/config.json
           if-no-files-found: warn

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           name: logs-asan
           path: |
-            workspace/config.json
-            workspace/std.out
-            workspace/std.err
-          if-no-files-found: ignore
+          /tmp/pytest-of-root/*current/*current/*.{out,err}
+          /tmp/pytest-of-root/*current/*current/config.json
+          if-no-files-found: warn

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -1,0 +1,50 @@
+name: Long Test
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+      - opened
+      - reopened
+  schedule:
+    - cron: "0 0 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  long-asan:
+    name: ASAN
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'run-long-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/microsoft/ccf/ci/default:build-08-10-2024
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          PLATFORM=virtual CMAKE_BUILD_TYPE=Debug BUILD_CCF_FROM_SOURCE=ON ./build.sh
+
+      - name: Unit tests
+        run: |
+          set +x
+          ./run_unit_tests.sh
+      
+      - name: E2E tests
+        run: |
+          set +x
+          PLATFORM=virtual ./run_functional_tests.sh
+
+      - name: "Upload logs"
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-asan
+          path: |
+            build/workspace/*/*.config.json
+            build/workspace/*/out
+            build/workspace/*/err
+            build/workspace/*.ledger/*
+          if-no-files-found: ignore

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -43,8 +43,7 @@ jobs:
         with:
           name: logs-asan
           path: |
-            build/workspace/*/*.config.json
-            build/workspace/*/out
-            build/workspace/*/err
-            build/workspace/*.ledger/*
+            workspace/config.json
+            workspace/std.out
+            workspace/std.err
           if-no-files-found: ignore

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -18,6 +18,13 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/microsoft/ccf/ci/default:build-08-10-2024
+    env:
+      # Fast unwinder only gives us partial stack traces in LeakSanitzer
+      # Alloc/dealloc mismatch has been disabled in CCF: https://github.com/microsoft/CCF/pull/5157
+      ASAN_OPTIONS: fast_unwind_on_malloc=0:alloc_dealloc_mismatch=0
+      PLATFORM: virtual
+      CMAKE_BUILD_TYPE: Debug
+      BUILD_CCF_FROM_SOURCE: ON
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,7 +32,7 @@ jobs:
       - name: Build
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          PLATFORM=virtual CMAKE_BUILD_TYPE=Debug BUILD_CCF_FROM_SOURCE=ON ./build.sh
+          ./build.sh
 
       - name: Unit tests
         run: |
@@ -35,7 +42,7 @@ jobs:
       - name: E2E tests
         run: |
           set +x
-          PLATFORM=virtual ./run_functional_tests.sh
+          ./run_functional_tests.sh
 
       - name: "Upload logs"
         if: success() || failure()

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 *.pyc
+ccf-source/
 build/
 tmp/
 out/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -137,8 +137,10 @@ scitt-ccf-ledger has unit tests, covering individual components of the source co
 
 The unit tests can be run with `run_unit_tests.sh` script.
 
+**Using your host environment**
+
 ```sh
-PLATFORM="virtual" ./docker/build.sh
+PLATFORM=virtual CMAKE_BUILD_TYPE=Debug ./build.sh
 ./run_unit_tests.sh
 ```
 
@@ -163,6 +165,17 @@ DOCKER=1 PLATFORM=virtual ./run_functional_tests.sh
 
 ```sh
 PLATFORM=virtual ./build.sh
+PLATFORM=virtual ./run_functional_tests.sh
+```
+
+### Address sanitization
+
+To enable ASan it is necessary to build CCF from source:
+
+```sh
+PLATFORM=virtual CMAKE_BUILD_TYPE=Debug BUILD_CCF_FROM_SOURCE=ON ./build.sh
+# once complete you run the tests
+./run_unit_tests.sh
 PLATFORM=virtual ./run_functional_tests.sh
 ```
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if((NOT CMAKE_CXX_COMPILER)
    AND "$ENV{CXX}" STREQUAL ""
 )
@@ -35,6 +37,9 @@ set(CMAKE_GENERATED_COMMENT
 )
 configure_file(src/generated/constants.h.in src/generated/constants.h @ONLY)
 
+# add CCF dependencies
+# add linking options
+# add SAN options if CCF is built with them
 add_ccf_app(scitt
   SRCS src/main.cpp
   INCLUDE_DIRS ${CCF_DIR}/include/ccf/_private

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ CCF_UNSAFE=${CCF_UNSAFE:-OFF}
 BUILD_TESTS=${BUILD_TESTS:-ON}
 ENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF}
 NINJA_FLAGS=${NINJA_FLAGS:-}
+BUILD_CCF_FROM_SOURCE=${BUILD_CCF_FROM_SOURCE:-OFF}
 
 if [ "$PLATFORM" = "sgx" ]; then
     CC=${CC:-clang-11}
@@ -25,6 +26,30 @@ elif [ "$PLATFORM" = "virtual" ] || [ "$PLATFORM" = "snp" ]; then
 else
     echo "Unknown platform: $PLATFORM, must be 'sgx', 'virtual', or 'snp'"
     exit 1
+fi
+
+if [ "$BUILD_CCF_FROM_SOURCE" = "ON" ]; then
+    CCF_SOUCE_VERSION="5.0.10"
+    echo "Cloning CCF sources"
+    rm -rf ccf-source
+    git clone --single-branch -b "ccf-${CCF_SOUCE_VERSION}" https://github.com/microsoft/CCF ccf-source
+    echo "Installing build dependencies for CCF"
+    pushd ccf-source/
+    pushd getting_started/setup_vm/
+    apt-get -y update
+    ./run.sh ccf-dev.yml -e ccf_ver="$CCF_SOUCE_VERSION" -e platform="$PLATFORM" -e clang_version=15
+    popd
+    echo "Compiling CCF $PLATFORM"
+    mkdir -p build
+    pushd build
+    cmake -L -GNinja -DCMAKE_INSTALL_PREFIX="/opt/ccf_${PLATFORM}" -DCOMPILE_TARGET="$PLATFORM" -DBUILD_TESTS=OFF -DBUILD_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF -DSAN=ON ..
+    ninja
+    echo "Packaging CCF into deb"
+    cpack -G DEB
+    echo "Installing CCF deb"
+    dpkg -i "ccf_virtual_${CCF_SOUCE_VERSION}_amd64.deb"
+    popd
+    popd
 fi
 
 git submodule sync

--- a/build.sh
+++ b/build.sh
@@ -29,15 +29,15 @@ else
 fi
 
 if [ "$BUILD_CCF_FROM_SOURCE" = "ON" ]; then
-    CCF_SOUCE_VERSION="5.0.10"
+    CCF_SOURCE_VERSION="5.0.10"
     echo "Cloning CCF sources"
     rm -rf ccf-source
-    git clone --single-branch -b "ccf-${CCF_SOUCE_VERSION}" https://github.com/microsoft/CCF ccf-source
+    git clone --single-branch -b "ccf-${CCF_SOURCE_VERSION}" https://github.com/microsoft/CCF ccf-source
     echo "Installing build dependencies for CCF"
     pushd ccf-source/
     pushd getting_started/setup_vm/
     apt-get -y update
-    ./run.sh ccf-dev.yml -e ccf_ver="$CCF_SOUCE_VERSION" -e platform="$PLATFORM" -e clang_version=15
+    ./run.sh ccf-dev.yml -e ccf_ver="$CCF_SOURCE_VERSION" -e platform="$PLATFORM" -e clang_version=15
     popd
     echo "Compiling CCF $PLATFORM"
     mkdir -p build
@@ -47,7 +47,7 @@ if [ "$BUILD_CCF_FROM_SOURCE" = "ON" ]; then
     echo "Packaging CCF into deb"
     cpack -G DEB
     echo "Installing CCF deb"
-    dpkg -i "ccf_virtual_${CCF_SOUCE_VERSION}_amd64.deb"
+    dpkg -i "ccf_virtual_${CCF_SOURCE_VERSION}_amd64.deb"
     popd
     popd
 fi

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -64,9 +64,6 @@ if [ -n "$ENABLE_PERF_TESTS" ]; then
     echo "Performance tests enabled"
 fi
 
-mkdir -p out
-TEST_ARGS="$TEST_ARGS --basetemp=out"
-
 echo "Running functional tests..."
 if [ -n "$ELEVATE_PRIVILEGES" ]; then
     sudo -E --preserve-env=PATH \
@@ -75,6 +72,3 @@ if [ -n "$ELEVATE_PRIVILEGES" ]; then
 else
     pytest ./test -v -rA $TEST_ARGS "$@"
 fi
-
-# OB pipeline can't copy out symlinks which are created by pytest.
-find out -maxdepth 1 -type l -delete

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -135,6 +135,8 @@ class CCHost(EventLoopThread):
             )
         else:
             self.snp_attestation_config = {}
+        
+        LOG.info("Starting cchost using workspace directory {}", self.workspace)
 
     def restart(self) -> None:
         # Delete PID file to let cchost restart

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -135,7 +135,7 @@ class CCHost(EventLoopThread):
             )
         else:
             self.snp_attestation_config = {}
-        
+
         LOG.info("Starting cchost using workspace directory {}", self.workspace)
 
     def restart(self) -> None:


### PR DESCRIPTION
Reviving disabled address sanitization ASAN as seen in https://github.com/microsoft/scitt-ccf-ledger/blob/044cd546914f86a0fe524223eaa1dbad50cf9f83/.pipelines/azure-pipelines.yml 

This is similar to what CCF does https://github.com/microsoft/CCF/blob/main/.github/workflows/long-test.yml 

ASAN depends on it being enabled in CCF (when using cmake functions `add_ccf_app` or `add_san`). For this CCF needs to be built from source with `-DSAN` flag after which subsequent scitt ledger build will have ASAN enabled and ready to be evaluated through unit and functional tests.

