### PR TITLE
Fix release action after upgrade to Azure Linux 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ on:
 jobs:
   build_pyscitt:
     name: "Build pyscitt"
-    runs-on: [self-hosted, 1ES.Pool=gha-scitt-pool]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       
@@ -33,7 +33,7 @@ jobs:
 
   create_github_release:
     name: "Create GitHub Release"
-    runs-on: [self-hosted, 1ES.Pool=gha-scitt-pool]
+    runs-on: ubuntu-latest
     needs: build_pyscitt
 
     permissions:
@@ -60,7 +60,7 @@ jobs:
 
   publish_pyscitt_to_pypi:
     name: "Publish pyscitt to PyPI"
-    runs-on: [self-hosted, 1ES.Pool=gha-scitt-pool]
+    runs-on: ubuntu-latest
     needs: build_pyscitt
 
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,54 +31,54 @@ jobs:
           name: dist
           path: pyscitt/dist
 
-  create_github_release:
-    name: "Create GitHub Release"
-    runs-on: ubuntu-latest
-    needs: build_pyscitt
+  # create_github_release:
+  #   name: "Create GitHub Release"
+  #   runs-on: ubuntu-latest
+  #   needs: build_pyscitt
 
-    permissions:
-      contents: write # IMPORTANT: this permission is mandatory for creating a GitHub Release
+  #   permissions:
+  #     contents: write # IMPORTANT: this permission is mandatory for creating a GitHub Release
     
-    steps:
+  #   steps:
 
-      - name: Checkout code
-        uses: actions/checkout@v4
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Download pyscitt dist folder
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: pyscitt/dist
+  #     - name: Download pyscitt dist folder
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: dist
+  #         path: pyscitt/dist
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            pyscitt/dist/*.whl
-            pyscitt/dist/*.tar.gz
-            LICENSE.txt
+  #     - name: Create GitHub Release
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         files: |
+  #           pyscitt/dist/*.whl
+  #           pyscitt/dist/*.tar.gz
+  #           LICENSE.txt
 
-  publish_pyscitt_to_pypi:
-    name: "Publish pyscitt to PyPI"
-    runs-on: ubuntu-latest
-    needs: build_pyscitt
+  # publish_pyscitt_to_pypi:
+  #   name: "Publish pyscitt to PyPI"
+  #   runs-on: ubuntu-latest
+  #   needs: build_pyscitt
 
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing to PyPi
+  #   permissions:
+  #     id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing to PyPi
     
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pyscitt
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/pyscitt
       
-    steps:
-      - name: Download pyscitt dist folder
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: pyscitt/dist
+  #   steps:
+  #     - name: Download pyscitt dist folder
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: dist
+  #         path: pyscitt/dist
 
-      - name: Publish pyscitt to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: pyscitt/dist
-          skip-existing: true
+  #     - name: Publish pyscitt to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         packages-dir: pyscitt/dist
+  #         skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - "*.*.*"
@@ -32,54 +31,54 @@ jobs:
           name: dist
           path: pyscitt/dist
 
-  # create_github_release:
-  #   name: "Create GitHub Release"
-  #   runs-on: ubuntu-latest
-  #   needs: build_pyscitt
+  create_github_release:
+    name: "Create GitHub Release"
+    runs-on: ubuntu-latest
+    needs: build_pyscitt
 
-  #   permissions:
-  #     contents: write # IMPORTANT: this permission is mandatory for creating a GitHub Release
+    permissions:
+      contents: write # IMPORTANT: this permission is mandatory for creating a GitHub Release
     
-  #   steps:
+    steps:
 
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Download pyscitt dist folder
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: dist
-  #         path: pyscitt/dist
+      - name: Download pyscitt dist folder
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: pyscitt/dist
 
-  #     - name: Create GitHub Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         files: |
-  #           pyscitt/dist/*.whl
-  #           pyscitt/dist/*.tar.gz
-  #           LICENSE.txt
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            pyscitt/dist/*.whl
+            pyscitt/dist/*.tar.gz
+            LICENSE.txt
 
-  # publish_pyscitt_to_pypi:
-  #   name: "Publish pyscitt to PyPI"
-  #   runs-on: ubuntu-latest
-  #   needs: build_pyscitt
+  publish_pyscitt_to_pypi:
+    name: "Publish pyscitt to PyPI"
+    runs-on: ubuntu-latest
+    needs: build_pyscitt
 
-  #   permissions:
-  #     id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing to PyPi
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing to PyPi
     
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/pyscitt
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyscitt
       
-  #   steps:
-  #     - name: Download pyscitt dist folder
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: dist
-  #         path: pyscitt/dist
+    steps:
+      - name: Download pyscitt dist folder
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: pyscitt/dist
 
-  #     - name: Publish pyscitt to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         packages-dir: pyscitt/dist
-  #         skip-existing: true
+      - name: Publish pyscitt to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: pyscitt/dist
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "*.*.*"


### PR DESCRIPTION
Release action started failing on the new self-hosted pools after #298: https://github.com/microsoft/scitt-ccf-ledger/actions/runs/14736913806/job/41365202114

Revert to use ubuntu managed pools to build pyscitt since the platform used shouldn't make any difference. Changes were manually tested here (excluding creation of new GH release and pyscitt publishing): https://github.com/microsoft/scitt-ccf-ledger/actions/runs/14737404260/job/41366870820