### PR TITLE
Remove usage of CCF private headers

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if((NOT CMAKE_CXX_COMPILER)
    AND "$ENV{CXX}" STREQUAL ""
 )
-  set(CMAKE_CXX_COMPILER "clang++-11")
-  message("Set CMAKE_CXX_COMPILER to clang++-11")
+  set(CMAKE_CXX_COMPILER "clang++-15")
+  message("Set CMAKE_CXX_COMPILER to clang++-15")
 endif()
 
 project(scitt
@@ -37,7 +37,6 @@ configure_file(src/generated/constants.h.in src/generated/constants.h @ONLY)
 # add SAN options if CCF is built with them
 add_ccf_app(scitt
   SRCS src/main.cpp
-  INCLUDE_DIRS ${CCF_DIR}/include/ccf/_private
   INSTALL_LIBS ON
 )
 
@@ -133,7 +132,6 @@ if (BUILD_TESTS)
     unit_tests SYSTEM PRIVATE
     ${CCF_DIR}/include
     ${CCF_DIR}/include/3rdparty
-    ${CCF_DIR}/include/ccf/_private # public_key.h and verifier.h depend on crypto/openssl/openssl_wrappers.h
   )
 
   if (ENABLE_CLANG_TIDY)

--- a/app/src/public_key.h
+++ b/app/src/public_key.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <crypto/openssl/openssl_wrappers.h>
+#include <ccf/crypto/openssl/openssl_wrappers.h>
 #include <optional>
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -11,10 +11,10 @@
 #include "signature_algorithms.h"
 #include "tracing.h"
 
+#include <ccf/crypto/openssl/openssl_wrappers.h>
 #include <ccf/crypto/pem.h>
 #include <ccf/crypto/rsa_key_pair.h>
 #include <ccf/service/tables/cert_bundles.h>
-#include <crypto/openssl/openssl_wrappers.h>
 #include <fmt/format.h>
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3


### PR DESCRIPTION
Depends on CCF 6.0.0-rc1 being released (https://github.com/microsoft/CCF/pull/6895), and scitt-ccf-ledger being updated accordingly.