### PR TITLE
Remove failing pypi release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,27 +58,3 @@ jobs:
             pyscitt/dist/*.tar.gz
             LICENSE.txt
 
-  publish_pyscitt_to_pypi:
-    name: "Publish pyscitt to PyPI"
-    runs-on: ubuntu-latest
-    needs: build_pyscitt
-
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing to PyPi
-    
-    environment:
-      name: pypi
-      url: https://pypi.org/p/pyscitt
-      
-    steps:
-      - name: Download pyscitt dist folder
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: pyscitt/dist
-
-      - name: Publish pyscitt to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: pyscitt/dist
-          skip-existing: true


### PR DESCRIPTION
Our GH releases are broken hence the removal.