### PR TITLE
Draft re-shape of the attestedsvc map

### DIFF
--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -37,7 +37,8 @@ namespace scitt::cose
   static constexpr int64_t COSE_HEADER_PARAM_X5CHAIN = 33;
   static constexpr int64_t COSE_HEADER_PARAM_CWT_CLAIMS = 15;
 
-  static constexpr const char* COSE_HEADER_PARAM_TSS = "msft-css-dev";
+  static constexpr const char* COSE_HEADER_PARAM_TSS = "attestedsvc";
+  static constexpr const char* COSE_HEADER_PARAM_TSS_SVC_ID = "svc_id";
   static constexpr const char* COSE_HEADER_PARAM_TSS_ATTESTATION =
     "attestation";
   static constexpr const char* COSE_HEADER_PARAM_TSS_ATTESTATION_TYPE =
@@ -273,6 +274,7 @@ namespace scitt::cose
   };
 
   /**
+  "svc_id": tstr,            ; service identifier
   "attestation": bstr,       ; raw hardware attestation report
   "attestation_type": tstr,  ; "SEV-SNP:ContainerPlat-AMD-UVM"
   "cose_key": { ... },       ; canonical COSE_Key map (embedded directly)
@@ -282,6 +284,7 @@ namespace scitt::cose
    */
   struct TSSMap
   {
+    std::optional<std::string> svc_id;
     std::optional<std::vector<uint8_t>> attestation;
     std::optional<std::string> attestation_type;
     std::optional<CoseKeyMap> cose_key;
@@ -482,6 +485,7 @@ namespace scitt::cose
 
     enum
     {
+      TSS_SVC_ID_INDEX,
       TSS_ATTESTATION_INDEX,
       TSS_ATTESTATION_TYPE_INDEX,
       TSS_SNP_ENDORSEMENTS_INDEX,
@@ -491,6 +495,11 @@ namespace scitt::cose
       TSS_END_INDEX,
     };
     QCBORItem tss_items[TSS_END_INDEX + 1];
+
+    tss_items[TSS_SVC_ID_INDEX].label.string =
+      UsefulBuf_FromSZ(COSE_HEADER_PARAM_TSS_SVC_ID);
+    tss_items[TSS_SVC_ID_INDEX].uLabelType = QCBOR_TYPE_TEXT_STRING;
+    tss_items[TSS_SVC_ID_INDEX].uDataType = QCBOR_TYPE_TEXT_STRING;
 
     tss_items[TSS_ATTESTATION_INDEX].label.string =
       UsefulBuf_FromSZ(COSE_HEADER_PARAM_TSS_ATTESTATION);
@@ -701,6 +710,11 @@ namespace scitt::cose
           tss_error));
       }
 
