### PR TITLE
Use release builds for benchmarks

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build and run virtual perf tests
         run: |
           ./scripts/setup-env.sh
-          ./build.sh
-          ./run_functional_tests.sh -m bencher
+          PLATFORM=bench-virtual ./build.sh
+          PLATFORM=virtual ./run_functional_tests.sh -m bencher
         shell: bash
 
       - uses: bencherdev/bencher@main

--- a/app/CMakePresets.json
+++ b/app/CMakePresets.json
@@ -44,6 +44,35 @@
         "COMPILE_TARGET": "snp",
         "BUILD_TESTS": "OFF"
       }
+    },
+    {
+      "name": "bench",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/app",
+      "installDir": "/tmp/scitt",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_C_COMPILER": "clang-18",
+        "CMAKE_CXX_COMPILER": "clang++-18",
+        "CMAKE_BUILD_WITH_INSTALL_RPATH":"ON",
+        "BUILD_TESTS": "OFF",
+        "ENABLE_CLANG_TIDY": "$env{ENABLE_CLANG_TIDY}"
+      }
+    },
+    {
+      "name": "bench-virtual",
+      "inherits": "bench",
+      "displayName": "Bench Virtual",
+      "description": "Bench build for virtual platform",
+      "cacheVariables": {
+        "COMPILE_TARGET": "virtual",
+        "BUILD_TESTS": "ON"
+      },
+      "environment": {
+        "CTEST_OUTPUT_ON_FAILURE": "1",
+        "GTEST_CATCH_EXCEPTIONS": "0"
+      }
     }
   ],
   "buildPresets": [
@@ -54,6 +83,10 @@
     {
       "name": "snp",
       "configurePreset": "dev-snp"
+    },
+    {
+      "name": "bench-virtual",
+      "configurePreset": "bench-virtual"
     }
   ],
   "testPresets": [
@@ -80,6 +113,19 @@
         {
           "type": "test",
           "name": "virtual"
+        }
+      ]
+    },
+    {
+      "name": "bench-virtual",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "bench-virtual"
+        },
+        {
+          "type": "build",
+          "name": "bench-virtual"
         }
       ]
     },

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,8 @@ set -ex
 PLATFORM=${PLATFORM:-virtual}
 BUILD_DEBUG_CCF_FROM_SOURCE=${BUILD_DEBUG_CCF_FROM_SOURCE:-OFF}
 
-if [ "$PLATFORM" != "virtual" ] && [ "$PLATFORM" != "snp" ]; then
-    echo "Unknown platform: $PLATFORM, must be 'virtual', or 'snp'"
+if [ "$PLATFORM" != "virtual" ] && [ "$PLATFORM" != "snp" ] && [ "$PLATFORM" != "bench-virtual" ]; then
+    echo "Unknown platform: $PLATFORM, must be 'virtual', or 'snp', or 'bench-virtual'"
     exit 1
 fi
 


### PR DESCRIPTION
Bencher numbers went up after the CMake refactor because the performance regression CI accidentally started building without optimisations, this small PR is fixing that.