### PR TITLE
Update cryptography package version to 46.* in tests

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,7 +5,7 @@ pytest
 loguru
 aiotools
 ccf==6.*
-cryptography==44.*
+cryptography==46.*
 jwcrypto==1.5.*
 types-jwcrypto
 cbor2


### PR DESCRIPTION
Should have been done in #361, but missed there. I wonder if we shouldn't just remove the pin, since we surely install pyscitt and effectively get it from there?

Should close https://github.com/microsoft/scitt-ccf-ledger/security/dependabot/24