### PR TITLE
Set up CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# https://help.github.com/en/articles/about-code-owners
+
+# Every review will request the SCITT-dev team as reviewer, unless a later match takes precedence
+* @Microsoft/scitt-dev


### PR DESCRIPTION
Useful to get a well-defined set of reviewers, and a sensible default on all new PRs.