+      if (tss_items[TSS_SVC_ID_INDEX].uDataType != QCBOR_TYPE_NONE)
+      {
+        parsed.tss_map.svc_id =
+          cbor::as_string(tss_items[TSS_SVC_ID_INDEX].val.string);
+      }
       if (tss_items[TSS_ATTESTATION_INDEX].uDataType != QCBOR_TYPE_NONE)
       {
         parsed.tss_map.attestation =

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -125,6 +125,10 @@ namespace scitt
         obj.set("cwt", std::move(cwt));
 
         auto tss_map = ctx.new_obj();
+        if (phdr.tss_map.svc_id.has_value())
+        {
+          tss_map.set("svc_id", ctx.new_string(phdr.tss_map.svc_id.value()));
+        }
         if (phdr.tss_map.attestation.has_value())
         {
           tss_map.set(
@@ -196,7 +200,7 @@ namespace scitt
         {
           tss_map.set_int64("ver", phdr.tss_map.ver.value());
         }
-        obj.set("msft-css-dev", std::move(tss_map));
+        obj.set("attestedsvc", std::move(tss_map));
       }
 
       return obj;

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -385,6 +385,26 @@ namespace scitt::verifier
             std::tie(payload, details) =
               process_signed_statement_with_didattestedsvc_issuer(
                 phdr, configuration, signed_statement);
+
+            if (!phdr.tss_map.svc_id.has_value())
+            {
+              throw VerificationError(fmt::format(
+                "Attested service map {} must contain a service "
+                "identifier (svc_id)",
+                cose::COSE_HEADER_PARAM_TSS));
+            }
+
+            // Authenticate the did:attestedsvc issuer against the svc_id
+            // contained in the attested service map.
+            auto expected_did_prefix =
+              fmt::format("did:attestedsvc:{}:", phdr.tss_map.svc_id.value());
+            if (!phdr.cwt_claims.iss->starts_with(expected_did_prefix))
+            {
+              throw VerificationError(fmt::format(
+                "did:attestedsvc issuer does not match svc_id (expected prefix "
+                "{})",
+                expected_did_prefix));
+            }
           }
           else
           {

--- a/app/unit-tests/cose_test.cpp
+++ b/app/unit-tests/cose_test.cpp
@@ -33,89 +33,93 @@ namespace
 
   // add a test case to use payloads from test/payloads directory
   // NOLINTBEGIN(bugprone-unchecked-optional-access)
-  TEST(CoseTest, DecodeTSSHeaders)
-  {
-    std::string filepath = "test_payloads/css-attested-cosesign1-20250617.cose";
-    std::ifstream file(filepath, std::ios::binary);
-    ASSERT_TRUE(file.is_open());
 
-    size_t size = std::filesystem::file_size(filepath);
+  // TODO: needs a new sample payload with latest attestedsvc TSS map
 
-    // Read file into vector
-    std::vector<uint8_t> signed_statement(size);
-    file.read(
-      reinterpret_cast<char*>(signed_statement.data()),
-      static_cast<std::streamsize>(size));
-    ASSERT_EQ(file.gcount(), size);
+  // TEST(CoseTest, DecodeTSSHeaders)
+  // {
+  //   std::string filepath =
+  //   "test_payloads/css-attested-cosesign1-20250617.cose"; std::ifstream
+  //   file(filepath, std::ios::binary); ASSERT_TRUE(file.is_open());
 
-    cose::ProtectedHeader phdr;
-    cose::UnprotectedHeader uhdr;
-    std::tie(phdr, uhdr) = cose::decode_headers(signed_statement);
+  //   size_t size = std::filesystem::file_size(filepath);
 
-    if (!phdr.alg.has_value())
-    {
-      throw std::runtime_error("Algorithm not found in protected header");
-    }
-    EXPECT_EQ(phdr.alg.value(), -35);
+  //   // Read file into vector
+  //   std::vector<uint8_t> signed_statement(size);
+  //   file.read(
+  //     reinterpret_cast<char*>(signed_statement.data()),
+  //     static_cast<std::streamsize>(size));
+  //   ASSERT_EQ(file.gcount(), size);
 
-    if (!phdr.cwt_claims.iss.has_value())
-    {
-      throw std::runtime_error("Issuer not found in protected header");
-    }
-    EXPECT_EQ(
-      phdr.cwt_claims.iss.value(),
-      "did:attestedsvc:msft-css-dev::3d7961c9-84b2-44d2-a9e0-33c040d168b3:test-"
-      "account1:profile1");
-    EXPECT_TRUE(phdr.tss_map.attestation.has_value());
-    EXPECT_TRUE(phdr.tss_map.attestation_type.has_value());
-    EXPECT_EQ(
-      phdr.tss_map.attestation_type.value(), "SEV-SNP:ContainerPlat-AMD-UVM");
-    EXPECT_TRUE(phdr.tss_map.snp_endorsements.has_value());
-    EXPECT_TRUE(phdr.tss_map.uvm_endorsements.has_value());
-    EXPECT_TRUE(phdr.tss_map.ver.has_value());
-    EXPECT_EQ(phdr.tss_map.ver.value(), 0);
-    EXPECT_TRUE(phdr.tss_map.cose_key.has_value());
-    EXPECT_EQ(phdr.tss_map.cose_key->kty(), 2);
-    /*
-    cose_key:
-      1: 2,
-      -1: 2,
-      -2:
-      h'6D2ECFA295A4FEAB4DF1715E9978B13A335AA3468013A6B1933A20205FB0943C3115EDBA2DADBC6EAC64403904347B23',
-      -3:
-      h'2D0FFD0127F1C015E1F5D2BA86DE32ECC872EED7F84F9CD96145275632297903CD246D87F29912D0CE19F81C7F6CAB3A'
-    */
-    EXPECT_TRUE(std::holds_alternative<int64_t>(
-      phdr.tss_map.cose_key->crv_n_k_pub().value()));
-    auto crv_n_k_pub =
-      std::get<int64_t>(phdr.tss_map.cose_key->crv_n_k_pub().value());
-    EXPECT_EQ(crv_n_k_pub, 2);
+  //   cose::ProtectedHeader phdr;
+  //   cose::UnprotectedHeader uhdr;
+  //   std::tie(phdr, uhdr) = cose::decode_headers(signed_statement);
 
-    EXPECT_EQ(phdr.tss_map.cose_key->x_e().has_value(), true);
-    EXPECT_EQ(
-      phdr.tss_map.cose_key->x_e().value(),
-      from_hex_string("6D2ECFA295A4FEAB4DF1715E9978B13A335AA3468013A6B1933A2020"
-                      "5FB0943C3115EDBA2DADBC6EAC64403904347B23"));
+  //   if (!phdr.alg.has_value())
+  //   {
+  //     throw std::runtime_error("Algorithm not found in protected header");
+  //   }
+  //   EXPECT_EQ(phdr.alg.value(), -35);
 
-    EXPECT_EQ(phdr.tss_map.cose_key->y().has_value(), true);
-    EXPECT_EQ(
-      phdr.tss_map.cose_key->y().value(),
-      from_hex_string("2D0FFD0127F1C015E1F5D2BA86DE32ECC872EED7F84F9CD961452756"
-                      "32297903CD246D87F29912D0CE19F81C7F6CAB3A"));
-  }
+  //   if (!phdr.cwt_claims.iss.has_value())
+  //   {
+  //     throw std::runtime_error("Issuer not found in protected header");
+  //   }
+  //   EXPECT_EQ(
+  //     phdr.cwt_claims.iss.value(),
+  //     "did:attestedsvc:msft-css-dev::3d7961c9-84b2-44d2-a9e0-33c040d168b3:test-"
+  //     "account1:profile1");
+  //   EXPECT_TRUE(phdr.tss_map.attestation.has_value());
+  //   EXPECT_TRUE(phdr.tss_map.attestation_type.has_value());
+  //   EXPECT_EQ(
+  //     phdr.tss_map.attestation_type.value(),
+  //     "SEV-SNP:ContainerPlat-AMD-UVM");
+  //   EXPECT_TRUE(phdr.tss_map.snp_endorsements.has_value());
+  //   EXPECT_TRUE(phdr.tss_map.uvm_endorsements.has_value());
+  //   EXPECT_TRUE(phdr.tss_map.ver.has_value());
+  //   EXPECT_EQ(phdr.tss_map.ver.value(), 0);
+  //   EXPECT_TRUE(phdr.tss_map.cose_key.has_value());
+  //   EXPECT_EQ(phdr.tss_map.cose_key->kty(), 2);
+  //   /*
+  //   cose_key:
+  //     1: 2,
+  //     -1: 2,
+  //     -2:
+  //     h'6D2ECFA295A4FEAB4DF1715E9978B13A335AA3468013A6B1933A20205FB0943C3115EDBA2DADBC6EAC64403904347B23',
+  //     -3:
+  //     h'2D0FFD0127F1C015E1F5D2BA86DE32ECC872EED7F84F9CD96145275632297903CD246D87F29912D0CE19F81C7F6CAB3A'
+  //   */
+  //   EXPECT_TRUE(std::holds_alternative<int64_t>(
+  //     phdr.tss_map.cose_key->crv_n_k_pub().value()));
+  //   auto crv_n_k_pub =
+  //     std::get<int64_t>(phdr.tss_map.cose_key->crv_n_k_pub().value());
+  //   EXPECT_EQ(crv_n_k_pub, 2);
+
+  //   EXPECT_EQ(phdr.tss_map.cose_key->x_e().has_value(), true);
+  //   EXPECT_EQ(
+  //     phdr.tss_map.cose_key->x_e().value(),
+  //     from_hex_string("6D2ECFA295A4FEAB4DF1715E9978B13A335AA3468013A6B1933A2020"
+  //                     "5FB0943C3115EDBA2DADBC6EAC64403904347B23"));
+
+  //   EXPECT_EQ(phdr.tss_map.cose_key->y().has_value(), true);
+  //   EXPECT_EQ(
+  //     phdr.tss_map.cose_key->y().value(),
+  //     from_hex_string("2D0FFD0127F1C015E1F5D2BA86DE32ECC872EED7F84F9CD961452756"
+  //                     "32297903CD246D87F29912D0CE19F81C7F6CAB3A"));
+  // }
   // NOLINTEND(bugprone-unchecked-optional-access)
 
   TEST(CoseTest, DecodeTSSHeadersFailsDueToInvalidMap)
   {
     const std::vector<uint8_t>& signed_statement = from_hex_string(
-      "D284590103A801382202816C6D7366742D6373732D646576045820A3FC5DF291C866D1AE"
-      "7FE90519384EEE2B84D412ED4ABE22C71395B6FDE3057D0FA40178596469643A61747465"
-      "737465647376633A6D7366742D6373732D6465763A3A33643739363163392D383462322D"
-      "343464322D613965302D3333633034306431363862333A746573742D6163636F756E7431"
-      "3A70726F66696C653102716578706572696D656E74616C2F7465737406C11A6852FBB263"
-      "73766E001901022F190103706170706C69636174696F6E2F6A736F6E1901047768747470"
-      "3A2F2F706174682D746F2D636F6E74656E742F6C6D7366742D6373732D6465766F73686F"
-      "756C642062652061206D6170A0A0A0");
+      "D284590111A801382202816B6174746573746564737663045820A3FC5DF291C866D1AE7F"
+      "E90519384EEE2B84D412ED4ABE22C71395B6FDE3057D0FA40178596469643A6174746573"
+      "7465647376633A6D7366742D6373732D6465763A3A33643739363163392D383462322D34"
+      "3464322D613965302D3333633034306431363862333A746573742D6163636F756E74313A"
+      "70726F66696C653102716578706572696D656E74616C2F7465737406C074323032352D30"
+      "362D31385431373A34373A33305A6373766E001901022F190103706170706C6963617469"
+      "6F6E2F6A736F6E19010477687474703A2F2F706174682D746F2D636F6E74656E742F6B61"
+      "747465737465647376636F73686F756C642062652061206D6170A0A0A0");
 
     cose::ProtectedHeader phdr;
     cose::UnprotectedHeader uhdr;

--- a/app/unit-tests/testutils.h
+++ b/app/unit-tests/testutils.h
@@ -133,6 +133,10 @@ namespace testutils
     // TSS map
     // ----------------------
     QCBOREncode_OpenMapInMap(&ectx, cose::COSE_HEADER_PARAM_TSS);
+    QCBOREncode_AddTextToMap(
+      &ectx,
+      cose::COSE_HEADER_PARAM_TSS_SVC_ID,
+      cbor::from_string("msft-css-dev"));
     QCBOREncode_AddBytesToMap(
       &ectx,
       cose::COSE_HEADER_PARAM_TSS_ATTESTATION,

--- a/app/unit-tests/verifier_test.cpp
+++ b/app/unit-tests/verifier_test.cpp
@@ -25,70 +25,75 @@ using namespace testutils;
 namespace
 {
   // NOLINTBEGIN(bugprone-unchecked-optional-access)
-  TEST(VerifierTest, VerifyTSSStatement)
-  {
-    std::string filepath = "test_payloads/css-attested-cosesign1-20250617.cose";
-    std::ifstream file(filepath, std::ios::binary);
-    ASSERT_TRUE(file.is_open());
 
-    size_t size = std::filesystem::file_size(filepath);
+  // TODO: needs a new sample payload with latest attestedsvc TSS map
 
-    // Read file into vector
-    std::vector<uint8_t> signed_statement(size);
-    file.read(
-      reinterpret_cast<char*>(signed_statement.data()),
-      static_cast<std::streamsize>(size));
-    ASSERT_EQ(file.gcount(), size);
+  // TEST(VerifierTest, VerifyTSSStatement)
+  // {
+  //   std::string filepath =
+  //   "test_payloads/css-attested-cosesign1-20250617.cose"; std::ifstream
+  //   file(filepath, std::ios::binary); ASSERT_TRUE(file.is_open());
 
-    auto verifier = std::make_unique<scitt::verifier::Verifier>();
+  //   size_t size = std::filesystem::file_size(filepath);
 
-    // Create a mock or test transaction - adjust based on your test framework
-    ccf::kv::ReadOnlyTx* tx_ptr = nullptr; // Or use your test framework's mock
-    timespec time = {0, 0}; // Use a fixed time for testing
-    scitt::Configuration configuration; // Use a default or mock configuration
-    cose::ProtectedHeader phdr;
-    cose::UnprotectedHeader uhdr;
-    std::span<uint8_t> payload;
-    std::optional<verifier::VerifiedSevSnpAttestationDetails> details;
-    std::tie(phdr, uhdr, payload, details) = verifier->verify_signed_statement(
-      signed_statement, *tx_ptr, time, configuration);
+  //   // Read file into vector
+  //   std::vector<uint8_t> signed_statement(size);
+  //   file.read(
+  //     reinterpret_cast<char*>(signed_statement.data()),
+  //     static_cast<std::streamsize>(size));
+  //   ASSERT_EQ(file.gcount(), size);
 
-    EXPECT_TRUE(phdr.tss_map.attestation.has_value());
-    EXPECT_TRUE(phdr.tss_map.snp_endorsements.has_value());
-    EXPECT_TRUE(phdr.tss_map.uvm_endorsements.has_value());
-    EXPECT_TRUE(phdr.tss_map.cose_key.has_value());
-    EXPECT_TRUE(phdr.alg.has_value());
+  //   auto verifier = std::make_unique<scitt::verifier::Verifier>();
 
-    EXPECT_TRUE(details.has_value());
-    EXPECT_EQ(
-      details->get_measurement().hex_str(),
-      "5feee30d6d7e1a29f403d70a4198237ddfb13051a2d6976439487c609388ed7f98189887"
-      "920ab2fa0096903a0c23fca1");
-    EXPECT_EQ(
-      details->get_report_data().hex_str(),
-      "a3fc5df291c866d1ae7fe90519384eee2b84d412ed4abe22c71395b6fde3057d00000000"
-      "00000000000000000000000000000000000000000000000000000000");
-    EXPECT_TRUE(details->get_uvm_endorsements().has_value());
-    EXPECT_EQ(
-      details->get_uvm_endorsements().value().did,
-      "did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s::eku:1.3."
-      "6.1.4.1.311.76.59.1.2");
-    EXPECT_EQ(
-      details->get_uvm_endorsements().value().feed, "ContainerPlat-AMD-UVM");
-    EXPECT_EQ(details->get_uvm_endorsements().value().svn, "101");
-    auto host_data = details->get_host_data();
-    auto host_data_str = ccf::ds::to_hex(host_data);
-    EXPECT_EQ(
-      host_data_str,
-      "953e208258fc57d814c44a0b083dbe4e8f2e734a2fde32f1049a78890d98b730");
-    EXPECT_EQ(details->get_product_name(), ccf::pal::snp::ProductName::Milan);
-    EXPECT_EQ(details->get_tcb_version_policy().microcode, 219);
-    EXPECT_EQ(details->get_tcb_version_policy().snp, 24);
-    EXPECT_EQ(details->get_tcb_version_policy().tee, 0);
-    EXPECT_EQ(details->get_tcb_version_policy().boot_loader, 4);
-    EXPECT_EQ(details->get_tcb_version_policy().fmc, std::nullopt);
-    EXPECT_EQ(details->get_tcb_version_policy().hexstring, "db18000000000004");
-  }
+  //   // Create a mock or test transaction - adjust based on your test
+  //   framework ccf::kv::ReadOnlyTx* tx_ptr = nullptr; // Or use your test
+  //   framework's mock timespec time = {0, 0}; // Use a fixed time for testing
+  //   scitt::Configuration configuration; // Use a default or mock
+  //   configuration cose::ProtectedHeader phdr; cose::UnprotectedHeader uhdr;
+  //   std::span<uint8_t> payload;
+  //   std::optional<verifier::VerifiedSevSnpAttestationDetails> details;
+  //   std::tie(phdr, uhdr, payload, details) =
+  //   verifier->verify_signed_statement(
+  //     signed_statement, *tx_ptr, time, configuration);
+
+  //   EXPECT_TRUE(phdr.tss_map.attestation.has_value());
+  //   EXPECT_TRUE(phdr.tss_map.snp_endorsements.has_value());
+  //   EXPECT_TRUE(phdr.tss_map.uvm_endorsements.has_value());
+  //   EXPECT_TRUE(phdr.tss_map.cose_key.has_value());
+  //   EXPECT_TRUE(phdr.alg.has_value());
+
+  //   EXPECT_TRUE(details.has_value());
+  //   EXPECT_EQ(
+  //     details->get_measurement().hex_str(),
+  //     "5feee30d6d7e1a29f403d70a4198237ddfb13051a2d6976439487c609388ed7f98189887"
+  //     "920ab2fa0096903a0c23fca1");
+  //   EXPECT_EQ(
+  //     details->get_report_data().hex_str(),
+  //     "a3fc5df291c866d1ae7fe90519384eee2b84d412ed4abe22c71395b6fde3057d00000000"
+  //     "00000000000000000000000000000000000000000000000000000000");
+  //   EXPECT_TRUE(details->get_uvm_endorsements().has_value());
+  //   EXPECT_EQ(
+  //     details->get_uvm_endorsements().value().did,
+  //     "did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s::eku:1.3."
+  //     "6.1.4.1.311.76.59.1.2");
+  //   EXPECT_EQ(
+  //     details->get_uvm_endorsements().value().feed, "ContainerPlat-AMD-UVM");
+  //   EXPECT_EQ(details->get_uvm_endorsements().value().svn, "101");
+  //   auto host_data = details->get_host_data();
+  //   auto host_data_str = ccf::ds::to_hex(host_data);
+  //   EXPECT_EQ(
+  //     host_data_str,
+  //     "953e208258fc57d814c44a0b083dbe4e8f2e734a2fde32f1049a78890d98b730");
+  //   EXPECT_EQ(details->get_product_name(),
+  //   ccf::pal::snp::ProductName::Milan);
+  //   EXPECT_EQ(details->get_tcb_version_policy().microcode, 219);
+  //   EXPECT_EQ(details->get_tcb_version_policy().snp, 24);
+  //   EXPECT_EQ(details->get_tcb_version_policy().tee, 0);
+  //   EXPECT_EQ(details->get_tcb_version_policy().boot_loader, 4);
+  //   EXPECT_EQ(details->get_tcb_version_policy().fmc, std::nullopt);
+  //   EXPECT_EQ(details->get_tcb_version_policy().hexstring,
+  //   "db18000000000004");
+  // }
   // NOLINTEND(bugprone-unchecked-optional-access)
 
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,8 +139,9 @@ Function arguments:
         svn?: number   // Software version number
       },
       
-      // Microsoft CSS Dev TSS Map
-      "msft-css-dev": {
+      // Microsoft Attested Service Map
+      "attestedsvc": {
+        svc_id?: string,
         attestation?: ArrayBuffer,
         attestation_type?: string,
         


### PR DESCRIPTION
```
{
   1: -35,                ; alg: ES384
   2: [ "attestedsvc" ], ; crit
   4: bstr,               ; kid: SHA256 hash of canonical COSE_Key
  15: { ... },            ; CWT-Claims including issuer/subject
  "attestedsvc": { "svc_id": "msft-css-dev", ... } ; attestation map as before
}
```

@briankr-ms this is `svc_id` rather than `svc-id` for consistency with the other fields in the map (`uvm_endorsement` etc). I am not clear on the utility, other than it being a minor convenience for the policy writer, since this is endorsed by the same key and under the same circumstances as Issuer.

TODO:

- [ ] Tests
- [ ] Confirm crit verification works
- [ ] Do we need `svc_id`? It seems redundant with the one in the issuer, and is equally authoritative.