### PR TITLE
[CLI ]Verify transparent statement using issuer endpoint in the receipt

### DIFF
--- a/app/unit-tests/historical/lru_test.cpp
+++ b/app/unit-tests/historical/lru_test.cpp
@@ -89,9 +89,8 @@ namespace
     LRU<int, int> cache(capacity);
     std::optional<std::pair<int, int>> last_culled;
 
-    cache.set_cull_callback([&last_culled](int k, int v) {
-      last_culled = {{k, v}};
-    });
+    cache.set_cull_callback(
+      [&last_culled](int k, int v) { last_culled = {{k, v}}; });
 
     for (size_t i = 0; i < insertions.size(); i++)
     {

--- a/app/unit-tests/historical/lru_test.cpp
+++ b/app/unit-tests/historical/lru_test.cpp
@@ -89,8 +89,9 @@ namespace
     LRU<int, int> cache(capacity);
     std::optional<std::pair<int, int>> last_culled;
 
-    cache.set_cull_callback(
-      [&last_culled](int k, int v) { last_culled = {{k, v}}; });
+    cache.set_cull_callback([&last_culled](int k, int v) {
+      last_culled = {{k, v}};
+    });
 
     for (size_t i = 0; i < insertions.size(); i++)
     {

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -6,7 +6,12 @@ from pathlib import Path
 from typing import Optional
 
 from ..client import Client
-from ..verify import StaticTrustStore, DynamicTrustStore, verify_transparent_statement
+from ..verify import (
+    DynamicTrustStore,
+    StaticTrustStore,
+    TrustStore,
+    verify_transparent_statement,
+)
 from .client_arguments import add_client_arguments, create_client
 
 
@@ -19,6 +24,7 @@ def retrieve_signed_claimsets(
 ):
     base_path.mkdir(parents=True, exist_ok=True)
 
+    service_trust_store: TrustStore
     if service_trust_store_path:
         service_trust_store = StaticTrustStore.load(service_trust_store_path)
     else:

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from ..client import Client
-from ..verify import StaticTrustStore, verify_transparent_statement
+from ..verify import StaticTrustStore, DynamicTrustStore, verify_transparent_statement
 from .client_arguments import add_client_arguments, create_client
 
 
@@ -22,7 +22,7 @@ def retrieve_signed_claimsets(
     if service_trust_store_path:
         service_trust_store = StaticTrustStore.load(service_trust_store_path)
     else:
-        service_trust_store = None
+        service_trust_store = DynamicTrustStore(client.get)
 
     for tx in client.enumerate_statements(start=from_seqno, end=to_seqno):
         claim = client.get_claim(tx)

--- a/pyscitt/pyscitt/cli/retrieve_signed_claims.py
+++ b/pyscitt/pyscitt/cli/retrieve_signed_claims.py
@@ -22,7 +22,7 @@ def retrieve_signed_claimsets(
     if service_trust_store_path:
         service_trust_store = StaticTrustStore.load(service_trust_store_path)
     else:
-        service_trust_store = DynamicTrustStore(client.get)
+        service_trust_store = DynamicTrustStore()
 
     for tx in client.enumerate_statements(start=from_seqno, end=to_seqno):
         claim = client.get_claim(tx)

--- a/pyscitt/pyscitt/cli/validate.py
+++ b/pyscitt/pyscitt/cli/validate.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from pycose.messages import Sign1Message
 
-from ..client import Client
 from ..verify import StaticTrustStore, DynamicTrustStore, verify_transparent_statement
 
 
@@ -28,8 +27,7 @@ def validate_transparent_statement(
     if service_trust_store_path is not None:
         service_trust_store = StaticTrustStore.load(service_trust_store_path)
     else:
-        client = Client()
-        service_trust_store = DynamicTrustStore(client.get)
+        service_trust_store = DynamicTrustStore()
 
     verify_transparent_statement(
         transparent_statment_bytes, service_trust_store, signed_statement

--- a/pyscitt/pyscitt/cli/validate.py
+++ b/pyscitt/pyscitt/cli/validate.py
@@ -6,7 +6,12 @@ from typing import Optional
 
 from pycose.messages import Sign1Message
 
-from ..verify import StaticTrustStore, DynamicTrustStore, verify_transparent_statement
+from ..verify import (
+    DynamicTrustStore,
+    StaticTrustStore,
+    TrustStore,
+    verify_transparent_statement,
+)
 
 
 def strip_uhdr(cose: bytes) -> bytes:
@@ -24,6 +29,7 @@ def validate_transparent_statement(
 ):
     transparent_statment_bytes = statement.read_bytes()
     signed_statement = strip_uhdr(transparent_statment_bytes)
+    service_trust_store: TrustStore
     if service_trust_store_path is not None:
         service_trust_store = StaticTrustStore.load(service_trust_store_path)
     else:

--- a/pyscitt/pyscitt/cli/validate.py
+++ b/pyscitt/pyscitt/cli/validate.py
@@ -6,7 +6,8 @@ from typing import Optional
 
 from pycose.messages import Sign1Message
 
-from ..verify import StaticTrustStore, verify_transparent_statement
+from ..client import Client
+from ..verify import StaticTrustStore, DynamicTrustStore, verify_transparent_statement
 
 
 def strip_uhdr(cose: bytes) -> bytes:
@@ -20,11 +21,15 @@ def strip_uhdr(cose: bytes) -> bytes:
 
 def validate_transparent_statement(
     statement: Path,
-    service_trust_store_path: Path,
+    service_trust_store_path: Optional[Path] = None,
 ):
     transparent_statment_bytes = statement.read_bytes()
     signed_statement = strip_uhdr(transparent_statment_bytes)
-    service_trust_store = StaticTrustStore.load(service_trust_store_path)
+    if service_trust_store_path is not None:
+        service_trust_store = StaticTrustStore.load(service_trust_store_path)
+    else:
+        client = Client()
+        service_trust_store = DynamicTrustStore(client.get)
 
     verify_transparent_statement(
         transparent_statment_bytes, service_trust_store, signed_statement

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -279,7 +279,9 @@ class DynamicTrustStore(TrustStore):
             cert = x509.load_pem_x509_certificate(pem.encode(), default_backend())
             kid = (
                 sha256(
-                    cert.public_key().public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+                    cert.public_key().public_bytes(
+                        Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+                    )
                 )
                 .digest()
                 .hex()

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -222,10 +222,10 @@ class DynamicTrustStoreClient:
         for jwks_key in jwks["keys"]:
             try:
                 pem_b = jwk.JWK.from_json(json.dumps(jwks_key)).export_to_pem()
-                cert = x509.load_pem_x509_certificate(pem_b, default_backend())
+                pub_key = load_pem_public_key(pem_b, default_backend())
                 pubhash = (
                     sha256(
-                        cert.public_key().public_bytes(
+                        pub_key.public_bytes(
                             Encoding.DER, PublicFormat.SubjectPublicKeyInfo
                         )
                     )

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -196,10 +196,15 @@ class DynamicTrustStoreClient:
 
     clients: Dict[str, httpx.Client] = {}
 
-    def __init__(self):
+    def __init__(self, forced_httpclient: Optional[httpx.Client] = None):
         self.retries = 5
+        # forced client is used in testing
+        self._forced_httpclient = forced_httpclient
 
     def _client(self, cadata: Optional[str] = None) -> httpx.Client:
+        if self._forced_httpclient is not None:
+            return self._forced_httpclient
+
         if cadata:
             ssl_context = ssl.create_default_context()
             ssl_context.load_verify_locations(cadata=cadata)

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -2,9 +2,8 @@
 # Licensed under the MIT License.
 
 import base64
-import httpx
-import ssl
 import json
+import ssl
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from hashlib import sha256
@@ -13,6 +12,7 @@ from typing import Dict, Optional
 
 import cbor2
 import ccf.cose
+import httpx
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 from cryptography.hazmat.primitives.serialization import (
@@ -165,7 +165,8 @@ class DynamicTrustStore(TrustStore):
     A dynamic trust store, based on a single service identity used to retrieve
     all keys from the service's transparency configuration endpoint.
     """
-    def __init__(self, client = None):
+
+    def __init__(self, client=None):
         if client is None:
             client = DynamicTrustStoreClient()
         self.client = client
@@ -185,13 +186,14 @@ class DynamicTrustStore(TrustStore):
         key = keys[parsed.phdr[KID]]
         pem_key = jwk.JWK.from_json(json.dumps(key)).export_to_pem()
         key = load_pem_public_key(pem_key, default_backend())
-        return key
+        return key  # type: ignore
 
 
 class DynamicTrustStoreClient:
     """
     A client for retrieving public keys from a transparency service identified by an issuer.
     """
+
     clients: Dict[str, httpx.Client] = {}
 
     def __init__(self):
@@ -205,7 +207,7 @@ class DynamicTrustStoreClient:
         else:
             transport = httpx.HTTPTransport(retries=self.retries)
         return httpx.Client(transport=transport)
-    
+
     def _client_for_issuer(self, issuer: str) -> httpx.Client:
         """
         Lightweight caching of clients based on issuer.
@@ -226,7 +228,9 @@ class DynamicTrustStoreClient:
         transparency_configuration.raise_for_status()
         config_response = cbor2.loads(transparency_configuration.content)
         jwks_uri = config_response["jwks_uri"]
-        return self._client_for_issuer(issuer).get(jwks_uri, headers={"Accept": "application/json"})
+        return self._client_for_issuer(issuer).get(
+            jwks_uri, headers={"Accept": "application/json"}
+        )
 
     def get_configuration(self, issuer: str):
         """
@@ -235,8 +239,11 @@ class DynamicTrustStoreClient:
         if not issuer:
             raise ValueError("Issuer cannot be empty")
 
-        return self._client_for_issuer(issuer).get("https://" + issuer + "/.well-known/transparency-configuration", headers={"Accept": "application/cbor"})
-    
+        return self._client_for_issuer(issuer).get(
+            "https://" + issuer + "/.well-known/transparency-configuration",
+            headers={"Accept": "application/cbor"},
+        )
+
     def is_confidential_ledger_issuer(self, issuer: str) -> bool:
         return issuer.endswith(".confidential-ledger.azure.com")
 
@@ -247,7 +254,10 @@ class DynamicTrustStoreClient:
         if not self.is_confidential_ledger_issuer(issuer):
             raise ValueError("Issuer is not a Confidential Ledger issuer")
         service_name = issuer.split(".")[0]
-        response = self._client().get(f"https://identity.confidential-ledger.core.azure.com/ledgerIdentity/{service_name}", headers={"Accept": "application/json"})
+        response = self._client().get(
+            f"https://identity.confidential-ledger.core.azure.com/ledgerIdentity/{service_name}",
+            headers={"Accept": "application/json"},
+        )
         response.raise_for_status()
         ledger_identity = response.json()
         if "ledgerTlsCertificate" not in ledger_identity:
@@ -257,4 +267,3 @@ class DynamicTrustStoreClient:
         if "-----BEGIN CERTIFICATE-----" not in ledger_identity["ledgerTlsCertificate"]:
             raise ValueError("TLS certificate is not in PEM format")
         return ledger_identity["ledgerTlsCertificate"]
-        

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -2,17 +2,17 @@
 # Licensed under the MIT License.
 
 import base64
+import httpx
+import ssl
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
 import cbor2
 import ccf.cose
-import httpx
-import pycose
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 from cryptography.hazmat.primitives.serialization import (
@@ -28,7 +28,6 @@ from pycose.messages import Sign1Message
 
 from . import crypto
 from .crypto import CWT_ISS, CWTClaims
-from .receipt import Receipt
 
 
 @dataclass
@@ -166,27 +165,20 @@ class DynamicTrustStore(TrustStore):
     A dynamic trust store, based on a single service identity used to retrieve
     all keys from the service's transparency configuration endpoint.
     """
+    def __init__(self, client = None):
+        if client is None:
+            client = DynamicTrustStoreClient()
+        self.client = client
 
-    services: Dict[str, ServiceParameters] = {}
-
-    def __init__(self, getter):
-        self.services = {}
-        self.getter = getter
+    @property
+    def services(self):
+        raise NotImplementedError()
 
     def get_key(self, receipt: bytes) -> CertificatePublicKeyTypes:
         parsed = Sign1Message.decode(receipt)
         cwt = parsed.phdr[CWTClaims]
         issuer = cwt[CWT_ISS]
-
-        transparency_configuration = self.getter(
-            f"https://{issuer}/.well-known/transparency-configuration",
-            headers={"Accept": "application/cbor"},
-        )
-        transparency_configuration.raise_for_status()
-        config_response = cbor2.loads(transparency_configuration.content)
-
-        jwks_uri = config_response["jwks_uri"]
-        jwk_set = self.getter(jwks_uri)
+        jwk_set = self.client.get_jwks(issuer)
         jwk_set.raise_for_status()
         jwks = jwk_set.json()["keys"]
         keys = {key["kid"].encode(): key for key in jwks}
@@ -194,3 +186,75 @@ class DynamicTrustStore(TrustStore):
         pem_key = jwk.JWK.from_json(json.dumps(key)).export_to_pem()
         key = load_pem_public_key(pem_key, default_backend())
         return key
+
+
+class DynamicTrustStoreClient:
+    """
+    A client for retrieving public keys from a transparency service identified by an issuer.
+    """
+    clients: Dict[str, httpx.Client] = {}
+
+    def __init__(self):
+        self.retries = 5
+
+    def _client(self, cadata: Optional[str] = None) -> httpx.Client:
+        if cadata:
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(cadata=cadata)
+            transport = httpx.HTTPTransport(verify=ssl_context, retries=self.retries)
+        else:
+            transport = httpx.HTTPTransport(retries=self.retries)
+        return httpx.Client(transport=transport)
+    
+    def _client_for_issuer(self, issuer: str) -> httpx.Client:
+        """
+        Lightweight caching of clients based on issuer.
+        """
+        if issuer not in self.clients:
+            if self.is_confidential_ledger_issuer(issuer):
+                pem = self.get_confidential_ledger_tls_pem(issuer)
+                self.clients[issuer] = self._client(cadata=pem)
+            else:
+                self.clients[issuer] = self._client()
+        return self.clients[issuer]
+
+    def get_jwks(self, issuer: str) -> httpx.Response:
+        """
+        Retrieve the JWKS from the issuer.
+        """
+        transparency_configuration = self.get_configuration(issuer)
+        transparency_configuration.raise_for_status()
+        config_response = cbor2.loads(transparency_configuration.content)
+        jwks_uri = config_response["jwks_uri"]
+        return self._client_for_issuer(issuer).get(jwks_uri, headers={"Accept": "application/json"})
+
+    def get_configuration(self, issuer: str):
+        """
+        Retrieve the transparency configuration from the issuer.
+        """
+        if not issuer:
+            raise ValueError("Issuer cannot be empty")
+
+        return self._client_for_issuer(issuer).get("https://" + issuer + "/.well-known/transparency-configuration", headers={"Accept": "application/cbor"})
+    
+    def is_confidential_ledger_issuer(self, issuer: str) -> bool:
+        return issuer.endswith(".confidential-ledger.azure.com")
+
+    def get_confidential_ledger_tls_pem(self, issuer: str):
+        """
+        Retrieve the TLS certificate for a Confidential Ledger issuer.
+        """
+        if not self.is_confidential_ledger_issuer(issuer):
+            raise ValueError("Issuer is not a Confidential Ledger issuer")
+        service_name = issuer.split(".")[0]
+        response = self._client().get(f"https://identity.confidential-ledger.core.azure.com/ledgerIdentity/{service_name}", headers={"Accept": "application/json"})
+        response.raise_for_status()
+        ledger_identity = response.json()
+        if "ledgerTlsCertificate" not in ledger_identity:
+            raise ValueError("TLS certificate not found in ledger identity")
+        if not isinstance(ledger_identity["ledgerTlsCertificate"], str):
+            raise ValueError("TLS certificate is not a string")
+        if "-----BEGIN CERTIFICATE-----" not in ledger_identity["ledgerTlsCertificate"]:
+            raise ValueError("TLS certificate is not in PEM format")
+        return ledger_identity["ledgerTlsCertificate"]
+        

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -14,6 +14,7 @@ import cbor2
 import ccf.cose
 import httpx
 from azure.confidentialledger.certificate import ConfidentialLedgerCertificateClient
+from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 from cryptography.hazmat.primitives.serialization import (
@@ -275,10 +276,10 @@ class DynamicTrustStore(TrustStore):
             if pem is None:
                 raise ValueError(f"No TLS certificate for issuer {issuer}.")
             # calculate pem public key sha256
-            key = load_pem_public_key(pem.encode(), default_backend())
+            cert = x509.load_pem_x509_certificate(pem.encode(), default_backend())
             kid = (
                 sha256(
-                    key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+                    cert.public_key().public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
                 )
                 .digest()
                 .hex()

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -35,6 +35,7 @@ setup(
         "types-jwcrypto",
         "azure-keyvault",
         "azure-identity",
+        "azure-confidentialledger==1.*",
     ],
     license="Apache License 2.0",
     author="SCITT CCF Team",

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -6,7 +6,7 @@ from os import path
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "pyscitt"
-PACKAGE_VERSION = "0.11.1"
+PACKAGE_VERSION = "0.11.2"
 
 path_here = path.abspath(path.dirname(__file__))
 

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -35,9 +35,11 @@ pip install --disable-pip-version-check -q -e ./pyscitt
 pip install --disable-pip-version-check -q -r test/requirements.txt
 
 echo "-- Python types"
+mypy -V
 git ls-files | grep -e '\.py$' | xargs mypy
 
 echo "-- Python imports"
+isort --version
 if [ $FIX -ne 0 ]; then
    git ls-files | grep -e '\.py$' | xargs isort
 else
@@ -45,6 +47,7 @@ else
 fi
 
 echo "-- Python format"
+black --version
 if [ $FIX -ne 0 ]; then
    git ls-files | grep -e '\.py$' | xargs black
 else

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -12,7 +12,11 @@ from jwcrypto import jwk
 
 from pyscitt import crypto
 from pyscitt.client import Client
-from pyscitt.verify import DynamicTrustStore, DynamicTrustStoreClient, verify_transparent_statement
+from pyscitt.verify import (
+    DynamicTrustStore,
+    DynamicTrustStoreClient,
+    verify_transparent_statement,
+)
 
 from .infra.assertions import service_error
 
@@ -88,7 +92,9 @@ def test_make_signed_statement_transparent(
     ).response_bytes
     verify_transparent_statement(transparent_statement, trust_store, signed_statement)
 
-    dynamic_trust_store = DynamicTrustStore(client=DynamicTrustStoreClient(forced_httpclient=client.session))
+    dynamic_trust_store = DynamicTrustStore(
+        client=DynamicTrustStoreClient(forced_httpclient=client.session)
+    )
     verify_transparent_statement(
         transparent_statement, dynamic_trust_store, signed_statement
     )
@@ -136,7 +142,9 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
     assert old_jwk in jwks["keys"]
     assert new_jwk in jwks["keys"]
 
-    dynamic_trust_store = DynamicTrustStore(client=DynamicTrustStoreClient(forced_httpclient=client.session))
+    dynamic_trust_store = DynamicTrustStore(
+        client=DynamicTrustStoreClient(forced_httpclient=client.session)
+    )
     verify_transparent_statement(
         first_transparent_statement, dynamic_trust_store, first_signed_statement
     )

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -12,7 +12,7 @@ from jwcrypto import jwk
 
 from pyscitt import crypto
 from pyscitt.client import Client
-from pyscitt.verify import DynamicTrustStore, verify_transparent_statement
+from pyscitt.verify import DynamicTrustStore, DynamicTrustStoreClient, verify_transparent_statement
 
 from .infra.assertions import service_error
 
@@ -88,7 +88,7 @@ def test_make_signed_statement_transparent(
     ).response_bytes
     verify_transparent_statement(transparent_statement, trust_store, signed_statement)
 
-    dynamic_trust_store = DynamicTrustStore(client.get)
+    dynamic_trust_store = DynamicTrustStore(client=DynamicTrustStoreClient(forced_httpclient=client.session))
     verify_transparent_statement(
         transparent_statement, dynamic_trust_store, signed_statement
     )
@@ -136,7 +136,7 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
     assert old_jwk in jwks["keys"]
     assert new_jwk in jwks["keys"]
 
-    dynamic_trust_store = DynamicTrustStore(client.get)
+    dynamic_trust_store = DynamicTrustStore(client=DynamicTrustStoreClient(forced_httpclient=client.session))
     verify_transparent_statement(
         first_transparent_statement, dynamic_trust_store, first_signed_statement
     )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -205,7 +205,7 @@ def test_extract_payload_from_cose(run, tmp_path: Path):
     assert claims.get("foo") == "bar"
 
 
-def test_submit_and_validate(tmp_path, client: Client, configure_service):
+def test_submit_and_validate(run, tmp_path, client: Client, configure_service):
     allow_all_policy_script = "export function apply(phdr) {return true}"
     configure_service({"policy": {"policyScript": allow_all_policy_script}})
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -13,12 +13,12 @@ from loguru import logger as LOG
 from pycose.messages import CoseMessage
 
 from pyscitt import crypto
-from pyscitt.client import Client
 from pyscitt.cli.governance import (
     SCITT_CONSTITUTION_MARKER_END,
     SCITT_CONSTITUTION_MARKER_START,
 )
 from pyscitt.cli.main import main
+from pyscitt.client import Client
 from pyscitt.governance import ProposalNotAccepted
 
 from .infra.assertions import service_error
@@ -227,8 +227,7 @@ def test_submit_and_validate(tmp_path, client: Client, configure_service):
         "pretty-receipt",
         tmp_path / "transparent_statement.cose",
     )
-    
-    
+
 
 @pytest.mark.isolated_test
 class TestUpdateScittConstitution:

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -3,14 +3,18 @@
 
 import base64
 import json
+from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import httpx
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-from cryptography.x509 import load_pem_x509_certificate
+from cryptography.x509 import Certificate, load_pem_x509_certificate
+from cryptography.x509.oid import NameOID
 from pycose.headers import KID
 from pycose.messages import Sign1Message
 
@@ -73,12 +77,35 @@ class TestDynamicTrustStore:
         )
         assert result == mock_key
 
+    @patch("pyscitt.verify.x509.load_pem_x509_certificate")
     @patch("pyscitt.verify.Sign1Message")
     @patch("pyscitt.verify.load_pem_public_key")
     @patch("pyscitt.verify.sha256")
     def test_get_key_validates_cl_tls_cert(
-        self, mock_sha256, mock_load_key, mock_sign1
+        self, mock_sha256, mock_load_key, mock_sign1, mock_load_cert
     ):
+        # create test certificate
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        subject = issuer = x509.Name(
+            [
+                x509.NameAttribute(NameOID.COUNTRY_NAME, "FR"),
+                x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Pays de la Loire"),
+                x509.NameAttribute(NameOID.LOCALITY_NAME, "Nantes"),
+                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
+                x509.NameAttribute(NameOID.COMMON_NAME, "mycompany.com"),
+            ]
+        )
+        test_cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.utcnow())
+            .not_valid_after(datetime.utcnow() + timedelta(days=365))
+            .sign(key, hashes.SHA256())
+        )
+
         # Setup mocks
         mock_receipt = b"test_receipt"
         mock_parsed = Mock()
@@ -108,17 +135,19 @@ class TestDynamicTrustStore:
 
         # Mock the key loading
         mock_key = Mock()
-        mock_load_key.side_effect = [mock_key, mock_key]
+        mock_load_key.side_effect = [mock_key]
 
         mock_jwk = MagicMock()
         mock_jwk.export_to_pem.return_value = b"mock_pem"
+
+        mock_load_cert.return_value = test_cert
 
         with patch("pyscitt.verify.jwk.JWK.from_json", return_value=mock_jwk):
             trust_store = DynamicTrustStore(mock_client)
             result = trust_store.get_key(mock_receipt)
 
-        # Assertions
-        assert mock_load_key.call_count == 2  # Called for both TLS cert and JWKS
+        mock_load_cert.assert_called_once_with(b"mock_pem_cert", ANY)
+        assert mock_load_key.call_count == 1  # Called for both TLS cert and JWKS
         assert result == mock_key
 
 

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import base64
-import json
 from datetime import datetime, timedelta
+from io import BytesIO
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import ANY, DEFAULT, MagicMock, Mock, patch
 
+import cbor2
 import httpx
 import pytest
 from cryptography import x509
@@ -37,9 +37,12 @@ class TestDynamicTrustStore:
         with pytest.raises(NotImplementedError):
             _ = trust_store.services
 
+    @patch("pyscitt.verify.jwk.JWK.from_json")
     @patch("pyscitt.verify.Sign1Message")
     @patch("pyscitt.verify.load_pem_public_key")
-    def test_get_key_retrieves_from_jwks(self, mock_load_key, mock_sign1):
+    def test_get_key_retrieves_from_jwks(
+        self, mock_load_key, mock_sign1, mock_jwk_from_json
+    ):
         # Setup mocks
         mock_receipt = b"test_receipt"
         mock_parsed = Mock()
@@ -47,108 +50,28 @@ class TestDynamicTrustStore:
         mock_kid = b"test_kid"
         mock_parsed.phdr = {CWTClaims: mock_cwt, KID: mock_kid}
         mock_sign1.decode.return_value = mock_parsed
-
+        mock_matched_jwk = MagicMock()
+        mock_matched_jwk.export_to_pem.return_value = b"mock_pem"
+        mock_jwk_from_json.return_value = mock_matched_jwk
+        mock_return_key = Mock()
+        mock_load_key.return_value = mock_return_key
         mock_client = Mock()
-        mock_client.is_confidential_ledger_issuer.return_value = False
-        mock_jwks_response = Mock()
-        mock_jwks_response.raise_for_status = Mock()
-        mock_jwks_response.json.return_value = {
+        mock_client.get_jwks.return_value = {
             "keys": [{"kid": "test_kid", "kty": "RSA"}]
         }
-        mock_client.get_jwks.return_value = mock_jwks_response
 
-        mock_jwk = MagicMock()
-        mock_jwk.export_to_pem.return_value = b"mock_pem"
-
-        mock_key = Mock()
-        mock_load_key.return_value = mock_key
-
-        with patch("pyscitt.verify.jwk.JWK.from_json", return_value=mock_jwk):
-            trust_store = DynamicTrustStore(mock_client)
-            result = trust_store.get_key(mock_receipt)
+        # Create instance and call method
+        trust_store = DynamicTrustStore(mock_client)
+        result = trust_store.get_key(mock_receipt)
 
         # Assertions
         mock_sign1.decode.assert_called_once_with(mock_receipt)
         mock_client.get_jwks.assert_called_once_with("example.com")
-        mock_jwks_response.raise_for_status.assert_called_once()
         mock_load_key.assert_called_once_with(
             b"mock_pem",
             pytest.importorskip("cryptography.hazmat.backends").default_backend(),
         )
-        assert result == mock_key
-
-    @patch("pyscitt.verify.x509.load_pem_x509_certificate")
-    @patch("pyscitt.verify.Sign1Message")
-    @patch("pyscitt.verify.load_pem_public_key")
-    @patch("pyscitt.verify.sha256")
-    def test_get_key_validates_cl_tls_cert(
-        self, mock_sha256, mock_load_key, mock_sign1, mock_load_cert
-    ):
-        # create test certificate
-        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        subject = issuer = x509.Name(
-            [
-                x509.NameAttribute(NameOID.COUNTRY_NAME, "FR"),
-                x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Pays de la Loire"),
-                x509.NameAttribute(NameOID.LOCALITY_NAME, "Nantes"),
-                x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
-                x509.NameAttribute(NameOID.COMMON_NAME, "mycompany.com"),
-            ]
-        )
-        test_cert = (
-            x509.CertificateBuilder()
-            .subject_name(subject)
-            .issuer_name(issuer)
-            .public_key(key.public_key())
-            .serial_number(x509.random_serial_number())
-            .not_valid_before(datetime.utcnow())
-            .not_valid_after(datetime.utcnow() + timedelta(days=365))
-            .sign(key, hashes.SHA256())
-        )
-
-        # Setup mocks
-        mock_receipt = b"test_receipt"
-        mock_parsed = Mock()
-        mock_cwt = {CWT_ISS: "test.confidential-ledger.azure.com"}
-        mock_kid = b"test_kid"
-        mock_kid_hex = "746573745f6b6964"  # hex representation of "test_kid"
-        mock_parsed.phdr = {CWTClaims: mock_cwt, KID: bytes(mock_kid_hex, "utf-8")}
-        mock_sign1.decode.return_value = mock_parsed
-
-        mock_client = Mock()
-        mock_client.is_confidential_ledger_issuer.return_value = True
-        mock_client.confidential_ledger_certs = {
-            "test.confidential-ledger.azure.com": "mock_pem_cert"
-        }
-
-        mock_jwks_response = Mock()
-        mock_jwks_response.raise_for_status = Mock()
-        mock_jwks_response.json.return_value = {
-            "keys": [{"kid": mock_kid_hex, "kty": "RSA"}]
-        }
-        mock_client.get_jwks.return_value = mock_jwks_response
-
-        # Mock the sha256 result for TLS cert validation
-        mock_sha_obj = Mock()
-        mock_sha_obj.digest.return_value = mock_kid
-        mock_sha256.return_value = mock_sha_obj
-
-        # Mock the key loading
-        mock_key = Mock()
-        mock_load_key.side_effect = [mock_key]
-
-        mock_jwk = MagicMock()
-        mock_jwk.export_to_pem.return_value = b"mock_pem"
-
-        mock_load_cert.return_value = test_cert
-
-        with patch("pyscitt.verify.jwk.JWK.from_json", return_value=mock_jwk):
-            trust_store = DynamicTrustStore(mock_client)
-            result = trust_store.get_key(mock_receipt)
-
-        mock_load_cert.assert_called_once_with(b"mock_pem_cert", ANY)
-        assert mock_load_key.call_count == 1  # Called for both TLS cert and JWKS
-        assert result == mock_key
+        assert result == mock_return_key
 
 
 class TestDynamicTrustStoreClient:
@@ -221,3 +144,192 @@ class TestDynamicTrustStoreClient:
         client = DynamicTrustStoreClient()
         with pytest.raises(ValueError, match="Issuer cannot be empty"):
             client.get_configuration("")
+
+    @patch("pyscitt.verify.DynamicTrustStoreClient.get_confidential_ledger_tls_pem")
+    @patch("pyscitt.verify.DynamicTrustStoreClient._assert_tls_in_jwks")
+    def test_get_jwks_validates_tls_cert(
+        self, mock_assert_tls_in_jwks, mock_get_confidential_ledger_tls_pem
+    ):
+        # key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        # subject = issuer = x509.Name(
+        #     [
+        #         x509.NameAttribute(NameOID.COUNTRY_NAME, "FR"),
+        #         x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Pays de la Loire"),
+        #         x509.NameAttribute(NameOID.LOCALITY_NAME, "Nantes"),
+        #         x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
+        #         x509.NameAttribute(NameOID.COMMON_NAME, "mycompany.com"),
+        #     ]
+        # )
+        # test_cert = (
+        #     x509.CertificateBuilder()
+        #     .subject_name(subject)
+        #     .issuer_name(issuer)
+        #     .public_key(key.public_key())
+        #     .serial_number(x509.random_serial_number())
+        #     .not_valid_before(datetime.utcnow())
+        #     .not_valid_after(datetime.utcnow() + timedelta(days=365))
+        #     .sign(key, hashes.SHA256())
+        # )
+
+        # Setup mocks
+        mock_get_confidential_ledger_tls_pem.return_value = "mock_pem_cert"
+        mock_httpx_client = Mock()
+
+        def get_side_effect(*args, **kwargs):
+            if (
+                args[0]
+                == "https://foobar.confidential-ledger.azure.com/.well-known/transparency-configuration"
+            ):
+                with BytesIO() as fp:
+                    cbor2.CBOREncoder(fp).encode(
+                        {
+                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/jwks"
+                        }
+                    )
+
+                return httpx.Response(
+                    200,
+                    content=cbor2.dumps(
+                        {
+                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/jwks"
+                        }
+                    ),
+                    request=httpx.Request("GET", args[0]),
+                )
+            if args[0] == "https://foobar.confidential-ledger.azure.com/jwks":
+                return httpx.Response(
+                    200, json={"keys": ["test"]}, request=httpx.Request("GET", args[0])
+                )
+
+        mock_httpx_client.get = Mock(side_effect=get_side_effect)
+
+        # Create instance and call method
+        trust_store_client = DynamicTrustStoreClient(
+            forced_httpclient=mock_httpx_client
+        )
+        result = trust_store_client.get_jwks("foobar.confidential-ledger.azure.com")
+
+        # Assertions
+        mock_assert_tls_in_jwks.assert_called_once_with(
+            "mock_pem_cert", {"keys": ["test"]}
+        )
+        assert result == {"keys": ["test"]}
+
+    def test_assert_tls_in_jwks_raises_for_empty_tls_pem(self):
+        client = DynamicTrustStoreClient()
+        with pytest.raises(ValueError, match="TLS PEM certificate is required"):
+            client._assert_tls_in_jwks("", {"keys": []})
+
+    def test_assert_tls_in_jwks_raises_for_none_jwks(self):
+        client = DynamicTrustStoreClient()
+        with pytest.raises(ValueError, match="JWKS is required"):
+            client._assert_tls_in_jwks("certificate", None)
+
+    def test_assert_tls_in_jwks_raises_for_missing_keys(self):
+        client = DynamicTrustStoreClient()
+        with pytest.raises(ValueError, match="JWKS does not contain 'keys'"):
+            client._assert_tls_in_jwks("certificate", {"other_key": []})
+
+    @patch("pyscitt.verify.x509.load_pem_x509_certificate")
+    @patch("pyscitt.verify.sha256")
+    @patch("pyscitt.verify.jwk.JWK.from_json")
+    def test_assert_tls_in_jwks_raises_when_key_not_found(
+        self, mock_jwk_from_json, mock_sha256, mock_load_cert
+    ):
+        # Mock certificate loading and hashing
+        mock_cert = Mock()
+        mock_public_key = Mock()
+        mock_cert.public_key.return_value = mock_public_key
+        mock_public_key.public_bytes.return_value = b"mock_public_bytes"
+        mock_jwks_cert = Mock()
+        mock_jwks_public_key = Mock()
+        mock_jwks_cert.public_key.return_value = mock_jwks_public_key
+        mock_jwks_public_key.public_bytes.return_value = b"jwks_public_bytes"
+        # Second call is for JWKS key
+        mock_load_cert.side_effect = [mock_cert, mock_jwks_cert]
+
+        # cert digests
+        mock_tls_digest = Mock()
+        mock_tls_digest.digest.return_value.hex.return_value = "tls_cert_digest"
+        mock_sha256.side_effect = lambda x: (
+            mock_tls_digest if x == b"mock_public_bytes" else DEFAULT
+        )
+
+        # JWKS key setup
+        mock_jwks_key = Mock()
+        mock_jwks_key.export_to_pem.return_value = b"jwks_pem"
+        mock_jwk_from_json.return_value = mock_jwks_key
+
+        jwks = {"keys": [{"kid": "test_kid"}]}
+        client = DynamicTrustStoreClient()
+
+        with pytest.raises(
+            ValueError, match="TLS public key digest tls_cert_digest not found in JWKS"
+        ):
+            client._assert_tls_in_jwks("certificate", jwks)
+
+        # Verify all expected calls
+        mock_load_cert.assert_called()
+        assert len(mock_load_cert.call_args_list) == 2
+        mock_sha256.assert_called()
+        assert len(mock_sha256.call_args_list) == 2
+        mock_jwk_from_json.assert_called_once_with('{"kid": "test_kid"}')
+
+    @patch("pyscitt.verify.x509.load_pem_x509_certificate")
+    @patch("pyscitt.verify.sha256")
+    @patch("pyscitt.verify.jwk.JWK.from_json")
+    def test_assert_tls_in_jwks_succeeds_when_key_found(
+        self, mock_jwk_from_json, mock_sha256, mock_load_cert
+    ):
+        # Mock certificate loading and hashing
+        mock_cert = Mock()
+        mock_public_key = Mock()
+        mock_cert.public_key.return_value = mock_public_key
+        mock_public_key.public_bytes.return_value = b"mock_public_bytes"
+        mock_load_cert.return_value = mock_cert
+
+        # Same digest for both TLS cert and JWKS key
+        mock_digest = Mock()
+        mock_digest.digest.return_value.hex.return_value = "same_digest"
+        mock_sha256.return_value = mock_digest
+
+        # JWKS key setup
+        mock_jwks_key = Mock()
+        mock_jwks_key.export_to_pem.return_value = b"jwks_pem"
+        mock_jwk_from_json.return_value = mock_jwks_key
+
+        client = DynamicTrustStoreClient()
+        client._assert_tls_in_jwks("certificate", {"keys": [{"kid": "test_kid"}]})
+
+        # Verify all expected calls
+        mock_load_cert.assert_called()
+        assert len(mock_load_cert.call_args_list) == 2
+        mock_sha256.assert_called()
+        assert len(mock_sha256.call_args_list) == 2
+        mock_jwk_from_json.assert_called_once_with('{"kid": "test_kid"}')
+
+    @patch("pyscitt.verify.x509.load_pem_x509_certificate")
+    @patch("pyscitt.verify.jwk.JWK.from_json")
+    @patch("builtins.print")
+    def test_assert_tls_in_jwks_handles_invalid_jwks_key(
+        self, mock_print, mock_jwk_from_json, mock_load_cert
+    ):
+        # Mock certificate loading for TLS cert
+        mock_cert = Mock()
+        mock_public_key = Mock()
+        mock_cert.public_key.return_value = mock_public_key
+        mock_public_key.public_bytes.return_value = b"mock_public_bytes"
+        mock_load_cert.return_value = mock_cert
+
+        # Mock JWK parsing to raise exception
+        mock_jwk_from_json.side_effect = Exception("Invalid JWK")
+
+        client = DynamicTrustStoreClient()
+        # Should raise because no valid keys were found
+        with pytest.raises(
+            ValueError, match="TLS public key digest .* not found in JWKS"
+        ):
+            client._assert_tls_in_jwks("certificate", {"keys": [{"kid": "test_kid"}]})
+
+        # Verify warning was printed
+        mock_print.assert_called_with("Warning: Could not parse JWKS key: Invalid JWK")

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -1,0 +1,174 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import pytest
+import json
+import httpx
+import base64
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from cryptography.x509 import load_pem_x509_certificate
+from pyscitt.verify import DynamicTrustStore, DynamicTrustStoreClient
+from pyscitt.crypto import CWT_ISS, CWTClaims
+from pycose.messages import Sign1Message
+from pycose.headers import KID    
+
+
+class TestDynamicTrustStore:
+    def test_init_creates_client_if_none_provided(self):
+        trust_store = DynamicTrustStore()
+        assert isinstance(trust_store.client, DynamicTrustStoreClient)
+    
+    def test_init_uses_provided_client(self):
+        client = Mock()
+        trust_store = DynamicTrustStore(client)
+        assert trust_store.client is client
+    
+    def test_services_property_raises_not_implemented(self):
+        trust_store = DynamicTrustStore()
+        with pytest.raises(NotImplementedError):
+            _ = trust_store.services
+    
+    @patch('pyscitt.verify.Sign1Message')
+    @patch('pyscitt.verify.load_pem_public_key')
+    def test_get_key_retrieves_from_jwks(self, mock_load_key, mock_sign1):
+        # Setup mocks
+        mock_receipt = b"test_receipt"
+        mock_parsed = Mock()
+        mock_cwt = {CWT_ISS: "example.com"}
+        mock_kid = b"test_kid"
+        mock_parsed.phdr = {CWTClaims: mock_cwt, KID: mock_kid}
+        mock_sign1.decode.return_value = mock_parsed
+        
+        mock_client = Mock()
+        mock_client.is_confidential_ledger_issuer.return_value = False
+        mock_jwks_response = Mock()
+        mock_jwks_response.raise_for_status = Mock()
+        mock_jwks_response.json.return_value = {
+            "keys": [{"kid": "test_kid", "kty": "RSA"}]
+        }
+        mock_client.get_jwks.return_value = mock_jwks_response
+        
+        mock_jwk = MagicMock()
+        mock_jwk.export_to_pem.return_value = b"mock_pem"
+        
+        mock_key = Mock()
+        mock_load_key.return_value = mock_key
+        
+        with patch('pyscitt.verify.jwk.JWK.from_json', return_value=mock_jwk):
+            trust_store = DynamicTrustStore(mock_client)
+            result = trust_store.get_key(mock_receipt)
+        
+        # Assertions
+        mock_sign1.decode.assert_called_once_with(mock_receipt)
+        mock_client.get_jwks.assert_called_once_with("example.com")
+        mock_jwks_response.raise_for_status.assert_called_once()
+        mock_load_key.assert_called_once_with(b"mock_pem", pytest.importorskip("cryptography.hazmat.backends").default_backend())
+        assert result == mock_key
+
+    @patch('pyscitt.verify.Sign1Message')
+    @patch('pyscitt.verify.load_pem_public_key')
+    @patch('pyscitt.verify.sha256')
+    def test_get_key_validates_cl_tls_cert(self, mock_sha256, mock_load_key, mock_sign1):
+        # Setup mocks
+        mock_receipt = b"test_receipt"
+        mock_parsed = Mock()
+        mock_cwt = {CWT_ISS: "test.confidential-ledger.azure.com"}
+        mock_kid = b"test_kid"
+        mock_kid_hex = "746573745f6b6964"  # hex representation of "test_kid"
+        mock_parsed.phdr = {CWTClaims: mock_cwt, KID: bytes(mock_kid_hex, 'utf-8')}
+        mock_sign1.decode.return_value = mock_parsed
+        
+        mock_client = Mock()
+        mock_client.is_confidential_ledger_issuer.return_value = True
+        mock_client.confidential_ledger_certs = {"test.confidential-ledger.azure.com": "mock_pem_cert"}
+        
+        mock_jwks_response = Mock()
+        mock_jwks_response.raise_for_status = Mock()
+        mock_jwks_response.json.return_value = {
+            "keys": [{"kid": mock_kid_hex, "kty": "RSA"}]
+        }
+        mock_client.get_jwks.return_value = mock_jwks_response
+        
+        # Mock the sha256 result for TLS cert validation
+        mock_sha_obj = Mock()
+        mock_sha_obj.digest.return_value = mock_kid
+        mock_sha256.return_value = mock_sha_obj
+        
+        # Mock the key loading
+        mock_key = Mock()
+        mock_load_key.side_effect = [mock_key, mock_key]
+        
+        mock_jwk = MagicMock()
+        mock_jwk.export_to_pem.return_value = b"mock_pem"
+        
+        with patch('pyscitt.verify.jwk.JWK.from_json', return_value=mock_jwk):
+            trust_store = DynamicTrustStore(mock_client)
+            result = trust_store.get_key(mock_receipt)
+        
+        # Assertions
+        assert mock_load_key.call_count == 2  # Called for both TLS cert and JWKS
+        assert result == mock_key
+
+
+class TestDynamicTrustStoreClient:
+    def test_init_sets_default_values(self):
+        client = DynamicTrustStoreClient()
+        assert client.retries == 5
+        assert client._forced_httpclient is None
+        
+    def test_init_accepts_forced_client(self):
+        forced_client = httpx.Client()
+        client = DynamicTrustStoreClient(forced_httpclient=forced_client)
+        assert client._forced_httpclient is forced_client
+        
+    def test_client_returns_forced_client_when_provided(self):
+        forced_client = httpx.Client()
+        client = DynamicTrustStoreClient(forced_httpclient=forced_client)
+        assert client._client() is forced_client
+        
+    @patch('pyscitt.verify.httpx.Client')
+    @patch('pyscitt.verify.httpx.HTTPTransport')
+    @patch('pyscitt.verify.ssl')
+    def test_client_creates_new_client_with_cadata(self, mock_ssl, mock_transport, mock_client):
+        client = DynamicTrustStoreClient()
+        result = client._client(cadata="test_cert")
+        mock_ssl.create_default_context.assert_called_once()
+        mock_transport.assert_called_once()
+        mock_client.assert_called_once()
+        
+    def test_is_confidential_ledger_issuer(self):
+        client = DynamicTrustStoreClient()
+        assert client.is_confidential_ledger_issuer("test.confidential-ledger.azure.com") is True
+        assert client.is_confidential_ledger_issuer("example.com") is False
+        
+    @patch('pyscitt.verify.ConfidentialLedgerCertificateClient')
+    def test_get_confidential_ledger_tls_pem(self, mock_cl_client):
+        mock_identity_client = Mock()
+        mock_cl_client.return_value = mock_identity_client
+        mock_identity_client.get_ledger_identity.return_value = {
+            "ledgerTlsCertificate": "test_cert"
+        }
+        
+        client = DynamicTrustStoreClient()
+        result = client.get_confidential_ledger_tls_pem("test.confidential-ledger.azure.com")
+        
+        mock_identity_client.get_ledger_identity.assert_called_once_with(ledger_id="test")
+        assert result == "test_cert"
+        
+    @patch('pyscitt.verify.ConfidentialLedgerCertificateClient')
+    def test_get_confidential_ledger_tls_pem_raises_for_missing_cert(self, mock_cl_client):
+        mock_identity_client = Mock()
+        mock_cl_client.return_value = mock_identity_client
+        mock_identity_client.get_ledger_identity.return_value = {}
+        
+        client = DynamicTrustStoreClient()
+        with pytest.raises(ValueError, match="No TLS certificate found for issuer"):
+            client.get_confidential_ledger_tls_pem("test.confidential-ledger.azure.com")
+            
+    def test_get_configuration_raises_for_empty_issuer(self):
+        client = DynamicTrustStoreClient()
+        with pytest.raises(ValueError, match="Issuer cannot be empty"):
+            client.get_configuration("")

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -1,38 +1,40 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import pytest
-import json
-import httpx
 import base64
-from unittest.mock import Mock, patch, MagicMock
+import json
 from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import httpx
+import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509 import load_pem_x509_certificate
-from pyscitt.verify import DynamicTrustStore, DynamicTrustStoreClient
-from pyscitt.crypto import CWT_ISS, CWTClaims
+from pycose.headers import KID
 from pycose.messages import Sign1Message
-from pycose.headers import KID    
+
+from pyscitt.crypto import CWT_ISS, CWTClaims
+from pyscitt.verify import DynamicTrustStore, DynamicTrustStoreClient
 
 
 class TestDynamicTrustStore:
     def test_init_creates_client_if_none_provided(self):
         trust_store = DynamicTrustStore()
         assert isinstance(trust_store.client, DynamicTrustStoreClient)
-    
+
     def test_init_uses_provided_client(self):
         client = Mock()
         trust_store = DynamicTrustStore(client)
         assert trust_store.client is client
-    
+
     def test_services_property_raises_not_implemented(self):
         trust_store = DynamicTrustStore()
         with pytest.raises(NotImplementedError):
             _ = trust_store.services
-    
-    @patch('pyscitt.verify.Sign1Message')
-    @patch('pyscitt.verify.load_pem_public_key')
+
+    @patch("pyscitt.verify.Sign1Message")
+    @patch("pyscitt.verify.load_pem_public_key")
     def test_get_key_retrieves_from_jwks(self, mock_load_key, mock_sign1):
         # Setup mocks
         mock_receipt = b"test_receipt"
@@ -41,7 +43,7 @@ class TestDynamicTrustStore:
         mock_kid = b"test_kid"
         mock_parsed.phdr = {CWTClaims: mock_cwt, KID: mock_kid}
         mock_sign1.decode.return_value = mock_parsed
-        
+
         mock_client = Mock()
         mock_client.is_confidential_ledger_issuer.return_value = False
         mock_jwks_response = Mock()
@@ -50,64 +52,71 @@ class TestDynamicTrustStore:
             "keys": [{"kid": "test_kid", "kty": "RSA"}]
         }
         mock_client.get_jwks.return_value = mock_jwks_response
-        
+
         mock_jwk = MagicMock()
         mock_jwk.export_to_pem.return_value = b"mock_pem"
-        
+
         mock_key = Mock()
         mock_load_key.return_value = mock_key
-        
-        with patch('pyscitt.verify.jwk.JWK.from_json', return_value=mock_jwk):
+
+        with patch("pyscitt.verify.jwk.JWK.from_json", return_value=mock_jwk):
             trust_store = DynamicTrustStore(mock_client)
             result = trust_store.get_key(mock_receipt)
-        
+
         # Assertions
         mock_sign1.decode.assert_called_once_with(mock_receipt)
         mock_client.get_jwks.assert_called_once_with("example.com")
         mock_jwks_response.raise_for_status.assert_called_once()
-        mock_load_key.assert_called_once_with(b"mock_pem", pytest.importorskip("cryptography.hazmat.backends").default_backend())
+        mock_load_key.assert_called_once_with(
+            b"mock_pem",
+            pytest.importorskip("cryptography.hazmat.backends").default_backend(),
+        )
         assert result == mock_key
 
-    @patch('pyscitt.verify.Sign1Message')
-    @patch('pyscitt.verify.load_pem_public_key')
-    @patch('pyscitt.verify.sha256')
-    def test_get_key_validates_cl_tls_cert(self, mock_sha256, mock_load_key, mock_sign1):
+    @patch("pyscitt.verify.Sign1Message")
+    @patch("pyscitt.verify.load_pem_public_key")
+    @patch("pyscitt.verify.sha256")
+    def test_get_key_validates_cl_tls_cert(
+        self, mock_sha256, mock_load_key, mock_sign1
+    ):
         # Setup mocks
         mock_receipt = b"test_receipt"
         mock_parsed = Mock()
         mock_cwt = {CWT_ISS: "test.confidential-ledger.azure.com"}
         mock_kid = b"test_kid"
         mock_kid_hex = "746573745f6b6964"  # hex representation of "test_kid"
-        mock_parsed.phdr = {CWTClaims: mock_cwt, KID: bytes(mock_kid_hex, 'utf-8')}
+        mock_parsed.phdr = {CWTClaims: mock_cwt, KID: bytes(mock_kid_hex, "utf-8")}
         mock_sign1.decode.return_value = mock_parsed
-        
+
         mock_client = Mock()
         mock_client.is_confidential_ledger_issuer.return_value = True
-        mock_client.confidential_ledger_certs = {"test.confidential-ledger.azure.com": "mock_pem_cert"}
-        
+        mock_client.confidential_ledger_certs = {
+            "test.confidential-ledger.azure.com": "mock_pem_cert"
+        }
+
         mock_jwks_response = Mock()
         mock_jwks_response.raise_for_status = Mock()
         mock_jwks_response.json.return_value = {
             "keys": [{"kid": mock_kid_hex, "kty": "RSA"}]
         }
         mock_client.get_jwks.return_value = mock_jwks_response
-        
+
         # Mock the sha256 result for TLS cert validation
         mock_sha_obj = Mock()
         mock_sha_obj.digest.return_value = mock_kid
         mock_sha256.return_value = mock_sha_obj
-        
+
         # Mock the key loading
         mock_key = Mock()
         mock_load_key.side_effect = [mock_key, mock_key]
-        
+
         mock_jwk = MagicMock()
         mock_jwk.export_to_pem.return_value = b"mock_pem"
-        
-        with patch('pyscitt.verify.jwk.JWK.from_json', return_value=mock_jwk):
+
+        with patch("pyscitt.verify.jwk.JWK.from_json", return_value=mock_jwk):
             trust_store = DynamicTrustStore(mock_client)
             result = trust_store.get_key(mock_receipt)
-        
+
         # Assertions
         assert mock_load_key.call_count == 2  # Called for both TLS cert and JWKS
         assert result == mock_key
@@ -118,56 +127,67 @@ class TestDynamicTrustStoreClient:
         client = DynamicTrustStoreClient()
         assert client.retries == 5
         assert client._forced_httpclient is None
-        
+
     def test_init_accepts_forced_client(self):
         forced_client = httpx.Client()
         client = DynamicTrustStoreClient(forced_httpclient=forced_client)
         assert client._forced_httpclient is forced_client
-        
+
     def test_client_returns_forced_client_when_provided(self):
         forced_client = httpx.Client()
         client = DynamicTrustStoreClient(forced_httpclient=forced_client)
         assert client._client() is forced_client
-        
-    @patch('pyscitt.verify.httpx.Client')
-    @patch('pyscitt.verify.httpx.HTTPTransport')
-    @patch('pyscitt.verify.ssl')
-    def test_client_creates_new_client_with_cadata(self, mock_ssl, mock_transport, mock_client):
+
+    @patch("pyscitt.verify.httpx.Client")
+    @patch("pyscitt.verify.httpx.HTTPTransport")
+    @patch("pyscitt.verify.ssl")
+    def test_client_creates_new_client_with_cadata(
+        self, mock_ssl, mock_transport, mock_client
+    ):
         client = DynamicTrustStoreClient()
         result = client._client(cadata="test_cert")
         mock_ssl.create_default_context.assert_called_once()
         mock_transport.assert_called_once()
         mock_client.assert_called_once()
-        
+
     def test_is_confidential_ledger_issuer(self):
         client = DynamicTrustStoreClient()
-        assert client.is_confidential_ledger_issuer("test.confidential-ledger.azure.com") is True
+        assert (
+            client.is_confidential_ledger_issuer("test.confidential-ledger.azure.com")
+            is True
+        )
         assert client.is_confidential_ledger_issuer("example.com") is False
-        
-    @patch('pyscitt.verify.ConfidentialLedgerCertificateClient')
+
+    @patch("pyscitt.verify.ConfidentialLedgerCertificateClient")
     def test_get_confidential_ledger_tls_pem(self, mock_cl_client):
         mock_identity_client = Mock()
         mock_cl_client.return_value = mock_identity_client
         mock_identity_client.get_ledger_identity.return_value = {
             "ledgerTlsCertificate": "test_cert"
         }
-        
+
         client = DynamicTrustStoreClient()
-        result = client.get_confidential_ledger_tls_pem("test.confidential-ledger.azure.com")
-        
-        mock_identity_client.get_ledger_identity.assert_called_once_with(ledger_id="test")
+        result = client.get_confidential_ledger_tls_pem(
+            "test.confidential-ledger.azure.com"
+        )
+
+        mock_identity_client.get_ledger_identity.assert_called_once_with(
+            ledger_id="test"
+        )
         assert result == "test_cert"
-        
-    @patch('pyscitt.verify.ConfidentialLedgerCertificateClient')
-    def test_get_confidential_ledger_tls_pem_raises_for_missing_cert(self, mock_cl_client):
+
+    @patch("pyscitt.verify.ConfidentialLedgerCertificateClient")
+    def test_get_confidential_ledger_tls_pem_raises_for_missing_cert(
+        self, mock_cl_client
+    ):
         mock_identity_client = Mock()
         mock_cl_client.return_value = mock_identity_client
         mock_identity_client.get_ledger_identity.return_value = {}
-        
+
         client = DynamicTrustStoreClient()
         with pytest.raises(ValueError, match="No TLS certificate found for issuer"):
             client.get_confidential_ledger_tls_pem("test.confidential-ledger.azure.com")
-            
+
     def test_get_configuration_raises_for_empty_issuer(self):
         client = DynamicTrustStoreClient()
         with pytest.raises(ValueError, match="Issuer cannot be empty"):


### PR DESCRIPTION
`scitt validate file.cose` does not pull the issuer keys from the confidential ledger receipt issuer that has self signed TLS. `DynamicTrustStore` is not used in the CLI by default.

This PR expands DynamicTrustStore:
- it checks if the issuer is from confidential ledger
  - if yes then a specific TLS cert will be downloaded from their identity API to establish a secure connection to the ledger to pull the public keys
  - if the issuer is not a confidential ledger then regular TLS certs will be used (via certifi) to get the public keys
- http client is also configured to retry the failing requests to reduce the failures in case of network issues