### PR TITLE
Removed Python dependencies step

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,10 +63,10 @@ jobs:
       # Manually disable Launchpad repository
       - name: Disable Launchpad and PPA repositories
         run: |
-          sudo sed -i.bak '/launchpad.net/s/^/#/' /etc/apt/sources.list
-          sudo sed -i.bak '/ppa.launchpad.net/s/^/#/' /etc/apt/sources.list
-          sudo find /etc/apt/sources.list.d/ -type f -exec sed -i.bak '/launchpad.net/s/^/#/' {} \;
-          sudo find /etc/apt/sources.list.d/ -type f -exec sed -i.bak '/ppa.launchpad.net/s/^/#/' {} \;
+          sudo sed -i '/launchpad.net/d' /etc/apt/sources.list
+          sudo sed -i '/ppa.launchpad.net/d' /etc/apt/sources.list
+          sudo find /etc/apt/sources.list.d/ -type f -exec sed -i '/launchpad.net/d' {} \;
+          sudo find /etc/apt/sources.list.d/ -type f -exec sed -i '/ppa.launchpad.net/d' {} \;
 
       - run: apt-get update && apt-get install -y clang-tidy-15
       - run: ./build.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,6 +59,15 @@ jobs:
       # Work-around for https://github.com/actions/runner/issues/2033
       - name: Work around git safe.directory in container
         run: chown -R $(id -u):$(id -g) $PWD
+
+      # Manually disable Launchpad repository
+      - name: Disable Launchpad and PPA repositories
+        run: |
+          sudo sed -i.bak '/launchpad.net/s/^/#/' /etc/apt/sources.list
+          sudo sed -i.bak '/ppa.launchpad.net/s/^/#/' /etc/apt/sources.list
+          sudo find /etc/apt/sources.list.d/ -type f -exec sed -i.bak '/launchpad.net/s/^/#/' {} \;
+          sudo find /etc/apt/sources.list.d/ -type f -exec sed -i.bak '/ppa.launchpad.net/s/^/#/' {} \;
+
       - run: apt-get update && apt-get install -y clang-tidy-15
       - run: ./build.sh
       - run: ./run_unit_tests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Work around git safe.directory in container
         run: chown -R $(id -u):$(id -g) $PWD
 
-      # Manually disable Launchpad repository
+      # Manually disable Launchpad repository to reduce the chances of a supply chain attack
       - name: Disable Launchpad and PPA repositories
         run: |
           sudo sed -i '/launchpad.net/d' /etc/apt/sources.list

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -97,7 +97,7 @@ extends:
           # unit tests run only on virtual platform
           - script: ./run_unit_tests.sh
             displayName: Run Unit tests
-          - template: ado_pipauth.yml@self
+          - template: .pipelines/ado_pipauth.yml@self
           - script: ./run_functional_tests.sh
             displayName: Run Functional Tests
 
@@ -121,7 +121,7 @@ extends:
             lfs: false
           - script: ./docker/build.sh
             displayName: Build virtual with Docker
-          - template: ado_pipauth.yml@self
+          - template: .pipelines/ado_pipauth.yml@self
           - script: ./run_functional_tests.sh
             displayName: Run Functional Tests
             env:

--- a/.pipelines/pullrequest.yml
+++ b/.pipelines/pullrequest.yml
@@ -97,7 +97,7 @@ extends:
           # unit tests run only on virtual platform
           - script: ./run_unit_tests.sh
             displayName: Run Unit tests
-          - template: .pipelines/python.yml@self
+          - template: ado_pipauth.yml@self
           - script: ./run_functional_tests.sh
             displayName: Run Functional Tests
 
@@ -121,7 +121,7 @@ extends:
             lfs: false
           - script: ./docker/build.sh
             displayName: Build virtual with Docker
-          - template: .pipelines/python.yml@self
+          - template: ado_pipauth.yml@self
           - script: ./run_functional_tests.sh
             displayName: Run Functional Tests
             env:

--- a/.pipelines/python.yml
+++ b/.pipelines/python.yml
@@ -1,9 +1,0 @@
-steps:
-- script: |
-    sudo apt-get -q update
-    sudo apt-get -qq install -y software-properties-common
-    sudo apt-get -q update
-    sudo apt-get -qq clean
-    sudo rm -rf /var/lib/apt/lists/*
-  displayName: Install python dependencies
-- template: ado_pipauth.yml@self


### PR DESCRIPTION
- Removed python.yml since it's not needed anymore. We are now referencing directly only ado_pipauth.yml.
- Explicitly delete any reference to **launchpad** in the repository files 