### PR TITLE
Remove now-unused maps

### DIFF
--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -185,15 +185,8 @@ namespace scitt
     Configuration, policy, authentication, service_identifier);
 
   // Tables
-
   static constexpr auto ENTRY_TABLE = "public:scitt.entry";
   using EntryTable = ccf::kv::RawCopySerialisedValue<std::vector<uint8_t>>;
-
-  static constexpr auto ENTRY_INFO_TABLE = "public:scitt.entry_info";
-  using EntryInfoTable = ccf::kv::Value<EntryInfo>;
-
-  static constexpr auto ISSUERS_TABLE = "public:scitt.issuers";
-  using IssuersTable = ccf::kv::Map<Issuer, IssuerInfo>;
 
   static constexpr auto OPERATIONS_TABLE = "public:scitt.operations";
   using OperationsTable = ccf::kv::Value<OperationLog>;

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -359,9 +359,6 @@ namespace scitt
         const auto parsed_query =
           ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
 
-        bool embed_receipt =
-          get_query_value<bool>(parsed_query, "embedReceipt").value_or(false);
-
         SCITT_DEBUG("Get transaction historical state");
         auto historical_tx = historical_state->store->create_read_only_tx();
 
@@ -376,38 +373,7 @@ namespace scitt
               historical_state->transaction_id.to_str()));
         }
 
-        std::vector<uint8_t> entry_out;
-        if (embed_receipt)
-        {
-          SCITT_DEBUG("Get saved SCITT entry");
-          auto entry_info_table =
-            historical_tx.template ro<EntryInfoTable>(ENTRY_INFO_TABLE);
-          auto entry_info = entry_info_table->get().value();
-
-          SCITT_DEBUG("Get CCF receipt");
-          auto ccf_receipt_ptr =
-            ccf::describe_receipt_v2(*historical_state->receipt);
-          std::vector<uint8_t> receipt;
-          try
-          {
-            SCITT_DEBUG("Build SCITT receipt");
-            receipt = serialize_receipt(entry_info, ccf_receipt_ptr);
-
-            SCITT_DEBUG("Embed SCITT receipt into the entry response");
-            entry_out = cose::embed_receipt(entry.value(), receipt);
-          }
-          catch (const ReceiptProcessingError& e)
-          {
-            SCITT_FAIL("Failed to embed receipt: {}", e.what());
-            throw InternalError(e.what());
-          }
-        }
-        else
-        {
-          entry_out = std::move(entry.value());
-        }
-
-        ctx.rpc_ctx->set_response_body(entry_out);
+        ctx.rpc_ctx->set_response_body(entry.value());
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::CONTENT_TYPE, "application/cose");
       };

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -16,7 +16,6 @@ def retrieve_signed_claimsets(
     from_seqno: Optional[int],
     to_seqno: Optional[int],
     service_trust_store_path: Optional[Path],
-    embed_receipt: bool = False,
 ):
     base_path.mkdir(parents=True, exist_ok=True)
 
@@ -26,7 +25,7 @@ def retrieve_signed_claimsets(
         service_trust_store = None
 
     for tx in client.enumerate_statements(start=from_seqno, end=to_seqno):
-        claim = client.get_claim(tx, embed_receipt=embed_receipt)
+        claim = client.get_claim(tx)
         path = base_path / f"{tx}.cose"
 
         if service_trust_store:
@@ -68,7 +67,6 @@ def cli(fn):
             args.from_seqno,
             args.to_seqno,
             args.service_trust_store,
-            args.embed_receipt,
         )
 
     parser.set_defaults(func=cmd)

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -548,10 +548,8 @@ class Client(BaseClient):
     def get_operations(self):
         return self.get("/operations").json()["operations"]
 
-    def get_claim(self, tx: str, *, embed_receipt=False) -> bytes:
-        response = self.get_historical(
-            f"/entries/{tx}", params={"embedReceipt": embed_receipt}
-        )
+    def get_claim(self, tx: str) -> bytes:
+        response = self.get_historical(f"/entries/{tx}")
         return response.content
 
     def get_signed_statement(self, tx: str) -> bytes:


### PR DESCRIPTION
`issuers` is a leftover from #231 and `entry_info` is no longer necessary now the receipt is over the input signed statement.

Similarly, the embed functionality is superseded by transparent statements.