### PR TITLE
Expose reported TCB to policy

### DIFF
--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -251,6 +251,37 @@ namespace scitt
         uvm_obj.set("svn", ctx.new_string(uvm_endorsements.svn));
         obj.set("uvm_endorsements", std::move(uvm_obj));
       }
+      auto reported_tcb = ctx.new_obj();
+      const auto& tcb = details.get_tcb_version_policy();
+      if (tcb.microcode.has_value())
+      {
+        reported_tcb.set_uint32("microcode", tcb.microcode.value());
+      }
+      if (tcb.snp.has_value())
+      {
+        reported_tcb.set_uint32("snp", tcb.snp.value());
+      }
+      if (tcb.tee.has_value())
+      {
+        reported_tcb.set_uint32("tee", tcb.tee.value());
+      }
+      if (tcb.boot_loader.has_value())
+      {
+        reported_tcb.set_uint32("boot_loader", tcb.boot_loader.value());
+      }
+      if (tcb.fmc.has_value())
+      {
+        reported_tcb.set_uint32("fmc", tcb.fmc.value());
+      }
+      if (tcb.hexstring.has_value())
+      {
+        reported_tcb.set("hexstring", ctx.new_string(tcb.hexstring.value()));
+      }
+      obj.set("reported_tcb", std::move(reported_tcb));
+      obj.set(
+        "product_name",
+        ctx.new_string(ccf::pal::snp::to_string(details.get_product_name())));
+
       return obj;
     }
 

--- a/app/src/verified_details.h
+++ b/app/src/verified_details.h
@@ -22,6 +22,8 @@ namespace scitt::verifier
     ccf::pal::PlatformAttestationReportData report_data;
     std::optional<ccf::pal::UVMEndorsements> uvm_endorsements;
     HostData host_data = {0};
+    ccf::pal::snp::ProductName product_name;
+    ccf::pal::snp::TcbVersionPolicy tcb_version_policy;
 
   public:
     VerifiedSevSnpAttestationDetails() = default;
@@ -29,10 +31,14 @@ namespace scitt::verifier
       ccf::pal::PlatformAttestationMeasurement measurement,
       ccf::pal::PlatformAttestationReportData report_data,
       std::optional<ccf::pal::UVMEndorsements> uvm_endorsements,
-      const uint8_t host_data_[HOST_DATA_SIZE]) :
+      const uint8_t host_data_[HOST_DATA_SIZE],
+      ccf::pal::snp::ProductName product_name,
+      ccf::pal::snp::TcbVersionPolicy&& tcb_version_policy) :
       measurement(measurement),
       report_data(report_data),
-      uvm_endorsements(uvm_endorsements)
+      uvm_endorsements(uvm_endorsements),
+      product_name(product_name),
+      tcb_version_policy(tcb_version_policy)
     {
       if (host_data_ == nullptr)
       {
@@ -56,6 +62,14 @@ namespace scitt::verifier
     const HostData& get_host_data() const
     {
       return host_data;
+    }
+    const ccf::pal::snp::ProductName& get_product_name() const
+    {
+      return product_name;
+    }
+    const ccf::pal::snp::TcbVersionPolicy& get_tcb_version_policy() const
+    {
+      return tcb_version_policy;
     }
     bool is_empty() const
     {

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -275,11 +275,18 @@ namespace scitt::verifier
         reinterpret_cast<const ccf::pal::snp::Attestation*>(
           quote_info.quote.data());
 
+      auto reported_tcb = snp_attestation->reported_tcb;
+      auto product_name = ccf::pal::snp::get_sev_snp_product(
+        snp_attestation->cpuid_fam_id, snp_attestation->cpuid_mod_id);
+      auto tcb_policy = reported_tcb.to_policy(product_name);
+
       VerifiedSevSnpAttestationDetails details(
         measurement,
         report_data,
         parsed_uvm_endorsements,
-        snp_attestation->host_data);
+        snp_attestation->host_data,
+        product_name,
+        std::move(tcb_policy));
 
       // Now check that the attestation report data matches the cose key
       // This allows us to verify that the enclave knew about the key

--- a/app/unit-tests/verifier_details_test.cpp
+++ b/app/unit-tests/verifier_details_test.cpp
@@ -25,7 +25,9 @@ namespace
       ccf::pal::PlatformAttestationMeasurement(),
       ccf::pal::PlatformAttestationReportData(),
       std::nullopt,
-      host_data);
+      host_data,
+      ccf::pal::snp::ProductName(),
+      ccf::pal::snp::TcbVersionPolicy());
     EXPECT_TRUE(details.is_empty());
 
     ccf::pal::AttestationMeasurement<4> measurement("abababab");
@@ -33,7 +35,9 @@ namespace
       ccf::pal::PlatformAttestationMeasurement(measurement),
       ccf::pal::PlatformAttestationReportData(),
       std::nullopt,
-      host_data);
+      host_data,
+      ccf::pal::snp::ProductName(),
+      ccf::pal::snp::TcbVersionPolicy());
     EXPECT_FALSE(details.is_empty());
   }
   // NOLINTEND(bugprone-unchecked-optional-access)

--- a/app/unit-tests/verifier_test.cpp
+++ b/app/unit-tests/verifier_test.cpp
@@ -82,6 +82,13 @@ namespace
     EXPECT_EQ(
       host_data_str,
       "953e208258fc57d814c44a0b083dbe4e8f2e734a2fde32f1049a78890d98b730");
+    EXPECT_EQ(details->get_product_name(), ccf::pal::snp::ProductName::Milan);
+    EXPECT_EQ(details->get_tcb_version_policy().microcode, 219);
+    EXPECT_EQ(details->get_tcb_version_policy().snp, 24);
+    EXPECT_EQ(details->get_tcb_version_policy().tee, 0);
+    EXPECT_EQ(details->get_tcb_version_policy().boot_loader, 4);
+    EXPECT_EQ(details->get_tcb_version_policy().fmc, std::nullopt);
+    EXPECT_EQ(details->get_tcb_version_policy().hexstring, "db18000000000004");
   }
   // NOLINTEND(bugprone-unchecked-optional-access)
 

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -581,6 +581,14 @@ return true;
             {
                 throw new Error("Invalid uvm_endorsements svn " + details.uvm_endorsements.svn);
             }
+            if (details.product_name != "Milan")
+            {
+                throw new Error("Invalid product name " + details.product_name);
+            }
+            if (details.reported_tcb.hexstring !== "db18000000000004")
+            {
+                throw new Error("Invalid reported TCB hexstring " + details.reported_tcb.hexstring);
+            }
             return true;
         }
         """


### PR DESCRIPTION
Close #312 by exposing `product_name` and `reported_tcb` to registration policy when attestation is used.