### PR TITLE
Remove CCF_UNSAFE

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -17,7 +17,6 @@ project(scitt
 )
 
 set(COMPILE_TARGET "snp" CACHE STRING "Target compilation platform, either 'virtual', or 'snp'")
-option(CCF_UNSAFE "Use CCF's unsafe variant (must be separately installed)" OFF)
 option(BUILD_TESTS "Whether to build tests" ON)
 option(ENABLE_CLANG_TIDY "Run clang-tidy on the codebase" OFF)
 # Added as option to enable Azure Linux build in 6.0.0-dev7, will eventually be removed

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,6 @@ set -ex
 
 CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}
 PLATFORM=${PLATFORM:-snp}
-CCF_UNSAFE=${CCF_UNSAFE:-OFF}
 BUILD_TESTS=${BUILD_TESTS:-ON}
 ENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF}
 NINJA_FLAGS=${NINJA_FLAGS:-}
@@ -33,7 +32,7 @@ if [ "$BUILD_CCF_FROM_SOURCE" = "ON" ]; then
     echo "Compiling CCF $PLATFORM"
     mkdir -p build
     pushd build
-    cmake -L -GNinja -DCMAKE_INSTALL_PREFIX="/opt/ccf_${PLATFORM}" -DCOMPILE_TARGET="$PLATFORM" -DBUILD_TESTS=OFF -DBUILD_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DLVI_MITIGATIONS=OFF -DSAN=ON ..
+    cmake -L -GNinja -DCMAKE_INSTALL_PREFIX="/opt/ccf_${PLATFORM}" -DCOMPILE_TARGET="$PLATFORM" -DBUILD_TESTS=OFF -DBUILD_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DSAN=ON ..
     ninja
     echo "Packaging CCF into deb"
     cpack -D CPACK_DEBIAN_FILE_NAME=ccf_virtual_amd64.deb -G DEB
@@ -51,13 +50,12 @@ install_dir=/tmp/scitt
 
 mkdir -p $install_dir
 
-# Note: LVI mitigations are disabled as this is a development build.
+# Note: this is a development build.
 # See docker/ for a non-development build.
 CC="$CC" CXX="$CXX" \
     cmake -GNinja -B build/app \
     -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DCOMPILE_TARGET="${PLATFORM}" \
-    -DCCF_UNSAFE="${CCF_UNSAFE}" \
     -DBUILD_TESTS="${BUILD_TESTS}" \
     -DCMAKE_INSTALL_PREFIX=$install_dir \
     -DENABLE_CLANG_TIDY="${ENABLE_CLANG_TIDY}" \


### PR DESCRIPTION
This flag is not needed post-SGX, instead we can use this flag on cchost:

```
--enclave-log-level ENUM:value in {debug->1,fail->3,fatal->4,info->2,trace->0} OR {1,3,4,2,0}
                              Logging level for the enclave code (security critical)
```

which will be captured in the command section of the CCEPolicy and therefore the attestation.