### PR TITLE
improve error in the case of an empty or nil payload within the cose

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -153,6 +153,14 @@ Unit tests will be run as part of the virtual platform build workflow in cmake.
 PLATFORM=virtual ./build.sh
 ```
 
+**Using Docker*
+
+The command below uses the built Docker image `mytestimg` to run the tests (see above how to build the image).
+
+```sh
+docker run --rm -it --env PLATFORM=virtual --volume $(pwd):/opt/app --workdir /opt/app --entrypoint /bin/bash mytestimg -c 'git config --global --add safe.directory "*" && ./build.sh'
+```
+
 ### Functional (e2e) tests
 
 To start the tests you need to use the script `run_functional_tests.sh`.


### PR DESCRIPTION
Respond with a user friendly message if the payload is missing in COSE envelope as requested in #352 