### PR TITLE
Fix Python type-checking error

### DIFF
--- a/test/infra/async_utils.py
+++ b/test/infra/async_utils.py
@@ -7,9 +7,10 @@ from abc import ABC, abstractmethod
 from typing import Any, Awaitable, Optional
 
 import aiotools
+from aiotools.types import CoroutineLike
 
 
-async def race_tasks(*awaitables: Awaitable[Any]):
+async def race_tasks(*awaitables: CoroutineLike[Any]) -> None:
     """
     Run a collection of awaitable objects as tasks, concurrently, until at least
     one of them completes or terminates with an exception. All uncompleted tasks


### PR DESCRIPTION
This resolves the issue that currently causes the CI to fail: https://github.com/microsoft/scitt-ccf-ledger/actions/runs/18338091273

aiotools recently released a 2.0.0 (and 2.0.1) which changed type definitions a little, and broke the type checking currently performed by mypy as part of ci-checks.sh.