### PR TITLE
Update cryptography version to 46.* in setup.py

### DIFF
--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -26,7 +26,7 @@ setup(
     python_requires=">=3.12",
     install_requires=[
         "ccf==6.*",
-        "cryptography==44.*",  # needs to match ccf
+        "cryptography==46.*",  # needs to match ccf
         "httpx",
         "cbor2==5.8.*",
         "pycose==1.1.0",


### PR DESCRIPTION
Update to version supported by https://github.com/microsoft/CCF/releases/tag/ccf-6.0.23