### PR TITLE
Delete dpkg list files containing ppa.lauchpad.net from docker images

### DIFF
--- a/docker/snp.Dockerfile
+++ b/docker/snp.Dockerfile
@@ -2,7 +2,8 @@ ARG CCF_VERSION=6.0.0-dev19
 FROM ghcr.io/microsoft/ccf/app/dev/snp:ccf-${CCF_VERSION}  as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE
-
+# remove all files that reference the ppa
+RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
 # Build CCF app
 COPY ./app /tmp/app/
 RUN mkdir /tmp/app-build && \
@@ -18,14 +19,12 @@ RUN mkdir /tmp/app-build && \
 
 FROM ghcr.io/microsoft/ccf/app/run/snp:ccf-${CCF_VERSION}
 ARG CCF_VERSION
-
 WORKDIR /usr/src/app
+# remove all files that reference the ppa
+RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
 COPY --from=builder /usr/src/app/lib/libscitt.snp.so libscitt.snp.so
 COPY --from=builder /usr/src/app/share/VERSION VERSION
-
 WORKDIR /host/node
-
 COPY docker/start-app.sh start-app.sh
 RUN ["chmod", "+x", "start-app.sh"]
-
 ENTRYPOINT [ "cchost" ]

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -2,7 +2,8 @@ ARG CCF_VERSION=6.0.0-dev19
 FROM ghcr.io/microsoft/ccf/app/dev/virtual:ccf-${CCF_VERSION}  as builder
 ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE
-
+# remove all files that reference the ppa
+RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
 # Build CCF app
 COPY ./app /tmp/app/
 RUN mkdir /tmp/app-build && \
@@ -18,11 +19,10 @@ RUN mkdir /tmp/app-build && \
 
 FROM ghcr.io/microsoft/ccf/app/run/virtual:ccf-${CCF_VERSION}
 ARG CCF_VERSION
-
 WORKDIR /usr/src/app
+# remove all files that reference the ppa
+RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
 COPY --from=builder /usr/src/app/lib/libscitt.virtual.so libscitt.virtual.so
 COPY --from=builder /usr/src/app/share/VERSION VERSION
-
 WORKDIR /host/node
-
 ENTRYPOINT [ "cchost" ]


### PR DESCRIPTION
As part of the network isolation we've been instructed to get rid of ppa.lauchpad.net from the images.

It is introduced in CCF base images we use for running our application, e.g.:

```
~: $ docker run --rm -it ghcr.io/microsoft/ccf/app/run/virtual:ccf-6.0.0-dev19 /bin/bash
root@e957c9711c78:/# grep -Ril "ppa.launchpad.net" /etc
/etc/apt/sources.list.d/ppa_ubuntu_toolchain_r_test_focal.list
```

