### PR TITLE
Remove now-unused ifdefs present for OpenSSL 1.1.1 (pre-3) support

### DIFF
--- a/app/src/public_key.h
+++ b/app/src/public_key.h
@@ -4,17 +4,11 @@
 #pragma once
 
 #include <ccf/crypto/openssl/openssl_wrappers.h>
+#include <openssl/core_names.h>
+#include <openssl/encoder.h>
+#include <openssl/evp.h>
+#include <openssl/sha.h>
 #include <optional>
-
-#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
-#  include <openssl/core_names.h>
-#  include <openssl/encoder.h>
-#  include <openssl/evp.h>
-#  include <openssl/sha.h>
-#else
-throw std::runtime_error(
-  "PublicKey class requires OpenSSL version 3 or higher");
-#endif
 
 namespace scitt
 {

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -22,12 +22,9 @@
 #include <ccf/pal/uvm_endorsements.h>
 #include <ccf/service/tables/cert_bundles.h>
 #include <fmt/format.h>
-
-#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
-#  include <openssl/core_names.h>
-#  include <openssl/encoder.h>
-#  include <openssl/param_build.h>
-#endif
+#include <openssl/core_names.h>
+#include <openssl/encoder.h>
+#include <openssl/param_build.h>
 
 namespace scitt::verifier
 {


### PR DESCRIPTION
Minor clean-up for something spotted while making another change.