### PR TITLE
Removed apt.llvm.org from Docker Images

### DIFF
--- a/docker/snp.Dockerfile
+++ b/docker/snp.Dockerfile
@@ -24,6 +24,7 @@ ARG CCF_VERSION
 WORKDIR /usr/src/app
 # remove all files that reference the ppa
 RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
+RUN find /etc/apt -type f -exec grep -Ril 'apt.llvm.org' {} \; -exec rm -f {} +
 COPY --from=builder /usr/src/app/lib/libscitt.snp.so libscitt.snp.so
 COPY --from=builder /usr/src/app/share/VERSION VERSION
 WORKDIR /host/node

--- a/docker/snp.Dockerfile
+++ b/docker/snp.Dockerfile
@@ -4,6 +4,8 @@ ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE
 # remove all files that reference the ppa
 RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
+RUN find /etc/apt -type f -exec grep -Ril 'apt.llvm.org' {} \; -exec rm -f {} +
+
 # Build CCF app
 COPY ./app /tmp/app/
 RUN mkdir /tmp/app-build && \

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -23,6 +23,7 @@ ARG CCF_VERSION
 WORKDIR /usr/src/app
 # remove all files that reference the ppa
 RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
+RUN find /etc/apt -type f -exec grep -Ril 'apt.llvm.org' {} \; -exec rm -f {} +
 COPY --from=builder /usr/src/app/lib/libscitt.virtual.so libscitt.virtual.so
 COPY --from=builder /usr/src/app/share/VERSION VERSION
 WORKDIR /host/node

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -4,6 +4,7 @@ ARG CCF_VERSION
 ARG SCITT_VERSION_OVERRIDE
 # remove all files that reference the ppa
 RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
+RUN find /etc/apt -type f -exec grep -Ril 'apt.llvm.org' {} \; -exec rm -f {} +
 # Build CCF app
 COPY ./app /tmp/app/
 RUN mkdir /tmp/app-build && \


### PR DESCRIPTION
- Removed apt.llvm.org from Docker Images
- Validated that the endpoint is not being used in both PR and Official builds.
