### PR TITLE
Add option to redirect cchost logs to local port in SNP images

### DIFF
--- a/docker/snp.Dockerfile
+++ b/docker/snp.Dockerfile
@@ -25,6 +25,10 @@ WORKDIR /usr/src/app
 # remove all files that reference the ppa
 RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
 RUN find /etc/apt -type f -exec grep -Ril 'apt.llvm.org' {} \; -exec rm -f {} +
+
+# Install ncat for logs forwarding
+RUN apt update && apt install -y ncat
+
 COPY --from=builder /usr/src/app/lib/libscitt.snp.so libscitt.snp.so
 COPY --from=builder /usr/src/app/share/VERSION VERSION
 WORKDIR /host/node

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -16,8 +16,11 @@
 # logic after cchost completes, we will need a different solution (e.g., https://unix.stackexchange.com/a/146770).
 
 # If the OUTPUT_LOGS_FILE is not empty, redirect the command output to the file
+# If OUTPUT_LOCAL_PORT is not empty, redirect the command output to the specified port on localhost
 if [ -n "${OUTPUT_LOGS_FILE}" ]; then
     exec cchost --config="${1}/${NODE_NAME}/${2}" "${@:3}" 2>&1 | tee -a "$OUTPUT_LOGS_FILE"
+elif [ -n "${OUTPUT_LOCAL_PORT}" ]; then
+    exec cchost --config="${1}/${NODE_NAME}/${2}" "${@:3}" 2>&1 | tee >(nc "127.0.0.1" "$OUTPUT_LOCAL_PORT")
 else
     exec cchost --config="${1}/${NODE_NAME}/${2}" "${@:3}"
 fi

--- a/docker/virtual.Dockerfile
+++ b/docker/virtual.Dockerfile
@@ -5,6 +5,7 @@ ARG SCITT_VERSION_OVERRIDE
 # remove all files that reference the ppa
 RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
 RUN find /etc/apt -type f -exec grep -Ril 'apt.llvm.org' {} \; -exec rm -f {} +
+
 # Build CCF app
 COPY ./app /tmp/app/
 RUN mkdir /tmp/app-build && \
@@ -24,7 +25,13 @@ WORKDIR /usr/src/app
 # remove all files that reference the ppa
 RUN find /etc/apt -type f -exec grep -Ril 'ppa.launchpad.net' {} \; -exec rm -f {} +
 RUN find /etc/apt -type f -exec grep -Ril 'apt.llvm.org' {} \; -exec rm -f {} +
+
+# Install ncat for logs forwarding
+RUN apt update && apt install -y ncat
+
 COPY --from=builder /usr/src/app/lib/libscitt.virtual.so libscitt.virtual.so
 COPY --from=builder /usr/src/app/share/VERSION VERSION
 WORKDIR /host/node
+COPY docker/start-app.sh start-app.sh
+RUN ["chmod", "+x", "start-app.sh"]
 ENTRYPOINT [ "cchost" ]


### PR DESCRIPTION
Similar to #294. This time, we add an option to send logs to a local TCP port that can be used to direct stdout/stderr to a local logging agent (e.g., fluentd) in virtual node deployments, without the need to write to file and having to deal with rotating logs.