### PR TITLE
Fix Python warnings from `test_load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.17.0]
+### Changes
+- 2926513 revert early cache cleanup and update local load test scripts to measure e2e latency (#387)
+- 408a10f Drop hardcoded HISTORICAL_CACHE_SOFT_LIMIT, document CCF node config option (#385)
+- cb20df1 Evict entries from cache after they were used to prevent cache from growing and depending on LRU eviction (#381)
+- e177832 Update sample CSS policy to handle multiple products and allow higher TCB values (#380)
+- 40f2ad7 Change operations removal from indexing strategy log from INFO to DEBUG (#386)
+- 4c6b4d6 Update CCF version from 6.0.23 to 6.0.26 (#384)
+- e696551 Remove retry-after header which slows down some clients who wait for a sec to retry (#383)
+- 9983dd9 Bump azurelinux/base/core from 3.0.20260204 to 3.0.20260304 in /docker (#379)
+- 5890213 Bump black from 26.1.0 to 26.3.1 in /test in the pip group across 1 directory (#378)
+- 15b6c26 Add PPE CSS testcase (#376)
+- 92c1733 Update detached/empty payload error message in COSE decoder (#371)
+- 5860db8 Print issuer for each verified receipt in scitt validate (#369)
+- 46862d5 Migrate CCF governance API calls to versioned API 2024-07-01 (#368)
+- f1e3010 improve error in the case of an empty or nil payload within the cose (#370)
+- 70e7055 Add configurable maxSignedStatementBytes to SCITT configuration (#364)
+- 40b1ff6 Replace custom LRU cache with CCF's set_soft_cache_limit() (#365)
+- 89ee97c Update load test include docker cpu and mem (#357)
+- 40f7e5c Update cryptography package version to 46.* in tests (#366)
+- 797c6cd Add support for Rego registration policies (rego-cpp 1.2.0) (#338)
+
 ## [0.16.5]
 ### Changes
 - 56132cd Bump azurelinux/base/core from 3.0.20260107 to 3.0.20260204 in /docker (#362)
@@ -403,3 +425,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.16.3]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.16.3
 [0.16.4]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.16.4
 [0.16.5]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.16.5
+[0.17.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,9 +18,7 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "perf: only run test if performance testing is enabled."
     )
-    config.addinivalue_line(
-        "markers", "bencher: benchmark tests using bencher."
-    )
+    config.addinivalue_line("markers", "bencher: benchmark tests using bencher.")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,6 +18,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "perf: only run test if performance testing is enabled."
     )
+    config.addinivalue_line(
+        "markers", "bencher: benchmark tests using bencher."
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/test/infra/cchost.py
+++ b/test/infra/cchost.py
@@ -306,7 +306,9 @@ class CCHost(EventLoopThread):
 
         Returns the service's port number if it is ready, and None otherwise.
         """
-        ssl_ctx = ssl.SSLContext()
+        ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
         try:
             # cchost writes its actual RPC port to this file. This works even if
             # it tried to bind on port 0 and was given a random port by the


### PR DESCRIPTION
Some driveby fixes while playing with the load testing tools.

Sample warnings, for posterity:
```
test/test_perf.py:250
  /workspaces/scitt-ccf-ledger/test/test_perf.py:250: PytestUnknownMarkWarning: Unknown pytest.mark.bencher - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.bencher
```

```
test/test_load.py::TestLoad::test_load
  /workspaces/scitt-ccf-ledger/test/infra/cchost.py:309: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
    ssl_ctx = ssl.SSLContext()
```