### PR TITLE
Add wait_for_commit query parameter to POST /entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ scitt submit test/payloads/manifest.spdx.json.sha384.digest.cose --development -
 # Received output.cose
 ```
 
+Alternatively, use `--wait-for-commit` to block until the transaction is committed and return the receipt directly in a single request, without polling:
+
+```sh
+scitt submit test/payloads/manifest.spdx.json.sha384.digest.cose --development --url "https://localhost:8000" --transparent-statement output.cose --wait-for-commit
+
+# 2025-11-06 13:19:16.006 | DEBUG    | pyscitt.client:request:402 - POST /entries?waitForCommit=true 200
+# Registered test/payloads/manifest.spdx.json.sha384.digest.cose as transaction 2.13
+# Received output.cose
+```
+
 ## Supported inputs
 
 See [inputs.md](./docs/inputs.md) to understand what you can register and store in the service.

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -248,8 +248,7 @@ namespace scitt
         const auto parsed_query =
           ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
         const auto wait_for_commit =
-          get_query_value<bool>(parsed_query, "waitForCommit")
-            .value_or(false);
+          get_query_value<bool>(parsed_query, "waitForCommit").value_or(false);
         if (wait_for_commit)
         {
           ctx.rpc_ctx->set_consensus_committed_function(

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -244,8 +244,7 @@ namespace scitt
 
       verifier = std::make_unique<verifier::Verifier>();
 
-      auto register_signed_statement =
-        [this, &context_](EndpointContext& ctx) {
+      auto register_signed_statement = [this, &context_](EndpointContext& ctx) {
         const auto parsed_query =
           ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
         const auto wait_for_commit =

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -257,16 +257,14 @@ namespace scitt
               if (info.status == ccf::FinalTxStatus::Invalid)
               {
                 info.rpc_ctx->set_response_status(
-                  HTTP_STATUS_INTERNAL_SERVER_ERROR);
+                  HTTP_STATUS_SERVICE_UNAVAILABLE);
                 info.rpc_ctx->set_response_header(
                   ccf::http::headers::CONTENT_TYPE,
-                  ccf::http::headervalues::contenttype::CBOR);
-                nlohmann::json error_body;
-                error_body["error"]["code"] = "TransactionInvalid";
-                error_body["error"]["message"] =
-                  "Transaction was dropped by consensus";
-                info.rpc_ctx->set_response_body(
-                  nlohmann::json::to_cbor(error_body));
+                  cbor::CBOR_ERROR_CONTENT_TYPE);
+                info.rpc_ctx->set_response_body(cbor::cbor_error(
+                  errors::InternalError,
+                  "The submission could not be committed and was rolled "
+                  "back, please retry"));
                 return;
               }
 
@@ -279,7 +277,7 @@ namespace scitt
 
               auto cose_receipt = get_cose_receipt(receipt);
 
-              info.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+              info.rpc_ctx->set_response_status(HTTP_STATUS_CREATED);
               info.rpc_ctx->set_response_header(
                 ccf::http::headers::CONTENT_TYPE,
                 ccf::http::headervalues::contenttype::COSE);

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -248,7 +248,7 @@ namespace scitt
         const auto parsed_query =
           ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
         const auto wait_for_commit =
-          get_query_value<bool>(parsed_query, "wait_for_commit")
+          get_query_value<bool>(parsed_query, "waitForCommit")
             .value_or(false);
         if (wait_for_commit)
         {
@@ -439,7 +439,7 @@ namespace scitt
         operation_locally_committed_func,
         authn_policy)
         .add_query_parameter<bool>(
-          "wait_for_commit",
+          "waitForCommit",
           ccf::endpoints::QueryParamPresence::OptionalParameter)
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Always)
         .set_redirection_strategy(

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -244,7 +244,52 @@ namespace scitt
 
       verifier = std::make_unique<verifier::Verifier>();
 
-      auto register_signed_statement = [this](EndpointContext& ctx) {
+      auto register_signed_statement =
+        [this, &context_](EndpointContext& ctx) {
+        const auto parsed_query =
+          ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
+        const auto wait_for_commit =
+          get_query_value<bool>(parsed_query, "wait_for_commit")
+            .value_or(false);
+        if (wait_for_commit)
+        {
+          ctx.rpc_ctx->set_consensus_committed_function(
+            [&context_](ccf::endpoints::CommittedTxInfo& info) {
+              if (info.status == ccf::FinalTxStatus::Invalid)
+              {
+                info.rpc_ctx->set_response_status(
+                  HTTP_STATUS_INTERNAL_SERVER_ERROR);
+                info.rpc_ctx->set_response_header(
+                  ccf::http::headers::CONTENT_TYPE,
+                  ccf::http::headervalues::contenttype::CBOR);
+                nlohmann::json error_body;
+                error_body["error"]["code"] = "TransactionInvalid";
+                error_body["error"]["message"] =
+                  "Transaction was dropped by consensus";
+                info.rpc_ctx->set_response_body(
+                  nlohmann::json::to_cbor(error_body));
+                return;
+              }
+
+              auto receipt =
+                ccf::endpoints::build_receipt_for_committed_tx(context_, info);
+              if (receipt == nullptr)
+              {
+                return;
+              }
+
+              auto cose_receipt = get_cose_receipt(receipt);
+
+              info.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+              info.rpc_ctx->set_response_header(
+                ccf::http::headers::CONTENT_TYPE,
+                ccf::http::headervalues::contenttype::COSE);
+              info.rpc_ctx->set_response_header(
+                ccf::http::headers::CCF_TX_ID, info.tx_id.to_str());
+              info.rpc_ctx->set_response_body(cose_receipt);
+            });
+        }
+
         const auto& body = ctx.rpc_ctx->get_request_body();
         SCITT_DEBUG(
           "Signed Statement Registration body size: {} bytes", body.size());
@@ -396,6 +441,9 @@ namespace scitt
         register_signed_statement,
         operation_locally_committed_func,
         authn_policy)
+        .add_query_parameter<bool>(
+          "wait_for_commit",
+          ccf::endpoints::QueryParamPresence::OptionalParameter)
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Always)
         .set_redirection_strategy(
           ccf::endpoints::RedirectionStrategy::ToPrimary)

--- a/pyscitt/pyscitt/cli/register.py
+++ b/pyscitt/pyscitt/cli/register.py
@@ -14,6 +14,7 @@ def register_signed_statement(
     path: Path,
     transparent_statement_path: Optional[Path],
     skip_confirmation: bool,
+    wait_for_commit: bool,
 ):
     if path.suffix != ".cose":
         raise ValueError("unsupported file extension, must end with .cose")
@@ -27,6 +28,16 @@ def register_signed_statement(
         print("""Confirmation of submission was skipped, the signed
               statement may not be registered on the ledger. 
               A transparent statement will not be downloaded nor saved.""")
+        return
+
+    if wait_for_commit:
+        submission = client.submit_signed_statement_wait_for_commit(signed_statement)
+        print(f"Registered {path} as transaction {submission.tx}")
+
+        if transparent_statement_path:
+            with open(transparent_statement_path, "wb") as f:
+                f.write(submission.response_bytes)
+            print(f"Received {transparent_statement_path}")
         return
 
     submission = client.submit_signed_statement_and_wait(signed_statement)
@@ -53,6 +64,11 @@ def cli(fn):
         action="store_true",
         help="Don't wait for confirmation or the transparent statement",
     )
+    parser.add_argument(
+        "--wait-for-commit",
+        action="store_true",
+        help="Use synchronous flow: block until commit and return receipt directly",
+    )
 
     def cmd(args):
         client = create_client(args)
@@ -61,6 +77,7 @@ def cli(fn):
             args.path,
             args.transparent_statement,
             args.skip_confirmation,
+            args.wait_for_commit,
         )
 
     parser.set_defaults(func=cmd)

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -610,14 +610,14 @@ class Client(BaseClient):
         """
         Submit a signed statement and wait for global commit.
 
-        This sets `wait_for_commit=true` on POST /entries, so the
+        This sets `waitForCommit=true` on POST /entries, so the
         response is deferred until consensus reaches a terminal state and
         returns the COSE receipt directly in the response body.
         """
         headers = {"Content-Type": CT_APPLICATION_COSE}
         resp = self.post(
             "/entries",
-            params={"wait_for_commit": "true"},
+            params={"waitForCommit": "true"},
             headers=headers,
             content=signed_statement,
         )

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -603,7 +603,7 @@ class Client(BaseClient):
         receipt = self.get_receipt(tx)
         return Submission(operation_id, tx, receipt, False)
 
-    def submit_signed_statement_blocking(
+    def submit_signed_statement_wait_for_commit(
         self,
         signed_statement: bytes,
     ) -> Submission:

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -603,6 +603,29 @@ class Client(BaseClient):
         receipt = self.get_receipt(tx)
         return Submission(operation_id, tx, receipt, False)
 
+    def submit_signed_statement_blocking(
+        self,
+        signed_statement: bytes,
+    ) -> Submission:
+        """
+        Submit a signed statement and wait for global commit.
+
+        This sets `wait_for_commit=true` on POST /entries, so the
+        response is deferred until consensus reaches a terminal state and
+        returns the COSE receipt directly in the response body.
+        """
+        headers = {"Content-Type": CT_APPLICATION_COSE}
+        resp = self.post(
+            "/entries",
+            params={"wait_for_commit": "true"},
+            headers=headers,
+            content=signed_statement,
+        )
+        resp.raise_for_status()
+        tx = resp.headers[CCF_TX_ID_HEADER]
+        receipt = resp.content
+        return Submission("", tx, receipt, False)
+
     def wait_for_operation(self, operation: str) -> str:
         resp = self.get(
             f"/operations/{operation}",

--- a/test/test_blocking.py
+++ b/test/test_blocking.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from hashlib import sha256
+
+import cbor2
+import ccf.cose
+from loguru import logger as LOG
+from pycose.messages import CoseMessage
+
+from pyscitt import crypto
+from pyscitt.client import Client
+
+
+def test_blocking_entries(
+    client: Client, cert_authority, trust_store, configure_service
+):
+    """
+    Submit a signed statement via POST /entries?wait_for_commit=true and
+    inspect the response.
+
+    The request blocks until the transaction is globally committed and
+    returns the COSE receipt directly.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(
+        identity, {"foo": "bar"}, cwt=True
+    )
+
+    submission = client.submit_signed_statement_blocking(signed_statement)
+
+    LOG.info("=== Blocking /entries?wait_for_commit=true response ===")
+    LOG.info(f"Transaction ID: {submission.tx}")
+    LOG.info(f"Response bytes length: {len(submission.response_bytes)}")
+    LOG.info(
+        f"Response bytes (hex, first 128): {submission.response_bytes[:128].hex()}"
+    )
+
+    # Decode via pycose to show the raw COSE structure
+    cose_msg = CoseMessage.decode(submission.response_bytes)
+    LOG.info(f"COSE message type: {type(cose_msg).__name__}")
+    LOG.info(f"COSE protected headers: {cose_msg.phdr}")
+    LOG.info(f"COSE unprotected headers: {cose_msg.uhdr}")
+    LOG.info(
+        f"COSE payload length: {len(cose_msg.payload) if cose_msg.payload else 0}"
+    )
+
+    # Decode the raw CBOR to inspect the full structure
+    raw = cbor2.loads(submission.response_bytes)
+    if isinstance(raw, cbor2.CBORTag):
+        LOG.info(f"CBOR tag: {raw.tag}")
+        raw = raw.value
+    LOG.info(f"COSE_Sign1 array length: {len(raw)}")
+    # raw[0] = protected headers, raw[1] = unprotected headers, raw[2] = payload, raw[3] = signature
+    uhdr = raw[1] if len(raw) > 1 else {}
+    LOG.info(f"Unprotected headers keys: {list(uhdr.keys()) if isinstance(uhdr, dict) else type(uhdr)}")
+    LOG.info(f"Unprotected headers: {uhdr}")
+
+    # Verify the receipt against the signed statement using ccf.cose directly.
+    service_key = trust_store.get_key(submission.response_bytes)
+    ccf.cose.verify_receipt(
+        submission.response_bytes,
+        service_key,
+        sha256(signed_statement).digest(),
+    )
+    LOG.info("Receipt verification: PASSED")

--- a/test/test_blocking.py
+++ b/test/test_blocking.py
@@ -33,9 +33,7 @@ def test_blocking_entries(
         }
     )
 
-    signed_statement = crypto.sign_json_statement(
-        identity, {"foo": "bar"}, cwt=True
-    )
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
 
     submission = client.submit_signed_statement_wait_for_commit(signed_statement)
 
@@ -51,9 +49,7 @@ def test_blocking_entries(
     LOG.info(f"COSE message type: {type(cose_msg).__name__}")
     LOG.info(f"COSE protected headers: {cose_msg.phdr}")
     LOG.info(f"COSE unprotected headers: {cose_msg.uhdr}")
-    LOG.info(
-        f"COSE payload length: {len(cose_msg.payload) if cose_msg.payload else 0}"
-    )
+    LOG.info(f"COSE payload length: {len(cose_msg.payload) if cose_msg.payload else 0}")
 
     # Decode the raw CBOR to inspect the full structure
     raw = cbor2.loads(submission.response_bytes)
@@ -63,7 +59,9 @@ def test_blocking_entries(
     LOG.info(f"COSE_Sign1 array length: {len(raw)}")
     # raw[0] = protected headers, raw[1] = unprotected headers, raw[2] = payload, raw[3] = signature
     uhdr = raw[1] if len(raw) > 1 else {}
-    LOG.info(f"Unprotected headers keys: {list(uhdr.keys()) if isinstance(uhdr, dict) else type(uhdr)}")
+    LOG.info(
+        f"Unprotected headers keys: {list(uhdr.keys()) if isinstance(uhdr, dict) else type(uhdr)}"
+    )
     LOG.info(f"Unprotected headers: {uhdr}")
 
     # Verify the receipt against the signed statement using ccf.cose directly.

--- a/test/test_blocking.py
+++ b/test/test_blocking.py
@@ -16,7 +16,7 @@ def test_blocking_entries(
     client: Client, cert_authority, trust_store, configure_service
 ):
     """
-    Submit a signed statement via POST /entries?wait_for_commit=true and
+    Submit a signed statement via POST /entries?waitForCommit=true and
     inspect the response.
 
     The request blocks until the transaction is globally committed and
@@ -37,7 +37,7 @@ def test_blocking_entries(
 
     submission = client.submit_signed_statement_wait_for_commit(signed_statement)
 
-    LOG.info("=== Blocking /entries?wait_for_commit=true response ===")
+    LOG.info("=== Blocking /entries?waitForCommit=true response ===")
     LOG.info(f"Transaction ID: {submission.tx}")
     LOG.info(f"Response bytes length: {len(submission.response_bytes)}")
     LOG.info(

--- a/test/test_blocking.py
+++ b/test/test_blocking.py
@@ -37,7 +37,7 @@ def test_blocking_entries(
         identity, {"foo": "bar"}, cwt=True
     )
 
-    submission = client.submit_signed_statement_blocking(signed_statement)
+    submission = client.submit_signed_statement_wait_for_commit(signed_statement)
 
     LOG.info("=== Blocking /entries?wait_for_commit=true response ===")
     LOG.info(f"Transaction ID: {submission.tx}")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -152,6 +152,49 @@ def test_extract_payload_from_cose(run, tmp_path: Path):
     assert claims.get("foo") == "bar"
 
 
+def test_submit_wait_for_commit(
+    run, tmp_path, cert_authority, configure_service
+):
+    """
+    Test the CLI submit command with --wait-for-commit flag.
+    This uses the synchronous flow (POST /entries?waitForCommit=true)
+    and saves the receipt to the --transparent-statement output path.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    cose_path = tmp_path / "statement.cose"
+    cose_path.write_bytes(signed_statement)
+
+    output_path = tmp_path / "receipt.cose"
+
+    run(
+        "submit",
+        cose_path,
+        "--transparent-statement",
+        output_path,
+        "--wait-for-commit",
+        with_service_url=True,
+    )
+
+    assert output_path.exists()
+    receipt_bytes = output_path.read_bytes()
+    assert len(receipt_bytes) > 0
+
+    # Verify the output is valid COSE
+    msg = CoseMessage.decode(receipt_bytes)
+    assert msg is not None
+
+
 @pytest.mark.parametrize(
     "filepath",
     [

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -152,9 +152,7 @@ def test_extract_payload_from_cose(run, tmp_path: Path):
     assert claims.get("foo") == "bar"
 
 
-def test_submit_wait_for_commit(
-    run, tmp_path, cert_authority, configure_service
-):
+def test_submit_wait_for_commit(run, tmp_path, cert_authority, configure_service):
     """
     Test the CLI submit command with --wait-for-commit flag.
     This uses the synchronous flow (POST /entries?waitForCommit=true)

--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -365,3 +365,151 @@ def test_write_throughput(
         f"Throughput {test_name}",
         Throughput(value=submissions_per_second),
     )
+
+
+@pytest.mark.bencher
+def test_wait_for_commit_latency(client: Client, cert_authority, configure_service):
+    """
+    Measure end-to-end latency of POST /entries?waitForCommit=true.
+    Compares against the traditional submit + poll + get_receipt flow.
+    """
+    client.wait_time = 0.1
+
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": (
+                    f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+                )
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    iterations = 50
+
+    # Measure wait_for_commit latency
+    latency_ns = []
+    for i in range(iterations):
+        start = time.time()
+        client.submit_signed_statement_wait_for_commit(signed_statement)
+        latency_ns.append((time.time() - start) * 1_000_000_000)
+
+    df = DataFrame({"latency (ns)": latency_ns})
+    print("wait_for_commit latency:")
+    print(df.describe())
+
+    bf = Bencher()
+    bf.set(
+        "wait_for_commit Latency",
+        Latency(
+            value=cast(float, df["latency (ns)"].mean()),
+            high_value=cast(float, df["latency (ns)"].max()),
+            low_value=cast(float, df["latency (ns)"].min()),
+        ),
+    )
+
+    # Measure traditional submit + wait_for_receipt latency for comparison
+    latency_ns = []
+    for i in range(iterations):
+        start = time.time()
+        client.submit_signed_statement_and_wait_for_receipt(signed_statement)
+        latency_ns.append((time.time() - start) * 1_000_000_000)
+
+    df = DataFrame({"latency (ns)": latency_ns})
+    print("submit + poll + get_receipt latency:")
+    print(df.describe())
+
+    bf.set(
+        "Poll-based Receipt Latency",
+        Latency(
+            value=cast(float, df["latency (ns)"].mean()),
+            high_value=cast(float, df["latency (ns)"].max()),
+            low_value=cast(float, df["latency (ns)"].min()),
+        ),
+    )
+
+
+@pytest.mark.bencher
+def test_wait_for_commit_throughput(client: Client, cert_authority, configure_service):
+    """
+    Measure throughput of concurrent POST /entries?waitForCommit=true requests.
+    Each request blocks until consensus, so this measures how many receipts
+    we can obtain per second with parallel submissions.
+    """
+    client.wait_time = 0.001
+
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": (
+                    f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+                )
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    duration_s = 30
+    max_workers = 16
+    warmup_requests = max_workers
+    lock = threading.Lock()
+    completed_count = 0
+    errors = 0
+    last_error = None
+    stop = False
+
+    def _submit():
+        nonlocal completed_count, errors, last_error
+        while not stop:
+            try:
+                client.submit_signed_statement_wait_for_commit(signed_statement)
+                with lock:
+                    completed_count += 1
+            except Exception as e:
+                with lock:
+                    errors += 1
+                    last_error = e
+
+    # Warmup
+    for _ in range(warmup_requests):
+        client.submit_signed_statement_wait_for_commit(signed_statement)
+
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [pool.submit(_submit) for _ in range(max_workers)]
+        time.sleep(duration_s)
+        stop = True
+        for fut in futures:
+            fut.result()
+    elapsed = time.monotonic() - start
+
+    submissions_per_second = completed_count / elapsed
+    error_rate = errors / max(completed_count + errors, 1)
+
+    print(
+        f"wait_for_commit throughput: {completed_count} submissions in {elapsed:.2f}s"
+    )
+    print(f"  Rate: {submissions_per_second:.2f} submissions/s")
+    print(f"  Errors: {errors} ({error_rate:.1%})")
+    if last_error:
+        print(f"  Last error: {last_error}")
+
+    assert error_rate < 0.01, (
+        f"Error rate too high: {error_rate:.1%} ({errors}/{completed_count + errors}). "
+        f"Last error: {last_error}"
+    )
+    assert submissions_per_second > 0, "No successful submissions"
+
+    bf = Bencher()
+    bf.set(
+        "wait_for_commit Throughput",
+        Throughput(value=submissions_per_second),
+    )


### PR DESCRIPTION
## Summary

Adds a `wait_for_commit` query parameter to the `POST /entries` endpoint. When `wait_for_commit=true`, the HTTP response is deferred until the transaction reaches global consensus, at which point a COSE receipt is returned inline with HTTP 200.

## Changes

- **app/src/main.cpp**: Uses CCF rc2 per-request `set_consensus_committed_function()` API on `RpcContext` to register a committed callback when the query parameter is present. On commit, builds a COSE receipt and returns it. On invalidation, returns an error.
- **pyscitt/pyscitt/client.py**: Adds `submit_signed_statement_blocking()` method that posts to `/entries?wait_for_commit=true` and returns the receipt directly.
- **test/test_blocking.py**: Functional test that validates the blocking behavior, COSE receipt structure, and cryptographic receipt verification.

## Testing

- All 18 C++ unit tests pass
- All 98 functional tests pass (2 skipped, pre-existing)