### PR TITLE
[Draft] Build on Azure Linux 3.0

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -88,7 +88,7 @@ if (BUILD_TESTS)
   FetchContent_Declare(
     rapidcheck
     GIT_REPOSITORY https://github.com/emil-e/rapidcheck.git
-    GIT_TAG 8fafda42e732164db58003e542196e94a28481f9
+    GIT_TAG ff6af6fc683159deb51c543b065eba14dfcf329b
   )
 
   # We use an explicit GetProperties and Populate rather than the more concise MakeAvailable,

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -78,6 +78,8 @@ namespace scitt
           return {
             .operation_id = operation_id,
             .status = OperationStatus::Running,
+            .entry_id = {},
+            .error = {}
           };
 
         case ccf::TxStatus::Invalid:
@@ -89,6 +91,7 @@ namespace scitt
           return {
             .operation_id = operation_id,
             .status = OperationStatus::Failed,
+            .entry_id = {},
             .error =
               ODataError{
                 .code = ccf::errors::TransactionInvalid,
@@ -120,6 +123,8 @@ namespace scitt
         return {
           .operation_id = operation_id,
           .status = OperationStatus::Running,
+          .entry_id = {},
+          .error = {}
         };
       }
       else if (auto it = operations_.find(operation_id.seqno);
@@ -448,7 +453,10 @@ namespace scitt
     auto operations_table = tx.template rw<OperationsTable>(OPERATIONS_TABLE);
     operations_table->put(OperationLog{
       .status = OperationStatus::Succeeded,
+      .operation_id = {},
       .created_at = current_time.tv_sec,
+      .context_digest = {},
+      .error = {}
     });
   }
 
@@ -486,6 +494,8 @@ namespace scitt
     GetOperation::Out operation{
       .operation_id = tx_id,
       .status = OperationStatus::Running,
+      .entry_id = {},
+      .error = {}
     };
 
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);

--- a/app/src/public_key.h
+++ b/app/src/public_key.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <crypto/openssl/openssl_wrappers.h>
+#include <ccf/crypto/openssl/openssl_wrappers.h>
 #include <optional>
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3

--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,8 @@ BUILD_TESTS=${BUILD_TESTS:-ON}
 ENABLE_CLANG_TIDY=${ENABLE_CLANG_TIDY:-OFF}
 NINJA_FLAGS=${NINJA_FLAGS:-}
 BUILD_CCF_FROM_SOURCE=${BUILD_CCF_FROM_SOURCE:-OFF}
-CC=${CC:-clang-15}
-CXX=${CXX:-clang++-15}
+CC=${CC:-clang-18}
+CXX=${CXX:-clang++-18}
 
 if [ "$PLATFORM" != "virtual" ] && [ "$PLATFORM" != "snp" ]; then
     echo "Unknown platform: $PLATFORM, must be 'virtual', or 'snp'"


### PR DESCRIPTION
Minor overlap with #292, this can be used to build on Azure Linux 3.0.

Pausing to look at a packaging improvement on the CCF side, which will make the CI setup easier.

Note: once the transition is complete, the #ifdef for OpenSSL 1.x can be removed.