### PR TITLE
User/sbasavapatna/add transparency service keys endpoint

### DIFF
--- a/app/src/call_types.h
+++ b/app/src/call_types.h
@@ -37,17 +37,6 @@ namespace scitt
     service_certificate,
     "serviceCertificate");
 
-  struct GetHistoricServiceParameters
-  {
-    struct Out
-    {
-      std::vector<GetServiceParameters::Out> parameters;
-    };
-  };
-
-  DECLARE_JSON_TYPE(GetHistoricServiceParameters::Out);
-  DECLARE_JSON_REQUIRED_FIELDS(GetHistoricServiceParameters::Out, parameters);
-
   struct GetEntriesTransactionIds
   {
     struct Out

--- a/app/src/call_types.h
+++ b/app/src/call_types.h
@@ -14,29 +14,6 @@
 
 namespace scitt
 {
-  struct GetServiceParameters
-  {
-    struct Out
-    {
-      std::string service_id;
-      std::string tree_algorithm;
-      std::string signature_algorithm;
-      std::string service_certificate;
-    };
-  };
-
-  DECLARE_JSON_TYPE(GetServiceParameters::Out);
-  DECLARE_JSON_REQUIRED_FIELDS_WITH_RENAMES(
-    GetServiceParameters::Out,
-    service_id,
-    "serviceId",
-    tree_algorithm,
-    "treeAlgorithm",
-    signature_algorithm,
-    "signatureAlgorithm",
-    service_certificate,
-    "serviceCertificate");
-
   struct GetEntriesTransactionIds
   {
     struct Out

--- a/app/src/cbor.h
+++ b/app/src/cbor.h
@@ -247,7 +247,8 @@ namespace scitt::cbor
       case ccf::crypto::CurveID::CURVE25519:
       case ccf::crypto::CurveID::X25519:
         throw std::runtime_error(
-          "Unsupported curve ID: " + std::to_string(static_cast<uint8_t>(curve_id)));
+          "Unsupported curve ID: " +
+          std::to_string(static_cast<uint8_t>(curve_id)));
     }
   }
 

--- a/app/src/cbor.h
+++ b/app/src/cbor.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <ccf/crypto/curve.h>
 #include <optional>
 #include <qcbor/UsefulBuf.h>
-#include <qcbor/qcbor_decode.h>
 #include <qcbor/qcbor_encode.h>
 #include <span>
 #include <stdexcept>
@@ -34,11 +34,6 @@ namespace scitt::cbor
     return std::vector<uint8_t>(
       static_cast<const uint8_t*>(buf.ptr),
       static_cast<const uint8_t*>(buf.ptr) + buf.len);
-  }
-
-  inline std::span<const uint8_t> as_span(UsefulBufC buf)
-  {
-    return {static_cast<const uint8_t*>(buf.ptr), buf.len};
   }
 
   inline std::string_view as_string(UsefulBufC buf)
@@ -216,6 +211,112 @@ namespace scitt::cbor
     if (err != QCBOR_SUCCESS)
     {
       throw std::logic_error("Failed to encode CBOR error");
+    }
+    output.resize(encoded_cbor.len);
+    output.shrink_to_fit();
+    return output;
+  }
+
+  // COSE Key type constants (RFC 9052)
+  static constexpr int64_t COSE_KEY_TYPE_EC2 = 2;
+
+  // COSE EC curve constants (RFC 9052)
+  static constexpr int64_t COSE_EC_CURVE_P256 = 1;
+  static constexpr int64_t COSE_EC_CURVE_P384 = 2;
+
+  // COSE Key parameter labels (RFC 9052)
+  static constexpr int64_t COSE_KEY_PARAM_KTY = 1;
+  static constexpr int64_t COSE_KEY_PARAM_KID = 2;
+  static constexpr int64_t COSE_KEY_PARAM_CRV = -1;
+  static constexpr int64_t COSE_KEY_PARAM_X = -2;
+  static constexpr int64_t COSE_KEY_PARAM_Y = -3;
+
+  /**
+   * Map a CCF CurveID to its COSE curve identifier.
+   * See RFC 9053 Section 7.1.
+   */
+  inline int64_t curve_id_to_cose_crv(ccf::crypto::CurveID curve_id)
+  {
+    switch (curve_id)
+    {
+      case ccf::crypto::CurveID::SECP256R1:
+        return COSE_EC_CURVE_P256;
+      case ccf::crypto::CurveID::SECP384R1:
+        return COSE_EC_CURVE_P384;
+      case ccf::crypto::CurveID::NONE:
+      case ccf::crypto::CurveID::CURVE25519:
+      case ccf::crypto::CurveID::X25519:
+        throw std::runtime_error(
+          "Unsupported curve ID: " + std::to_string(static_cast<uint8_t>(curve_id)));
+    }
+  }
+
+  /**
+   * Encode an EC COSE_Key with kid to CBOR.
+   * See RFC 9052 Section 7.
+   */
+  inline std::vector<uint8_t> ec_cose_key_with_kid_to_cbor(
+    const int64_t crv,
+    const std::vector<uint8_t>& x,
+    const std::vector<uint8_t>& y,
+    const std::string& kid)
+  {
+    size_t approx_buff_size = (1 + 5 + 5) * QCBOR_HEAD_BUFFER_SIZE +
+      sizeof(COSE_KEY_TYPE_EC2) + sizeof(crv) + x.size() + y.size() +
+      kid.size();
+    std::vector<uint8_t> output(approx_buff_size);
+
+    UsefulBuf output_buf{output.data(), output.size()};
+    QCBOREncodeContext ectx;
+    QCBOREncode_Init(&ectx, output_buf);
+    QCBOREncode_OpenMap(&ectx);
+    QCBOREncode_AddInt64ToMapN(&ectx, COSE_KEY_PARAM_KTY, COSE_KEY_TYPE_EC2);
+    QCBOREncode_AddTextToMapN(&ectx, COSE_KEY_PARAM_KID, from_string(kid));
+    QCBOREncode_AddInt64ToMapN(&ectx, COSE_KEY_PARAM_CRV, crv);
+    QCBOREncode_AddBytesToMapN(&ectx, COSE_KEY_PARAM_X, from_bytes(x));
+    QCBOREncode_AddBytesToMapN(&ectx, COSE_KEY_PARAM_Y, from_bytes(y));
+    QCBOREncode_CloseMap(&ectx);
+    UsefulBufC encoded_cbor;
+    QCBORError err;
+    err = QCBOREncode_Finish(&ectx, &encoded_cbor);
+    if (err != QCBOR_SUCCESS)
+    {
+      throw std::logic_error("Failed to encode COSE Key to CBOR");
+    }
+    output.resize(encoded_cbor.len);
+    output.shrink_to_fit();
+    return output;
+  }
+
+  /**
+   * Encode a COSE_Key_Set (array of COSE_Key) to CBOR.
+   * See RFC 9052 Section 7.
+   */
+  inline std::vector<uint8_t> cose_key_set_to_cbor(
+    const std::vector<std::vector<uint8_t>>& cose_keys)
+  {
+    size_t approx_buff_size = QCBOR_HEAD_BUFFER_SIZE;
+    for (const auto& key : cose_keys)
+    {
+      approx_buff_size += key.size();
+    }
+    std::vector<uint8_t> output(approx_buff_size);
+
+    UsefulBuf output_buf{output.data(), output.size()};
+    QCBOREncodeContext ectx;
+    QCBOREncode_Init(&ectx, output_buf);
+    QCBOREncode_OpenArray(&ectx);
+    for (const auto& key : cose_keys)
+    {
+      QCBOREncode_AddEncoded(&ectx, from_bytes(key));
+    }
+    QCBOREncode_CloseArray(&ectx);
+    UsefulBufC encoded_cbor;
+    QCBORError err;
+    err = QCBOREncode_Finish(&ectx, &encoded_cbor);
+    if (err != QCBOR_SUCCESS)
+    {
+      throw std::logic_error("Failed to encode COSE Key Set to CBOR");
     }
     output.resize(encoded_cbor.len);
     output.shrink_to_fit();

--- a/app/src/service_endpoints.h
+++ b/app/src/service_endpoints.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
-#include "did/document.h"
+#include "cbor.h"
 #include "visit_each_entry_in_value.h"
 
 #include <ccf/base_endpoint_registry.h>
 #include <ccf/cose_signatures_config_interface.h>
 #include <ccf/crypto/verifier.h>
 #include <ccf/endpoint.h>
-#include <ccf/http_accept.h>
 #include <ccf/json_handler.h>
+#include <ccf/network_identity_interface.h>
 #include <ccf/service/tables/service.h>
 
 namespace scitt
@@ -33,74 +33,39 @@ namespace scitt
   }
 
   /**
-   * An indexing strategy collecting service keys used to sign receipts.
+   * Compute a kid from a public key using SHA-256 hash of the DER encoding.
    */
-  class ServiceKeyIndexingStrategy
-    : public VisitEachEntryInValueTyped<ccf::Service>
+  static std::string kid_from_key(const ccf::crypto::ECPublicKeyPtr& key)
   {
-  public:
-    ServiceKeyIndexingStrategy() :
-      VisitEachEntryInValueTyped(ccf::Tables::SERVICE)
-    {}
+    auto der = key->public_key_der();
+    return ccf::crypto::Sha256Hash(der).hex_str();
+  }
 
-    nlohmann::json get_jwks() const
-    {
-      std::lock_guard guard(lock);
+  /**
+   * Encode an EC public key as a COSE_Key with kid.
+   */
+  static std::vector<uint8_t> key_to_cose_key(
+    const ccf::crypto::ECPublicKeyPtr& key, const std::string& kid)
+  {
+    auto coords = key->coordinates();
+    auto crv = cbor::curve_id_to_cose_crv(key->get_curve_id());
+    return cbor::ec_cose_key_with_kid_to_cbor(crv, coords.x, coords.y, kid);
+  }
 
-      std::vector<nlohmann::json> jwks;
-      for (const auto& service_certificate : service_certificates)
-      {
-        auto verifier = ccf::crypto::make_unique_verifier(service_certificate);
-        auto pub_pem = verifier->public_key_pem();
-        auto kid =
-          ccf::crypto::Sha256Hash(verifier->public_key_der()).hex_str();
-        nlohmann::json json_jwk;
-        try
-        {
-          json_jwk =
-            ccf::crypto::make_ec_public_key(pub_pem)->public_key_jwk(kid);
-        }
-        catch (const std::exception& ec_error)
-        {
-          try
-          {
-            json_jwk =
-              ccf::crypto::make_rsa_public_key(pub_pem)->public_key_jwk(kid);
-          }
-          catch (const std::exception& rsa_error)
-          {
-            throw std::runtime_error(
-              std::string("Unable to parse service public key as EC or RSA. ") +
-              "EC parse failed: " + ec_error.what() +
-              ". RSA parse failed: " + rsa_error.what());
-          }
-        }
-        json_jwk["kid"] = kid;
-        jwks.emplace_back(std::move(json_jwk));
-      }
-      nlohmann::json jwks_json;
-      jwks_json["keys"] = jwks;
-      return jwks_json;
-    }
+  static void set_cbor_response(
+    ccf::endpoints::ReadOnlyEndpointContext& ctx,
+    ccf::http_status status,
+    std::vector<uint8_t>&& body)
+  {
+    ctx.rpc_ctx->set_response_status(status);
+    ctx.rpc_ctx->set_response_header(
+      ccf::http::headers::CONTENT_TYPE,
+      ccf::http::headervalues::contenttype::CBOR);
+    ctx.rpc_ctx->set_response_body(std::move(body));
+  }
 
-  protected:
-    void visit_entry(
-      const ccf::TxID& tx_id, const ccf::ServiceInfo& service_info) override
-    {
-      std::lock_guard guard(lock);
-
-      // It is possible for multiple entries in the ServiceInfo table to contain
-      // the same certificate, eg. if the service status changes. Using an
-      // std::set removes duplicates.
-      service_certificates.insert(service_info.cert);
-    }
-
-  private:
-    mutable std::mutex lock;
-
-    std::set<ccf::crypto::Pem> service_certificates;
-  }; /**
-      * An indexing strategy collecting all past and present service
+  /**
+   * An indexing strategy collecting all past and present service
       * certificates and makes them immediately available.
       */
   class ServiceCertificateIndexingStrategy
@@ -180,15 +145,6 @@ namespace scitt
       out.version = SCITT_VERSION;
       return out;
     };
-
-    static nlohmann::json get_jwks(
-      const std::shared_ptr<ServiceKeyIndexingStrategy>& index,
-      ccf::endpoints::EndpointContext& ctx,
-      nlohmann::json&& params)
-    {
-      // TODO: this is not right when the indexer is not up to date
-      return index->get_jwks();
-    }
   }
 
   static void register_service_endpoints(
@@ -201,12 +157,8 @@ namespace scitt
     auto service_certificate_index =
       std::make_shared<ServiceCertificateIndexingStrategy>();
 
-    auto service_key_index = std::make_shared<ServiceKeyIndexingStrategy>();
-
     context.get_indexing_strategies().install_strategy(
       service_certificate_index);
-
-    context.get_indexing_strategies().install_strategy(service_key_index);
 
     auto get_transparency_config =
       [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
@@ -220,7 +172,8 @@ namespace scitt
 
         nlohmann::json config;
         config["issuer"] = cfg.issuer;
-        config["jwks_uri"] = fmt::format("https://{}/jwks", cfg.issuer);
+        config["jwks_uri"] =
+          fmt::format("https://{}/.well-known/scitt-keys", cfg.issuer);
         ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::CONTENT_TYPE,
@@ -296,17 +249,98 @@ namespace scitt
       .install();
 
     /**
-     * This endpoint is indirectly mentioned in the RFC,
-     * through the "jwks_uri" field in the transparency configuration.
-     * See 2.1.1. Transparency Configuration
-     * https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/
+     * See Section 2.1 of draft-ietf-scitt-scrapi-08.
+     * Returns all trusted service keys as a COSE_Key_Set in
+     * application/cbor format.
      */
+    auto get_scitt_keys =
+      [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
+        auto network_identity =
+          context.get_subsystem<ccf::NetworkIdentitySubsystemInterface>();
+        if (!network_identity)
+        {
+          set_cbor_response(
+            ctx,
+            HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            cbor::cbor_error(
+              "InternalError",
+              "Network identity subsystem not available"));
+          return;
+        }
+
+        auto trusted_keys = network_identity->get_trusted_keys();
+        std::vector<std::vector<uint8_t>> cose_keys;
+        for (const auto& [seq_no, key] : trusted_keys)
+        {
+          cose_keys.push_back(key_to_cose_key(key, kid_from_key(key)));
+        }
+
+        set_cbor_response(
+          ctx,
+          HTTP_STATUS_OK,
+          cbor::cose_key_set_to_cbor(cose_keys));
+      };
+
     registry
-      .make_endpoint(
-        "/jwks",
+      .make_read_only_endpoint(
+        "/.well-known/scitt-keys",
         HTTP_GET,
-        ccf::json_adapter(
-          std::bind(endpoints::get_jwks, service_key_index, _1, _2)),
+        get_scitt_keys,
+        no_authn_policy)
+      .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
+      .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
+      .install();
+
+    /**
+     * See Section 2.2 of draft-ietf-scitt-scrapi-08.
+     * Returns a single trusted service key by kid value
+     * as a COSE_Key in application/cbor format.
+     */
+    auto get_scitt_key_by_kid =
+      [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
+        auto kid_value =
+          ctx.rpc_ctx->get_request_path_params().at("kid_value");
+
+        auto network_identity =
+          context.get_subsystem<ccf::NetworkIdentitySubsystemInterface>();
+        if (!network_identity)
+        {
+          set_cbor_response(
+            ctx,
+            HTTP_STATUS_INTERNAL_SERVER_ERROR,
+            cbor::cbor_error(
+              "InternalError",
+              "Network identity subsystem not available"));
+          return;
+        }
+
+        auto trusted_keys = network_identity->get_trusted_keys();
+        for (const auto& [seq_no, key] : trusted_keys)
+        {
+          auto kid = kid_from_key(key);
+          if (kid == kid_value)
+          {
+            set_cbor_response(
+              ctx,
+              HTTP_STATUS_OK,
+              cbor::cose_key_set_to_cbor({key_to_cose_key(key, kid)}));
+            return;
+          }
+        }
+
+        set_cbor_response(
+          ctx,
+          HTTP_STATUS_NOT_FOUND,
+          cbor::cbor_error(
+            "KeyNotFound",
+            fmt::format("Key with kid '{}' not found", kid_value)));
+      };
+
+    registry
+      .make_read_only_endpoint(
+        "/.well-known/scitt-keys/{kid_value}",
+        HTTP_GET,
+        get_scitt_key_by_kid,
         no_authn_policy)
       .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
       .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
@@ -314,7 +348,7 @@ namespace scitt
 
     /**
      * See 2.1.1. Transparency Configuration
-     * https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/
+     * https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi-08/
      */
     registry
       .make_read_only_endpoint(

--- a/app/src/service_endpoints.h
+++ b/app/src/service_endpoints.h
@@ -18,22 +18,6 @@
 
 namespace scitt
 {
-  static GetServiceParameters::Out certificate_to_service_parameters(
-    const std::vector<uint8_t>& certificate_der)
-  {
-    auto service_id = ccf::crypto::Sha256Hash(certificate_der).hex_str();
-
-    // TODO: extend to support multiple tree hash algorithms once CCF
-    // supports them
-
-    GetServiceParameters::Out out;
-    out.service_id = service_id;
-    out.tree_algorithm = "CCF";
-    out.signature_algorithm = JOSE_ALGORITHM_ES256;
-    out.service_certificate = ccf::crypto::b64_from_raw(certificate_der);
-    return out;
-  }
-
   /**
    * Compute a kid from a public key using SHA-256 hash of the DER encoding.
    *
@@ -73,15 +57,6 @@ namespace scitt
 
   namespace endpoints
   {
-    static GetServiceParameters::Out get_service_parameters(
-      ccf::endpoints::EndpointContext& ctx, nlohmann::json&& params)
-    {
-      auto service = ctx.tx.template ro<ccf::Service>(ccf::Tables::SERVICE);
-      auto service_info = service->get().value();
-      auto service_cert_der = ccf::crypto::cert_pem_to_der(service_info.cert);
-      return certificate_to_service_parameters(service_cert_der);
-    }
-
     static Configuration get_configuration(
       ccf::endpoints::EndpointContext& ctx, nlohmann::json&& params)
     {
@@ -126,20 +101,6 @@ namespace scitt
         ctx.rpc_ctx->set_response_body(nlohmann::json::to_cbor(config));
         return;
       };
-
-    /**
-     * The endpoint exposes the current service parameters.
-     */
-    registry
-      .make_endpoint(
-        "/parameters",
-        HTTP_GET,
-        ccf::json_adapter(endpoints::get_service_parameters),
-        no_authn_policy)
-      .set_auto_schema<void, GetServiceParameters::Out>()
-      .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
-      .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
-      .install();
 
     /**
      * Convenience endpoint to provide the service configuration.
@@ -189,7 +150,8 @@ namespace scitt
           ccf::http::headers::CONTENT_TYPE,
           ccf::http::headervalues::contenttype::JSON);
         nlohmann::json error;
-        error["error"] = "Network identity subsystem not available";
+        error["error"] = "InternalError";
+        error["message"] = "Service keys temporarily unavailable";
         ctx.rpc_ctx->set_response_body(error.dump());
         return;
       }
@@ -235,7 +197,7 @@ namespace scitt
           ctx,
           HTTP_STATUS_INTERNAL_SERVER_ERROR,
           cbor::cbor_error(
-            "InternalError", "Network identity subsystem not available"));
+            "InternalError", "Service keys temporarily unavailable"));
         return;
       }
 
@@ -274,7 +236,7 @@ namespace scitt
             ctx,
             HTTP_STATUS_INTERNAL_SERVER_ERROR,
             cbor::cbor_error(
-              "InternalError", "Network identity subsystem not available"));
+              "InternalError", "Service keys temporarily unavailable"));
           return;
         }
 

--- a/app/src/service_endpoints.h
+++ b/app/src/service_endpoints.h
@@ -35,75 +35,6 @@ namespace scitt
   }
 
   /**
-   * An indexing strategy collecting service keys used to sign receipts.
-   */
-  class ServiceKeyIndexingStrategy
-    : public VisitEachEntryInValueTyped<ccf::Service>
-  {
-  public:
-    ServiceKeyIndexingStrategy() :
-      VisitEachEntryInValueTyped(ccf::Tables::SERVICE)
-    {}
-
-    nlohmann::json get_jwks() const
-    {
-      std::lock_guard guard(lock);
-
-      std::vector<nlohmann::json> jwks;
-      for (const auto& service_certificate : service_certificates)
-      {
-        auto verifier = ccf::crypto::make_unique_verifier(service_certificate);
-        auto pub_pem = verifier->public_key_pem();
-        auto kid =
-          ccf::crypto::Sha256Hash(verifier->public_key_der()).hex_str();
-        nlohmann::json json_jwk;
-        try
-        {
-          json_jwk =
-            ccf::crypto::make_ec_public_key(pub_pem)->public_key_jwk(kid);
-        }
-        catch (const std::exception& ec_error)
-        {
-          try
-          {
-            json_jwk =
-              ccf::crypto::make_rsa_public_key(pub_pem)->public_key_jwk(kid);
-          }
-          catch (const std::exception& rsa_error)
-          {
-            throw std::runtime_error(
-              std::string("Unable to parse service public key as EC or RSA. ") +
-              "EC parse failed: " + ec_error.what() +
-              ". RSA parse failed: " + rsa_error.what());
-          }
-        }
-        json_jwk["kid"] = kid;
-        jwks.emplace_back(std::move(json_jwk));
-      }
-      nlohmann::json jwks_json;
-      jwks_json["keys"] = jwks;
-      return jwks_json;
-    }
-
-  protected:
-    void visit_entry(
-      const ccf::TxID& tx_id, const ccf::ServiceInfo& service_info) override
-    {
-      std::lock_guard guard(lock);
-
-      // It is possible for multiple entries in the ServiceInfo table to contain
-      // the same certificate, eg. if the service status changes. Using an
-      // std::set removes duplicates.
-      service_certificates.insert(service_info.cert);
-    }
-
-  private:
-    mutable std::mutex lock;
-
-    std::set<ccf::crypto::Pem> service_certificates;
-  };
-
-  /**
    * Compute a kid from a public key using SHA-256 hash of the DER encoding.
    *
    * Note: CCF has an equivalent internal function ccf::crypto::kid_from_key()
@@ -140,51 +71,6 @@ namespace scitt
     ctx.rpc_ctx->set_response_body(std::move(body));
   }
 
-  /**
-   * An indexing strategy collecting all past and present service
-   * certificates and makes them immediately available.
-   */
-  class ServiceCertificateIndexingStrategy
-    : public VisitEachEntryInValueTyped<ccf::Service>
-  {
-  public:
-    ServiceCertificateIndexingStrategy() :
-      VisitEachEntryInValueTyped(ccf::Tables::SERVICE)
-    {}
-
-    std::vector<GetServiceParameters::Out> get_service_parameters() const
-    {
-      std::lock_guard guard(lock);
-
-      std::vector<GetServiceParameters::Out> out;
-      for (const auto& certificate : service_certificates)
-      {
-        out.push_back(certificate_to_service_parameters(certificate));
-      }
-      return out;
-    }
-
-  protected:
-    void visit_entry(
-      const ccf::TxID& tx_id, const ccf::ServiceInfo& service_info) override
-    {
-      std::lock_guard guard(lock);
-
-      auto service_cert_der = ccf::crypto::cert_pem_to_der(service_info.cert);
-
-      // It is possible for multiple entries in the ServiceInfo table to contain
-      // the same certificate, eg. if the service status changes. Using an
-      // std::set removes duplicates.
-      service_certificates.insert(service_cert_der);
-    }
-
-  private:
-    mutable std::mutex lock;
-
-    // Set of DER-encoded certificates
-    std::set<std::vector<uint8_t>> service_certificates;
-  };
-
   namespace endpoints
   {
     static GetServiceParameters::Out get_service_parameters(
@@ -194,16 +80,6 @@ namespace scitt
       auto service_info = service->get().value();
       auto service_cert_der = ccf::crypto::cert_pem_to_der(service_info.cert);
       return certificate_to_service_parameters(service_cert_der);
-    }
-
-    static GetHistoricServiceParameters::Out get_historic_service_parameters(
-      const std::shared_ptr<ServiceCertificateIndexingStrategy>& index,
-      ccf::endpoints::EndpointContext& ctx,
-      nlohmann::json&& params)
-    {
-      GetHistoricServiceParameters::Out out;
-      out.parameters = index->get_service_parameters();
-      return out;
     }
 
     static Configuration get_configuration(
@@ -221,15 +97,6 @@ namespace scitt
       out.version = SCITT_VERSION;
       return out;
     };
-
-    static nlohmann::json get_jwks(
-      const std::shared_ptr<ServiceKeyIndexingStrategy>& index,
-      ccf::endpoints::EndpointContext& ctx,
-      nlohmann::json&& params)
-    {
-      // TODO: this is not right when the indexer is not up to date
-      return index->get_jwks();
-    }
   }
 
   static void register_service_endpoints(
@@ -238,16 +105,6 @@ namespace scitt
     using namespace std::placeholders;
 
     const ccf::AuthnPolicies no_authn_policy = {ccf::empty_auth_policy};
-
-    auto service_certificate_index =
-      std::make_shared<ServiceCertificateIndexingStrategy>();
-
-    auto service_key_index = std::make_shared<ServiceKeyIndexingStrategy>();
-
-    context.get_indexing_strategies().install_strategy(
-      service_certificate_index);
-
-    context.get_indexing_strategies().install_strategy(service_key_index);
 
     auto get_transparency_config =
       [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
@@ -280,26 +137,6 @@ namespace scitt
         ccf::json_adapter(endpoints::get_service_parameters),
         no_authn_policy)
       .set_auto_schema<void, GetServiceParameters::Out>()
-      .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
-      .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
-      .install();
-
-    /**
-     * The endpoint exposes older service parameters.
-     * Parameters can change in the case of a
-     * disaster recovery.
-     */
-    registry
-      .make_endpoint(
-        "/parameters/historic",
-        HTTP_GET,
-        ccf::json_adapter(std::bind(
-          endpoints::get_historic_service_parameters,
-          service_certificate_index,
-          _1,
-          _2)),
-        no_authn_policy)
-      .set_auto_schema<void, GetHistoricServiceParameters::Out>()
       .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
       .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
       .install();
@@ -342,13 +179,44 @@ namespace scitt
      * See 2.1.1. Transparency Configuration
      * https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/
      */
+    auto get_jwks = [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
+      auto network_identity =
+        context.get_subsystem<ccf::NetworkIdentitySubsystemInterface>();
+      if (!network_identity)
+      {
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR);
+        ctx.rpc_ctx->set_response_header(
+          ccf::http::headers::CONTENT_TYPE,
+          ccf::http::headervalues::contenttype::JSON);
+        nlohmann::json error;
+        error["error"] = "Network identity subsystem not available";
+        ctx.rpc_ctx->set_response_body(error.dump());
+        return;
+      }
+
+      auto trusted_keys = network_identity->get_trusted_keys();
+      std::vector<nlohmann::json> jwks;
+      for (const auto& [seq_no, key] : trusted_keys)
+      {
+        auto kid = kid_from_key(key);
+        auto jwk = key->public_key_jwk(kid);
+        nlohmann::json json_jwk;
+        to_json(json_jwk, jwk);
+        jwks.emplace_back(std::move(json_jwk));
+      }
+
+      nlohmann::json jwks_json;
+      jwks_json["keys"] = jwks;
+
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
+      ctx.rpc_ctx->set_response_header(
+        ccf::http::headers::CONTENT_TYPE,
+        ccf::http::headervalues::contenttype::JSON);
+      ctx.rpc_ctx->set_response_body(jwks_json.dump());
+    };
+
     registry
-      .make_endpoint(
-        "/jwks",
-        HTTP_GET,
-        ccf::json_adapter(
-          std::bind(endpoints::get_jwks, service_key_index, _1, _2)),
-        no_authn_policy)
+      .make_read_only_endpoint("/jwks", HTTP_GET, get_jwks, no_authn_policy)
       .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
       .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
       .install();

--- a/app/src/service_endpoints.h
+++ b/app/src/service_endpoints.h
@@ -4,12 +4,14 @@
 #pragma once
 
 #include "cbor.h"
+#include "did/document.h"
 #include "visit_each_entry_in_value.h"
 
 #include <ccf/base_endpoint_registry.h>
 #include <ccf/cose_signatures_config_interface.h>
 #include <ccf/crypto/verifier.h>
 #include <ccf/endpoint.h>
+#include <ccf/http_accept.h>
 #include <ccf/json_handler.h>
 #include <ccf/network_identity_interface.h>
 #include <ccf/service/tables/service.h>
@@ -33,7 +35,81 @@ namespace scitt
   }
 
   /**
+   * An indexing strategy collecting service keys used to sign receipts.
+   */
+  class ServiceKeyIndexingStrategy
+    : public VisitEachEntryInValueTyped<ccf::Service>
+  {
+  public:
+    ServiceKeyIndexingStrategy() :
+      VisitEachEntryInValueTyped(ccf::Tables::SERVICE)
+    {}
+
+    nlohmann::json get_jwks() const
+    {
+      std::lock_guard guard(lock);
+
+      std::vector<nlohmann::json> jwks;
+      for (const auto& service_certificate : service_certificates)
+      {
+        auto verifier = ccf::crypto::make_unique_verifier(service_certificate);
+        auto pub_pem = verifier->public_key_pem();
+        auto kid =
+          ccf::crypto::Sha256Hash(verifier->public_key_der()).hex_str();
+        nlohmann::json json_jwk;
+        try
+        {
+          json_jwk =
+            ccf::crypto::make_ec_public_key(pub_pem)->public_key_jwk(kid);
+        }
+        catch (const std::exception& ec_error)
+        {
+          try
+          {
+            json_jwk =
+              ccf::crypto::make_rsa_public_key(pub_pem)->public_key_jwk(kid);
+          }
+          catch (const std::exception& rsa_error)
+          {
+            throw std::runtime_error(
+              std::string("Unable to parse service public key as EC or RSA. ") +
+              "EC parse failed: " + ec_error.what() +
+              ". RSA parse failed: " + rsa_error.what());
+          }
+        }
+        json_jwk["kid"] = kid;
+        jwks.emplace_back(std::move(json_jwk));
+      }
+      nlohmann::json jwks_json;
+      jwks_json["keys"] = jwks;
+      return jwks_json;
+    }
+
+  protected:
+    void visit_entry(
+      const ccf::TxID& tx_id, const ccf::ServiceInfo& service_info) override
+    {
+      std::lock_guard guard(lock);
+
+      // It is possible for multiple entries in the ServiceInfo table to contain
+      // the same certificate, eg. if the service status changes. Using an
+      // std::set removes duplicates.
+      service_certificates.insert(service_info.cert);
+    }
+
+  private:
+    mutable std::mutex lock;
+
+    std::set<ccf::crypto::Pem> service_certificates;
+  };
+
+  /**
    * Compute a kid from a public key using SHA-256 hash of the DER encoding.
+   *
+   * Note: CCF has an equivalent internal function ccf::crypto::kid_from_key()
+   * in src/crypto/public_key.h. If it gets exposed in the public API with an
+   * ECPublicKeyPtr overload, we should switch to using it.
+   * See: https://github.com/microsoft/CCF/blob/main/src/crypto/public_key.cpp
    */
   static std::string kid_from_key(const ccf::crypto::ECPublicKeyPtr& key)
   {
@@ -145,6 +221,15 @@ namespace scitt
       out.version = SCITT_VERSION;
       return out;
     };
+
+    static nlohmann::json get_jwks(
+      const std::shared_ptr<ServiceKeyIndexingStrategy>& index,
+      ccf::endpoints::EndpointContext& ctx,
+      nlohmann::json&& params)
+    {
+      // TODO: this is not right when the indexer is not up to date
+      return index->get_jwks();
+    }
   }
 
   static void register_service_endpoints(
@@ -157,8 +242,12 @@ namespace scitt
     auto service_certificate_index =
       std::make_shared<ServiceCertificateIndexingStrategy>();
 
+    auto service_key_index = std::make_shared<ServiceKeyIndexingStrategy>();
+
     context.get_indexing_strategies().install_strategy(
       service_certificate_index);
+
+    context.get_indexing_strategies().install_strategy(service_key_index);
 
     auto get_transparency_config =
       [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
@@ -172,8 +261,7 @@ namespace scitt
 
         nlohmann::json config;
         config["issuer"] = cfg.issuer;
-        config["jwks_uri"] =
-          fmt::format("https://{}/.well-known/scitt-keys", cfg.issuer);
+        config["jwks_uri"] = fmt::format("https://{}/jwks", cfg.issuer);
         ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::CONTENT_TYPE,
@@ -249,6 +337,23 @@ namespace scitt
       .install();
 
     /**
+     * This endpoint is indirectly mentioned in the RFC,
+     * through the "jwks_uri" field in the transparency configuration.
+     * See 2.1.1. Transparency Configuration
+     * https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/
+     */
+    registry
+      .make_endpoint(
+        "/jwks",
+        HTTP_GET,
+        ccf::json_adapter(
+          std::bind(endpoints::get_jwks, service_key_index, _1, _2)),
+        no_authn_policy)
+      .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
+      .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
+      .install();
+
+    /**
      * See Section 2.1 of draft-ietf-scitt-scrapi-08.
      * Returns all trusted service keys as a COSE_Key_Set in
      * application/cbor format.
@@ -311,10 +416,9 @@ namespace scitt
           auto kid = kid_from_key(key);
           if (kid == kid_value)
           {
-            set_cbor_response(
-              ctx,
-              HTTP_STATUS_OK,
-              cbor::cose_key_set_to_cbor({key_to_cose_key(key, kid)}));
+            // Return a single COSE Key (map), not a COSE Key Set (array)
+            // per Section 2.2 of draft-ietf-scitt-scrapi-09
+            set_cbor_response(ctx, HTTP_STATUS_OK, key_to_cose_key(key, kid));
             return;
           }
         }
@@ -323,8 +427,9 @@ namespace scitt
           ctx,
           HTTP_STATUS_NOT_FOUND,
           cbor::cbor_error(
-            "KeyNotFound",
-            fmt::format("Key with kid '{}' not found", kid_value)));
+            "No such key",
+            fmt::format(
+              "No key could be found for this '{}' value", kid_value)));
       };
 
     registry

--- a/app/src/service_endpoints.h
+++ b/app/src/service_endpoints.h
@@ -66,8 +66,8 @@ namespace scitt
 
   /**
    * An indexing strategy collecting all past and present service
-      * certificates and makes them immediately available.
-      */
+   * certificates and makes them immediately available.
+   */
   class ServiceCertificateIndexingStrategy
     : public VisitEachEntryInValueTyped<ccf::Service>
   {
@@ -253,40 +253,33 @@ namespace scitt
      * Returns all trusted service keys as a COSE_Key_Set in
      * application/cbor format.
      */
-    auto get_scitt_keys =
-      [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
-        auto network_identity =
-          context.get_subsystem<ccf::NetworkIdentitySubsystemInterface>();
-        if (!network_identity)
-        {
-          set_cbor_response(
-            ctx,
-            HTTP_STATUS_INTERNAL_SERVER_ERROR,
-            cbor::cbor_error(
-              "InternalError",
-              "Network identity subsystem not available"));
-          return;
-        }
-
-        auto trusted_keys = network_identity->get_trusted_keys();
-        std::vector<std::vector<uint8_t>> cose_keys;
-        for (const auto& [seq_no, key] : trusted_keys)
-        {
-          cose_keys.push_back(key_to_cose_key(key, kid_from_key(key)));
-        }
-
+    auto get_scitt_keys = [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
+      auto network_identity =
+        context.get_subsystem<ccf::NetworkIdentitySubsystemInterface>();
+      if (!network_identity)
+      {
         set_cbor_response(
           ctx,
-          HTTP_STATUS_OK,
-          cbor::cose_key_set_to_cbor(cose_keys));
-      };
+          HTTP_STATUS_INTERNAL_SERVER_ERROR,
+          cbor::cbor_error(
+            "InternalError", "Network identity subsystem not available"));
+        return;
+      }
+
+      auto trusted_keys = network_identity->get_trusted_keys();
+      std::vector<std::vector<uint8_t>> cose_keys;
+      for (const auto& [seq_no, key] : trusted_keys)
+      {
+        cose_keys.push_back(key_to_cose_key(key, kid_from_key(key)));
+      }
+
+      set_cbor_response(
+        ctx, HTTP_STATUS_OK, cbor::cose_key_set_to_cbor(cose_keys));
+    };
 
     registry
       .make_read_only_endpoint(
-        "/.well-known/scitt-keys",
-        HTTP_GET,
-        get_scitt_keys,
-        no_authn_policy)
+        "/.well-known/scitt-keys", HTTP_GET, get_scitt_keys, no_authn_policy)
       .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
       .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
       .install();
@@ -298,8 +291,7 @@ namespace scitt
      */
     auto get_scitt_key_by_kid =
       [&](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
-        auto kid_value =
-          ctx.rpc_ctx->get_request_path_params().at("kid_value");
+        auto kid_value = ctx.rpc_ctx->get_request_path_params().at("kid_value");
 
         auto network_identity =
           context.get_subsystem<ccf::NetworkIdentitySubsystemInterface>();
@@ -309,8 +301,7 @@ namespace scitt
             ctx,
             HTTP_STATUS_INTERNAL_SERVER_ERROR,
             cbor::cbor_error(
-              "InternalError",
-              "Network identity subsystem not available"));
+              "InternalError", "Network identity subsystem not available"));
           return;
         }
 

--- a/demo/transparency-service-poc/3-client-demo.sh
+++ b/demo/transparency-service-poc/3-client-demo.sh
@@ -25,12 +25,12 @@ source venv/bin/activate
 pip install --disable-pip-version-check -q -e ./pyscitt
 
 # Get service parameters
-echo -e "\nGetting service parameters"
+echo -e "\nGetting service keys"
 SERVICE_PARAMS_FOLDER="$OUTPUT_FOLDER"/service_params
 mkdir -p "$SERVICE_PARAMS_FOLDER"
 
-# Get service parameters to populate the trust store
-curl -k -f "$SCITT_URL"/parameters > "$SERVICE_PARAMS_FOLDER"/scitt.json
+# Get service keys from /.well-known/scitt-keys endpoint (COSE_Key_Set in CBOR format)
+curl -k -f "$SCITT_URL"/.well-known/scitt-keys -o "$SERVICE_PARAMS_FOLDER"/scitt-keys.cbor
 
 echo -e "\nSubmitting claim to the ledger and getting receipt for the committed transaction"
 RECEIPT_FOLDER="$OUTPUT_FOLDER"/receipts

--- a/demo/transparency-service-poc/3-client-demo.sh
+++ b/demo/transparency-service-poc/3-client-demo.sh
@@ -29,9 +29,8 @@ echo -e "\nGetting service parameters"
 SERVICE_PARAMS_FOLDER="$OUTPUT_FOLDER"/service_params
 mkdir -p "$SERVICE_PARAMS_FOLDER"
 
-# Get historic parameters to populate the trust store with all the previous service identities
-# This is useful to verify entries that have been committed with a previous service identity (e.g., prior to a CCF disaster recovery)
-curl -k -f "$SCITT_URL"/parameters/historic > "$SERVICE_PARAMS_FOLDER"/scitt.json
+# Get service parameters to populate the trust store
+curl -k -f "$SCITT_URL"/parameters > "$SERVICE_PARAMS_FOLDER"/scitt.json
 
 echo -e "\nSubmitting claim to the ledger and getting receipt for the committed transaction"
 RECEIPT_FOLDER="$OUTPUT_FOLDER"/receipts

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -8,11 +8,10 @@ The assumption here is that the original build was done using a Docker.
 
 You need a couple pieces of information to begin with:
 
-- The ledger certificate. It might be distributed in a variety of ways by the ledger operator, please follow their guidance. Otherwise it is accessible at `https://<LEDGER-URL>/app/parameters`, e.g.:
+- The ledger certificate. It might be distributed in a variety of ways by the ledger operator, please follow their guidance. Otherwise it is accessible at `https://<LEDGER-URL>/node/network`, e.g.:
 
     ```sh
-    $ curl -k "https://<LEDGER-URL>/app/parameters" | jq -r .serviceCertificate | base64 -d > cacert.der
-    $ openssl x509 -inform der -in cacert.der > cacert.pem
+    $ curl -k "https://<LEDGER-URL>/node/network" | jq -r .service_certificate > cacert.pem
     ```
 
 - The quote of a running application code, get it from `https://<LEDGER-URL>/node/quotes` which will contain the measurements of each node in the network. They will be the same almost all of the time except when upgrading to the new version e.g.:

--- a/pyscitt/pyscitt/cli/governance.py
+++ b/pyscitt/pyscitt/cli/governance.py
@@ -10,6 +10,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional, Union
 from urllib.parse import urlparse
 
+import cbor2
 import certifi
 
 from .. import governance
@@ -214,12 +215,12 @@ def setup_local_development(client: Client, trust_store_dir: Optional[Path]):
     client.wait_for_network_open()
 
     if trust_store_dir:
-        print(f"Adding service to {trust_store_dir} ...")
+        print(f"Adding service keys to {trust_store_dir} ...")
         trust_store_dir.mkdir(parents=True, exist_ok=True)
-        parameters = client.get_parameters().as_dict()
-        service_id = parameters["serviceId"]
-        path = trust_store_dir.joinpath(service_id + ".json")
-        path.write_text(json.dumps(parameters))
+        # Save COSE_Key_Set from /.well-known/scitt-keys as CBOR
+        scitt_keys = client.get_scitt_keys()
+        path = trust_store_dir.joinpath("scitt-keys.cbor")
+        path.write_bytes(cbor2.dumps(scitt_keys))
 
 
 def cli(fn):

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -612,6 +612,7 @@ class Client(BaseClient):
         resp = self.get(f"/.well-known/scitt-keys/{kid}")
         resp.raise_for_status()
         return cbor2.loads(resp.read())
+
     @staticmethod
     def _extract_tx_from_location(location: str) -> str:
         """Extract and validate the transaction ID from a Location header."""

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -549,6 +549,11 @@ class Client(BaseClient):
     def get_version(self) -> dict:
         return self.get("/version").json()
 
+    def get_jwks(self) -> dict:
+        resp = self.get(f"/jwks")
+        resp.raise_for_status()
+        return resp.json()
+
     def get_scitt_keys(self) -> list:
         resp = self.get("/.well-known/scitt-keys")
         resp.raise_for_status()

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -20,7 +20,6 @@ from loguru import logger as LOG
 from . import crypto
 from .governance import CCF_GOV_API_VERSION, GovernanceClient
 from .receipt import Receipt
-from .verify import ServiceParameters
 
 CCF_TX_ID_HEADER = "x-ms-ccf-transaction-id"
 CT_APPLICATION_JSON = "application/json"
@@ -536,9 +535,6 @@ class Client(BaseClient):
     """
     Specialization of the BaseClient, aimed at interacting with a SCITT CCF ledger instance.
     """
-
-    def get_parameters(self) -> ServiceParameters:
-        return ServiceParameters.from_dict(self.get("/parameters").json())
 
     def get_constitution(self) -> str:
         return self.get(

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -549,10 +549,15 @@ class Client(BaseClient):
     def get_version(self) -> dict:
         return self.get("/version").json()
 
-    def get_jwks(self) -> dict:
-        resp = self.get(f"/jwks")
+    def get_scitt_keys(self) -> list:
+        resp = self.get("/.well-known/scitt-keys")
         resp.raise_for_status()
-        return resp.json()
+        return cbor2.loads(resp.read())
+
+    def get_scitt_key(self, kid: str) -> list:
+        resp = self.get(f"/.well-known/scitt-keys/{kid}")
+        resp.raise_for_status()
+        return cbor2.loads(resp.read())
 
     def submit_signed_statement(
         self,

--- a/pyscitt/pyscitt/receipt.py
+++ b/pyscitt/pyscitt/receipt.py
@@ -6,7 +6,7 @@ import datetime
 import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Union
+from typing import Any, Union
 
 import cbor2
 import ccf.receipt
@@ -18,9 +18,6 @@ from pycose.messages import Sign1Message
 from pycose.messages.cosebase import CoseBase
 
 from . import crypto
-
-if TYPE_CHECKING:
-    from .verify import ServiceParameters
 
 HEADER_PARAM_TREE_ALGORITHM = "tree_alg"
 TREE_ALGORITHM_CCF = "CCF"
@@ -139,7 +136,7 @@ class LeafInfo:
 
 class ReceiptContents(ABC):
     @abstractmethod
-    def verify(self, tbs: bytes, service: "ServiceParameters"):
+    def verify(self, tbs: bytes, service: Any):
         pass
 
     @abstractmethod
@@ -178,7 +175,7 @@ class CCFReceiptContents(ReceiptContents):
 
         return bytes.fromhex(ccf.receipt.root(leaf, proof))
 
-    def verify(self, tbs: bytes, service: "ServiceParameters"):
+    def verify(self, tbs: bytes, service: Any):
         if service.tree_algorithm != "CCF":
             raise ValueError("treeAlgorithm must be CCF")
         if service.signature_algorithm != "ES256":
@@ -253,7 +250,7 @@ class Receipt:
         ]
         return cbor2.dumps(countersign_structure)
 
-    def verify(self, claim: Sign1Message, service_params: "ServiceParameters"):
+    def verify(self, claim: Sign1Message, service_params: Any):
         tbs = self.countersign_structure(claim)
         self.contents.verify(tbs, service_params)
 

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -16,14 +16,13 @@ import httpx
 from azure.confidentialledger.certificate import ConfidentialLedgerCertificateClient
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     PublicFormat,
-    load_pem_public_key,
 )
 from cryptography.x509 import load_der_x509_certificate
-from jwcrypto import jwk
 from pycose.headers import KID
 from pycose.keys.cosekey import CoseKey
 from pycose.messages import Sign1Message
@@ -241,14 +240,12 @@ class DynamicTrustStoreClient:
                 self.clients[issuer] = self._client()
         return self.clients[issuer]
 
-    def _assert_tls_in_jwks(self, tls_pem: str, jwks: dict):
-        """Parse JSON web keys to find the KID of the TLS certificate public key."""
+    def _assert_tls_in_cose_keys(self, tls_pem: str, cose_keys: list):
+        """Check that the TLS certificate public key is present in the COSE Key Set."""
         if not tls_pem:
             raise ValueError("TLS PEM certificate is required")
-        if not jwks:
-            raise ValueError("JWKS is required")
-        if not "keys" in jwks:
-            raise ValueError("JWKS does not contain 'keys'")
+        if not cose_keys:
+            raise ValueError("COSE Key Set is required")
         cert = x509.load_pem_x509_certificate(tls_pem.encode(), default_backend())
         cert_digest = (
             sha256(
@@ -259,50 +256,36 @@ class DynamicTrustStoreClient:
             .digest()
             .hex()
         )
-        jwks_keys_digests = []
-        for jwks_key in jwks["keys"]:
-            try:
-                pem_b = jwk.JWK.from_json(json.dumps(jwks_key)).export_to_pem()
-                pub_key = load_pem_public_key(pem_b, default_backend())
-                pubhash = (
-                    sha256(
-                        pub_key.public_bytes(
-                            Encoding.DER, PublicFormat.SubjectPublicKeyInfo
-                        )
-                    )
-                    .digest()
-                    .hex()
-                )
-                jwks_keys_digests.append(pubhash)
-            except Exception as e:
-                print(f"Warning: Could not parse JWKS key: {e}")
+        # kid (label 2) in COSE Keys is SHA-256 of DER public key, hex encoded
+        key_kids = [key.get(2) for key in cose_keys if isinstance(key, dict)]
+        if cert_digest not in key_kids:
+            raise ValueError(
+                f"TLS public key digest {cert_digest} not found in COSE Key Set"
+            )
 
-        if cert_digest not in jwks_keys_digests:
-            raise ValueError(f"TLS public key digest {cert_digest} not found in JWKS")
-
-    def get_jwks(self, issuer: str) -> dict:
+    def get_scitt_keys(self, issuer: str) -> list:
         """
-        Retrieve the JWKS from the issuer.
+        Retrieve the COSE Key Set from the issuer's SCITT keys endpoint.
         """
         transparency_configuration = self.get_configuration(issuer)
         transparency_configuration.raise_for_status()
         config_response = cbor2.loads(transparency_configuration.content)
         jwks_uri = config_response["jwks_uri"]
-        jwks_response = self._client_for_issuer(issuer).get(
-            jwks_uri, headers={"Accept": "application/json"}
+        keys_response = self._client_for_issuer(issuer).get(
+            jwks_uri, headers={"Accept": "application/cbor"}
         )
-        jwks_response.raise_for_status()
-        jwks = jwks_response.json()
+        keys_response.raise_for_status()
+        cose_keys = cbor2.loads(keys_response.content)
 
-        # If issuer is a Confidential Ledger issuer, ensure the TLS certificate public key is in the JWKS.
-        # This step adds an additional layer of trustworthiness of the public keys used for verification.
+        # If issuer is a Confidential Ledger issuer, ensure the TLS certificate
+        # public key is in the COSE Key Set.
         if self.is_confidential_ledger_issuer(issuer):
             pem = self.confidential_ledger_certs.get(issuer)
             if pem is None:
                 raise ValueError(f"No TLS certificate for issuer {issuer}.")
-            self._assert_tls_in_jwks(pem, jwks)
+            self._assert_tls_in_cose_keys(pem, cose_keys)
 
-        return jwks
+        return cose_keys
 
     def get_configuration(self, issuer: str):
         """
@@ -348,6 +331,12 @@ class DynamicTrustStore(TrustStore):
     def services(self):
         raise NotImplementedError()
 
+    COSE_CRV_TO_EC = {
+        1: ec.SECP256R1(),
+        2: ec.SECP384R1(),
+        3: ec.SECP521R1(),
+    }
+
     def get_key(self, receipt: bytes) -> CertificatePublicKeyTypes:
         """
         Look up a service's public key based on the protected headers from a receipt.
@@ -356,12 +345,27 @@ class DynamicTrustStore(TrustStore):
         cwt = parsed.phdr[CWTClaims]
         key_id = parsed.phdr[KID]
         issuer = cwt[CWT_ISS]
-        jwk_set = self.client.get_jwks(issuer)
-        jwks = jwk_set["keys"]
-        keys = {key["kid"].encode(): key for key in jwks}
+        cose_keys = self.client.get_scitt_keys(issuer)
+        # kid (label 2) is a text string; KID in receipt header is bytes
+        keys = {}
+        for k in cose_keys:
+            kid = k.get(2)
+            if isinstance(kid, str):
+                keys[kid.encode()] = k
+            elif isinstance(kid, bytes):
+                keys[kid] = k
         if key_id not in keys:
-            raise ValueError(f"Key ID {key_id} not found in JWKS for issuer {issuer}")
-        key = keys[key_id]
-        pem_key = jwk.JWK.from_json(json.dumps(key)).export_to_pem()
-        key = load_pem_public_key(pem_key, default_backend())
-        return key  # type: ignore
+            raise ValueError(
+                f"Key ID {key_id} not found in COSE Key Set for issuer {issuer}"
+            )
+        cose_key = keys[key_id]
+        crv = cose_key.get(-1)
+        curve = self.COSE_CRV_TO_EC.get(crv)
+        if curve is None:
+            raise ValueError(f"Unsupported COSE curve: {crv}")
+        public_numbers = ec.EllipticCurvePublicNumbers(
+            x=int.from_bytes(cose_key[-2], "big"),
+            y=int.from_bytes(cose_key[-3], "big"),
+            curve=curve,
+        )
+        return public_numbers.public_key()

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -5,7 +5,6 @@ import base64
 import json
 import ssl
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Dict, Optional
@@ -30,36 +29,6 @@ from pycose.messages import Sign1Message
 
 from . import crypto
 from .crypto import CWT_IAT, CWT_ISS, CWTClaims
-
-
-@dataclass
-class ServiceParameters:
-    tree_algorithm: str
-    signature_algorithm: str
-    certificate: bytes
-    service_id: Optional[str] = None
-
-    @staticmethod
-    def from_dict(data) -> "ServiceParameters":
-        """
-        Decode service parameters as returned by the /parameters endpoint.
-        """
-        return ServiceParameters(
-            tree_algorithm=data["treeAlgorithm"],
-            signature_algorithm=data["signatureAlgorithm"],
-            certificate=base64.b64decode(data["serviceCertificate"]),
-            service_id=data["serviceId"],
-        )
-
-    def as_dict(self) -> Dict[str, str]:
-        result = {
-            "treeAlgorithm": self.tree_algorithm,
-            "signatureAlgorithm": self.signature_algorithm,
-            "serviceCertificate": base64.b64encode(self.certificate).decode("ascii"),
-        }
-        if self.service_id is not None:
-            result["serviceId"] = self.service_id
-        return result
 
 
 class TrustStore(ABC):
@@ -140,62 +109,120 @@ def verify_transparent_statement(
 
 class StaticTrustStore(TrustStore):
     """
-    A static trust store, based on a list of trusted service certificates.
+    A static trust store, based on a list of trusted COSE keys from /.well-known/scitt-keys
+    or DER-encoded service certificates (legacy format).
     """
 
-    services: Dict[str, ServiceParameters] = {}
     trust_store_keys: dict = {}
 
-    def __init__(self, services: Dict[str, ServiceParameters]):
-        self.services = services
-        for _, service_params in self.services.items():
-            cert = load_der_x509_certificate(
-                service_params.certificate, default_backend()
-            )
-            key = cert.public_key()
-            kid = (
-                sha256(
-                    key.public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)
+    def __init__(
+        self,
+        cose_keys: Optional[list] = None,
+        certificates: Optional[list] = None,
+    ):
+        self.trust_store_keys = {}
+
+        # Load keys from COSE_Key_Set (from /.well-known/scitt-keys)
+        if cose_keys:
+            for cose_key_dict in cose_keys:
+                cose_key = CoseKey.from_dict(cose_key_dict)  # type: ignore[var-annotated]
+                kid = cose_key.kid
+                if isinstance(kid, str):
+                    kid = kid.encode()
+                # Convert COSE_Key to cryptography public key
+                pub_key = self._cose_key_to_cryptography_key(cose_key)
+                self.trust_store_keys[kid] = pub_key
+
+        # Load keys from DER-encoded certificates (legacy format)
+        if certificates:
+            for cert_der in certificates:
+                cert = load_der_x509_certificate(cert_der, default_backend())
+                key = cert.public_key()
+                # Compute kid as hex-encoded SHA256 of public key DER
+                kid = (
+                    sha256(
+                        key.public_bytes(
+                            Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+                        )
+                    )
+                    .digest()
+                    .hex()
+                    .encode()
                 )
-                .digest()
-                .hex()
-                .encode()
-            )
-            self.trust_store_keys[kid] = key
+                self.trust_store_keys[kid] = key
+
+    @property
+    def services(self):
+        return {}
+
+    @staticmethod
+    def _cose_key_to_cryptography_key(cose_key: CoseKey) -> CertificatePublicKeyTypes:
+        """Convert a pycose CoseKey to a cryptography public key."""
+        from cryptography.hazmat.primitives.asymmetric.ec import (
+            SECP256R1,
+            SECP384R1,
+            SECP521R1,
+            EllipticCurvePublicNumbers,
+        )
+        from pycose.keys.curves import P256, P384, P521
+
+        # Map COSE curve to cryptography curve
+        curve_map = {
+            P256: SECP256R1(),
+            P384: SECP384R1(),
+            P521: SECP521R1(),
+        }
+
+        curve = curve_map.get(cose_key.crv)  # type: ignore[attr-defined]
+        if curve is None:
+            raise ValueError(f"Unsupported curve: {cose_key.crv}")  # type: ignore[attr-defined]
+
+        x_int = int.from_bytes(cose_key.x, "big")  # type: ignore[attr-defined]
+        y_int = int.from_bytes(cose_key.y, "big")  # type: ignore[attr-defined]
+        pub_numbers = EllipticCurvePublicNumbers(x_int, y_int, curve)
+        return pub_numbers.public_key(default_backend())
 
     @staticmethod
     def load(path: Path) -> "StaticTrustStore":
         """
-        Populate a static trust store from a directory. Each JSON file in the
-        directory corresponds to a trusted service identity.
+        Populate a static trust store from a directory containing:
+        - CBOR files with COSE_Key_Set (from /.well-known/scitt-keys)
+        - JSON files with service certificates (legacy format for backwards compatibility)
         """
-        store = {}
-        for path in path.glob("**/*.json"):
-            with open(path) as f:
-                data = json.load(f)
+        cose_keys = []
+        certificates = []
 
-            def _parse_service_param(param: dict):
-                service_id = param.get("serviceId")
-                if not isinstance(service_id, str) or not service_id:
-                    raise ValueError("serviceId must be a non-empty string")
+        # Load CBOR files (COSE_Key_Set from /.well-known/scitt-keys)
+        for cbor_path in path.glob("**/*.cbor"):
+            with open(cbor_path, "rb") as f:
+                data = cbor2.loads(f.read())
+            # COSE_Key_Set is an array of COSE_Key maps
+            if isinstance(data, list):
+                cose_keys.extend(data)
 
-                if service_id in store:
-                    raise ValueError(
-                        f"Duplicate service ID while reading trust store: {service_id}"
-                    )
+        # Load JSON files (legacy format with service certificates)
+        for json_path in path.glob("**/*.json"):
+            with open(json_path, encoding="utf-8") as json_file:
+                data = json.load(json_file)
 
-                store[service_id] = ServiceParameters.from_dict(param)
+            def _extract_certificates(param: dict):
+                cert_b64 = param.get("serviceCertificate")
+                if cert_b64:
+                    certificates.append(base64.b64decode(cert_b64))
 
-            # If the JSON file contains a list of parameters, parse each one
+            # If the JSON file contains a list of parameters, extract from each
             params = data.get("parameters")
             if params and isinstance(params, list):
                 for param in params:
-                    _parse_service_param(param)
-            # Otherwise, assume the JSON file contains a single set of parameters (as returned by /parameters)
+                    _extract_certificates(param)
+            # Otherwise, assume the JSON file contains a single set of parameters
             else:
-                _parse_service_param(data)
+                _extract_certificates(data)
 
-        return StaticTrustStore(store)
+        return StaticTrustStore(
+            cose_keys=cose_keys if cose_keys else None,
+            certificates=certificates if certificates else None,
+        )
 
     def get_key(self, receipt: bytes) -> CertificatePublicKeyTypes:
         parsed = Sign1Message.decode(receipt)

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -186,7 +186,7 @@ class StaticTrustStore(TrustStore):
 
                 store[service_id] = ServiceParameters.from_dict(param)
 
-            # If the JSON file contains a list of parameters, parse each one (as returned by /parameters/historic)
+            # If the JSON file contains a list of parameters, parse each one
             params = data.get("parameters")
             if params and isinstance(params, list):
                 for param in params:

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -16,13 +16,14 @@ import httpx
 from azure.confidentialledger.certificate import ConfidentialLedgerCertificateClient
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     PublicFormat,
+    load_pem_public_key,
 )
 from cryptography.x509 import load_der_x509_certificate
+from jwcrypto import jwk
 from pycose.headers import KID
 from pycose.keys.cosekey import CoseKey
 from pycose.messages import Sign1Message
@@ -240,12 +241,14 @@ class DynamicTrustStoreClient:
                 self.clients[issuer] = self._client()
         return self.clients[issuer]
 
-    def _assert_tls_in_cose_keys(self, tls_pem: str, cose_keys: list):
-        """Check that the TLS certificate public key is present in the COSE Key Set."""
+    def _assert_tls_in_jwks(self, tls_pem: str, jwks: dict):
+        """Parse JSON web keys to find the KID of the TLS certificate public key."""
         if not tls_pem:
             raise ValueError("TLS PEM certificate is required")
-        if not cose_keys:
-            raise ValueError("COSE Key Set is required")
+        if not jwks:
+            raise ValueError("JWKS is required")
+        if not "keys" in jwks:
+            raise ValueError("JWKS does not contain 'keys'")
         cert = x509.load_pem_x509_certificate(tls_pem.encode(), default_backend())
         cert_digest = (
             sha256(
@@ -256,36 +259,50 @@ class DynamicTrustStoreClient:
             .digest()
             .hex()
         )
-        # kid (label 2) in COSE Keys is SHA-256 of DER public key, hex encoded
-        key_kids = [key.get(2) for key in cose_keys if isinstance(key, dict)]
-        if cert_digest not in key_kids:
-            raise ValueError(
-                f"TLS public key digest {cert_digest} not found in COSE Key Set"
-            )
+        jwks_keys_digests = []
+        for jwks_key in jwks["keys"]:
+            try:
+                pem_b = jwk.JWK.from_json(json.dumps(jwks_key)).export_to_pem()
+                pub_key = load_pem_public_key(pem_b, default_backend())
+                pubhash = (
+                    sha256(
+                        pub_key.public_bytes(
+                            Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+                        )
+                    )
+                    .digest()
+                    .hex()
+                )
+                jwks_keys_digests.append(pubhash)
+            except Exception as e:
+                print(f"Warning: Could not parse JWKS key: {e}")
 
-    def get_scitt_keys(self, issuer: str) -> list:
+        if cert_digest not in jwks_keys_digests:
+            raise ValueError(f"TLS public key digest {cert_digest} not found in JWKS")
+
+    def get_jwks(self, issuer: str) -> dict:
         """
-        Retrieve the COSE Key Set from the issuer's SCITT keys endpoint.
+        Retrieve the JWKS from the issuer.
         """
         transparency_configuration = self.get_configuration(issuer)
         transparency_configuration.raise_for_status()
         config_response = cbor2.loads(transparency_configuration.content)
         jwks_uri = config_response["jwks_uri"]
-        keys_response = self._client_for_issuer(issuer).get(
-            jwks_uri, headers={"Accept": "application/cbor"}
+        jwks_response = self._client_for_issuer(issuer).get(
+            jwks_uri, headers={"Accept": "application/json"}
         )
-        keys_response.raise_for_status()
-        cose_keys = cbor2.loads(keys_response.content)
+        jwks_response.raise_for_status()
+        jwks = jwks_response.json()
 
-        # If issuer is a Confidential Ledger issuer, ensure the TLS certificate
-        # public key is in the COSE Key Set.
+        # If issuer is a Confidential Ledger issuer, ensure the TLS certificate public key is in the JWKS.
+        # This step adds an additional layer of trustworthiness of the public keys used for verification.
         if self.is_confidential_ledger_issuer(issuer):
             pem = self.confidential_ledger_certs.get(issuer)
             if pem is None:
                 raise ValueError(f"No TLS certificate for issuer {issuer}.")
-            self._assert_tls_in_cose_keys(pem, cose_keys)
+            self._assert_tls_in_jwks(pem, jwks)
 
-        return cose_keys
+        return jwks
 
     def get_configuration(self, issuer: str):
         """
@@ -331,12 +348,6 @@ class DynamicTrustStore(TrustStore):
     def services(self):
         raise NotImplementedError()
 
-    COSE_CRV_TO_EC = {
-        1: ec.SECP256R1(),
-        2: ec.SECP384R1(),
-        3: ec.SECP521R1(),
-    }
-
     def get_key(self, receipt: bytes) -> CertificatePublicKeyTypes:
         """
         Look up a service's public key based on the protected headers from a receipt.
@@ -345,27 +356,12 @@ class DynamicTrustStore(TrustStore):
         cwt = parsed.phdr[CWTClaims]
         key_id = parsed.phdr[KID]
         issuer = cwt[CWT_ISS]
-        cose_keys = self.client.get_scitt_keys(issuer)
-        # kid (label 2) is a text string; KID in receipt header is bytes
-        keys = {}
-        for k in cose_keys:
-            kid = k.get(2)
-            if isinstance(kid, str):
-                keys[kid.encode()] = k
-            elif isinstance(kid, bytes):
-                keys[kid] = k
+        jwk_set = self.client.get_jwks(issuer)
+        jwks = jwk_set["keys"]
+        keys = {key["kid"].encode(): key for key in jwks}
         if key_id not in keys:
-            raise ValueError(
-                f"Key ID {key_id} not found in COSE Key Set for issuer {issuer}"
-            )
-        cose_key = keys[key_id]
-        crv = cose_key.get(-1)
-        curve = self.COSE_CRV_TO_EC.get(crv)
-        if curve is None:
-            raise ValueError(f"Unsupported COSE curve: {crv}")
-        public_numbers = ec.EllipticCurvePublicNumbers(
-            x=int.from_bytes(cose_key[-2], "big"),
-            y=int.from_bytes(cose_key[-3], "big"),
-            curve=curve,
-        )
-        return public_numbers.public_key()
+            raise ValueError(f"Key ID {key_id} not found in JWKS for issuer {issuer}")
+        key = keys[key_id]
+        pem_key = jwk.JWK.from_json(json.dumps(key)).export_to_pem()
+        key = load_pem_public_key(pem_key, default_backend())
+        return key  # type: ignore

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -30,7 +30,7 @@ if [ "$DOCKER" = "1" ]; then
 
     # wait until the network is ready
     timeout=120
-    while ! curl -s -f -k $CCF_URL/parameters > /dev/null; do
+    while ! curl -s -f -k $CCF_URL/version > /dev/null; do
         echo "Waiting for service to be ready..."
         sleep 1
         timeout=$((timeout - 1))

--- a/run_fuzz_tests.sh
+++ b/run_fuzz_tests.sh
@@ -43,7 +43,7 @@ if [ "$DOCKER" = "1" ]; then
     CCF_NETWORK_PID=$!
     trap "kill $CCF_NETWORK_PID" EXIT
 
-    wait_for_service "$CCF_URL/parameters"
+    wait_for_service "$CCF_URL/version"
 else
     echo "Will use a built SCITT binary for testing..."
         
@@ -59,7 +59,7 @@ else
         --member-key workspace/member0_privk.pem \
         --member-cert workspace/member0_cert.pem;
     
-    wait_for_service "$CCF_URL/parameters"
+    wait_for_service "$CCF_URL/version"
 fi
 
 python3.12 -m test.fuzz_api_submissions

--- a/test/README.md
+++ b/test/README.md
@@ -33,8 +33,9 @@ the service would have a `client` parameter, which is can use inside the test
 body.
 
 ```python
-def test_parameters(client: Client):
-  assert client.get_parameters()["treeAlgorithm"] == "CCF"
+def test_scitt_keys(client: Client):
+  keys = client.get_scitt_keys()
+  assert len(keys) > 0  # At least one service key
 ```
 
 The name of this parameter must match of the name of the fixtures. See below

--- a/test/infra/fixtures.py
+++ b/test/infra/fixtures.py
@@ -103,7 +103,7 @@ class ManagedCCHostFixtures:
                 )
                 client.governance.propose(proposal, must_pass=True)
                 client.get(
-                    "/parameters",
+                    "/version",
                     retry_on=[(HTTPStatus.NOT_FOUND, "FrontendNotOpen")],
                 )
 
@@ -301,5 +301,5 @@ def trust_store(client) -> StaticTrustStore:
     """
     Get the static trust store associated with the service.
     """
-    params = client.get_parameters()
-    return StaticTrustStore({params.service_id: params})
+    cose_keys = client.get_scitt_keys()
+    return StaticTrustStore(cose_keys=cose_keys)

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-import json
 from hashlib import sha256
 
 import cbor2
@@ -8,35 +7,31 @@ import pytest
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from jwcrypto import jwk
 
 from pyscitt import crypto
-from pyscitt.client import Client
+from pyscitt.client import Client, ServiceError
 from pyscitt.verify import (
     DynamicTrustStore,
     DynamicTrustStoreClient,
     verify_transparent_statement,
-)
+)       
 
 from .infra.assertions import service_error
 
 
-def pem_cert_to_ccf_jwk(cert_pem: str) -> dict:
+CURVE_TO_COSE_CRV = {
+    "secp256r1": 1,  # P-256
+    "secp384r1": 2,  # P-384
+    "secp521r1": 3,  # P-521
+}
+
+
+def pem_cert_to_ccf_cose_key(cert_pem: str) -> dict:
     cert = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
-    pkey_pem = cert.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    key = jwk.JWK.from_pem(pkey_pem)
-    jwk_from_cert = json.loads(key.export(private_key=False))
-    # jwcrypto sets the kid to the JWK thumbprint, which is not what CCF does
-    # because it would not work in CBOR/COSE contexts. Instead, CCF uses the
-    # SHA-256 hash of the DER-encoded public key, encoded as hex.
-    # The kid is to be used as an opaque handler by clients, but we want this
-    # test to be precise.
+    pub_key = cert.public_key()
     ccf_kid = (
         sha256(
-            cert.public_key().public_bytes(
+            pub_key.public_bytes(
                 serialization.Encoding.DER,
                 serialization.PublicFormat.SubjectPublicKeyInfo,
             )
@@ -44,21 +39,50 @@ def pem_cert_to_ccf_jwk(cert_pem: str) -> dict:
         .digest()
         .hex()
     )
-    jwk_from_cert["kid"] = ccf_kid
-    return jwk_from_cert
+    numbers = pub_key.public_numbers()
+    curve = pub_key.curve
+    crv = CURVE_TO_COSE_CRV[curve.name]
+    key_size = (curve.key_size + 7) // 8
+    return {
+        1: 2,  # kty: EC2
+        2: ccf_kid,  # kid
+        -1: crv,  # crv
+        -2: numbers.x.to_bytes(key_size, "big"),  # x
+        -3: numbers.y.to_bytes(key_size, "big"),  # y
+    }
 
 
-def test_jwks(client: Client):
+def test_scitt_keys(client: Client):
     """
-    Test that the JWKS endpoint returns the expected keys.
+    Test that the SCITT keys endpoint returns the expected keys.
     """
 
-    jwks = client.get_jwks()
-    assert len(jwks["keys"]) == 1
+    keys = client.get_scitt_keys()
+    assert len(keys) == 1
 
     cert_pem = client.get("/node/network").json()["service_certificate"]
-    svc_jwk = pem_cert_to_ccf_jwk(cert_pem)
-    assert svc_jwk == jwks["keys"][0]
+    expected = pem_cert_to_ccf_cose_key(cert_pem)
+    assert expected == keys[0]
+
+
+def test_scitt_key_by_kid(client: Client):
+    """
+    Test that a single key can be retrieved by kid.
+    """
+    keys = client.get_scitt_keys()
+    assert len(keys) == 1
+    kid = keys[0][2]  # label 2 is kid
+    key_set = client.get_scitt_key(kid)
+    assert len(key_set) == 1
+    assert key_set[0] == keys[0]
+
+def test_scitt_key_by_kid_not_found(client: Client):
+    """
+    Test that requesting a non-existent kid returns 404.
+    """
+    with pytest.raises(ServiceError) as exc_info:
+        client.get("/.well-known/scitt-keys/nonexistent-kid")
+    assert exc_info.value.code == "KeyNotFound"
 
 
 @pytest.mark.parametrize(
@@ -120,14 +144,14 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
 
     old_network = client.get("/node/network").json()
     assert old_network["recovery_count"] == 0
-    old_jwk = pem_cert_to_ccf_jwk(old_network["service_certificate"])
+    old_cose_key = pem_cert_to_ccf_cose_key(old_network["service_certificate"])
 
     restart_service()
 
     new_network = client.get("/node/network").json()
     assert new_network["recovery_count"] == 1
     assert new_network["service_certificate"] != old_network["service_certificate"]
-    new_jwk = pem_cert_to_ccf_jwk(new_network["service_certificate"])
+    new_cose_key = pem_cert_to_ccf_cose_key(new_network["service_certificate"])
 
     # Check that the service is still operating correctly
     second_signed_statement = crypto.sign_json_statement(
@@ -137,10 +161,10 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
         second_signed_statement
     ).response_bytes
 
-    jwks = client.get_jwks()
-    assert len(jwks["keys"]) == 2
-    assert old_jwk in jwks["keys"]
-    assert new_jwk in jwks["keys"]
+    keys = client.get_scitt_keys()
+    assert len(keys) == 2
+    assert old_cose_key in keys
+    assert new_cose_key in keys
 
     dynamic_trust_store = DynamicTrustStore(
         client=DynamicTrustStoreClient(forced_httpclient=client.session)
@@ -156,7 +180,7 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
 @pytest.mark.isolated_test
 def test_transparency_configuration(client, cchost):
     issuer = f"127.0.0.1:{cchost.rpc_port}"
-    reference = {"issuer": issuer, "jwks_uri": f"https://{issuer}/jwks"}
+    reference = {"issuer": issuer, "jwks_uri": f"https://{issuer}/.well-known/scitt-keys"}
     config = client.get("/.well-known/transparency-configuration")
     assert config.status_code == 200
     assert config.headers["Content-Type"] == "application/cbor"

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+import json
 from hashlib import sha256
 
 import cbor2
@@ -8,6 +9,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
+from jwcrypto import jwk
 
 from pyscitt import crypto
 from pyscitt.client import Client, ServiceError
@@ -53,6 +55,46 @@ def pem_cert_to_ccf_cose_key(cert_pem: str) -> dict:
     }
 
 
+def pem_cert_to_ccf_jwk(cert_pem: str) -> dict:
+    cert = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
+    pkey_pem = cert.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    key = jwk.JWK.from_pem(pkey_pem)
+    jwk_from_cert = json.loads(key.export(private_key=False))
+    # jwcrypto sets the kid to the JWK thumbprint, which is not what CCF does
+    # because it would not work in CBOR/COSE contexts. Instead, CCF uses the
+    # SHA-256 hash of the DER-encoded public key, encoded as hex.
+    # The kid is to be used as an opaque handler by clients, but we want this
+    # test to be precise.
+    ccf_kid = (
+        sha256(
+            cert.public_key().public_bytes(
+                serialization.Encoding.DER,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        )
+        .digest()
+        .hex()
+    )
+    jwk_from_cert["kid"] = ccf_kid
+    return jwk_from_cert
+
+
+def test_jwks(client: Client):
+    """
+    Test that the JWKS endpoint returns the expected keys.
+    """
+
+    jwks = client.get_jwks()
+    assert len(jwks["keys"]) == 1
+
+    cert_pem = client.get("/node/network").json()["service_certificate"]
+    svc_jwk = pem_cert_to_ccf_jwk(cert_pem)
+    assert svc_jwk == jwks["keys"][0]
+
+
 def test_scitt_keys(client: Client):
     """
     Test that the SCITT keys endpoint returns the expected keys.
@@ -73,9 +115,10 @@ def test_scitt_key_by_kid(client: Client):
     keys = client.get_scitt_keys()
     assert len(keys) == 1
     kid = keys[0][2]  # label 2 is kid
-    key_set = client.get_scitt_key(kid)
-    assert len(key_set) == 1
-    assert key_set[0] == keys[0]
+    # Returns a single COSE Key (map), not a COSE Key Set (array)
+    single_key = client.get_scitt_key(kid)
+    assert isinstance(single_key, dict)
+    assert single_key == keys[0]
 
 
 def test_scitt_key_by_kid_not_found(client: Client):
@@ -84,7 +127,7 @@ def test_scitt_key_by_kid_not_found(client: Client):
     """
     with pytest.raises(ServiceError) as exc_info:
         client.get("/.well-known/scitt-keys/nonexistent-kid")
-    assert exc_info.value.code == "KeyNotFound"
+    assert exc_info.value.code == "No such key"
 
 
 @pytest.mark.parametrize(
@@ -146,6 +189,7 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
 
     old_network = client.get("/node/network").json()
     assert old_network["recovery_count"] == 0
+    old_jwk = pem_cert_to_ccf_jwk(old_network["service_certificate"])
     old_cose_key = pem_cert_to_ccf_cose_key(old_network["service_certificate"])
 
     restart_service()
@@ -153,6 +197,7 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
     new_network = client.get("/node/network").json()
     assert new_network["recovery_count"] == 1
     assert new_network["service_certificate"] != old_network["service_certificate"]
+    new_jwk = pem_cert_to_ccf_jwk(new_network["service_certificate"])
     new_cose_key = pem_cert_to_ccf_cose_key(new_network["service_certificate"])
 
     # Check that the service is still operating correctly
@@ -162,6 +207,11 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
     second_transparent_statement = client.submit_signed_statement_and_wait(
         second_signed_statement
     ).response_bytes
+
+    jwks = client.get_jwks()
+    assert len(jwks["keys"]) == 2
+    assert old_jwk in jwks["keys"]
+    assert new_jwk in jwks["keys"]
 
     keys = client.get_scitt_keys()
     assert len(keys) == 2
@@ -182,10 +232,7 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
 @pytest.mark.isolated_test
 def test_transparency_configuration(client, cchost):
     issuer = f"127.0.0.1:{cchost.rpc_port}"
-    reference = {
-        "issuer": issuer,
-        "jwks_uri": f"https://{issuer}/.well-known/scitt-keys",
-    }
+    reference = {"issuer": issuer, "jwks_uri": f"https://{issuer}/jwks"}
     config = client.get("/.well-known/transparency-configuration")
     assert config.status_code == 200
     assert config.headers["Content-Type"] == "application/cbor"

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -7,6 +7,7 @@ import pytest
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePublicKey
 
 from pyscitt import crypto
 from pyscitt.client import Client, ServiceError
@@ -14,10 +15,9 @@ from pyscitt.verify import (
     DynamicTrustStore,
     DynamicTrustStoreClient,
     verify_transparent_statement,
-)       
+)
 
 from .infra.assertions import service_error
-
 
 CURVE_TO_COSE_CRV = {
     "secp256r1": 1,  # P-256
@@ -29,6 +29,7 @@ CURVE_TO_COSE_CRV = {
 def pem_cert_to_ccf_cose_key(cert_pem: str) -> dict:
     cert = x509.load_pem_x509_certificate(cert_pem.encode(), default_backend())
     pub_key = cert.public_key()
+    assert isinstance(pub_key, EllipticCurvePublicKey)
     ccf_kid = (
         sha256(
             pub_key.public_bytes(
@@ -75,6 +76,7 @@ def test_scitt_key_by_kid(client: Client):
     key_set = client.get_scitt_key(kid)
     assert len(key_set) == 1
     assert key_set[0] == keys[0]
+
 
 def test_scitt_key_by_kid_not_found(client: Client):
     """
@@ -180,7 +182,10 @@ def test_recovery(client, cert_authority, restart_service, configure_service):
 @pytest.mark.isolated_test
 def test_transparency_configuration(client, cchost):
     issuer = f"127.0.0.1:{cchost.rpc_port}"
-    reference = {"issuer": issuer, "jwks_uri": f"https://{issuer}/.well-known/scitt-keys"}
+    reference = {
+        "issuer": issuer,
+        "jwks_uri": f"https://{issuer}/.well-known/scitt-keys",
+    }
     config = client.get("/.well-known/transparency-configuration")
     assert config.status_code == 200
     assert config.headers["Content-Type"] == "application/cbor"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -176,16 +176,17 @@ def test_submit_and_validate(
 
     (tmp_path / "transparent_statement.cose").write_bytes(statement)
 
-    params_resp = client.get("/parameters")
-    params_resp.raise_for_status()
-    (tmp_path / "params").mkdir(parents=True, exist_ok=True)
-    (tmp_path / "params" / "scitt.json").write_bytes(params_resp.content)
+    # Fetch service keys from /.well-known/scitt-keys (COSE_Key_Set in CBOR)
+    keys_resp = client.get("/.well-known/scitt-keys")
+    keys_resp.raise_for_status()
+    (tmp_path / "trust_store").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "trust_store" / "scitt-keys.cbor").write_bytes(keys_resp.content)
 
     run(
         "validate",
         tmp_path / "transparent_statement.cose",
         "--service-trust-store",
-        (tmp_path / "params"),
+        (tmp_path / "trust_store"),
     )
 
     run(

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -42,9 +42,7 @@ class TestDynamicTrustStore:
 
     @patch("pyscitt.verify.ec")
     @patch("pyscitt.verify.Sign1Message")
-    def test_get_key_retrieves_from_cose_keys(
-        self, mock_sign1, mock_ec
-    ):
+    def test_get_key_retrieves_from_cose_keys(self, mock_sign1, mock_ec):
         # Setup mocks
         mock_receipt = b"test_receipt"
         mock_parsed = Mock()
@@ -226,9 +224,7 @@ class TestDynamicTrustStoreClient:
         mock_digest.digest.return_value.hex.return_value = "tls_cert_digest"
         mock_sha256.return_value = mock_digest
 
-        cose_keys = [
-            {1: 2, 2: "other_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
-        ]
+        cose_keys = [{1: 2, 2: "other_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}]
         client = DynamicTrustStoreClient()
 
         with pytest.raises(

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -2,8 +2,9 @@
 # Licensed under the MIT License.
 
 from datetime import datetime, timedelta
+from io import BytesIO
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, DEFAULT, MagicMock, Mock, patch
 
 import cbor2
 import httpx
@@ -40,9 +41,12 @@ class TestDynamicTrustStore:
         with pytest.raises(NotImplementedError):
             _ = trust_store.services
 
-    @patch("pyscitt.verify.ec")
+    @patch("pyscitt.verify.jwk.JWK.from_json")
     @patch("pyscitt.verify.Sign1Message")
-    def test_get_key_retrieves_from_cose_keys(self, mock_sign1, mock_ec):
+    @patch("pyscitt.verify.load_pem_public_key")
+    def test_get_key_retrieves_from_jwks(
+        self, mock_load_key, mock_sign1, mock_jwk_from_json
+    ):
         # Setup mocks
         mock_receipt = b"test_receipt"
         mock_parsed = Mock()
@@ -50,15 +54,15 @@ class TestDynamicTrustStore:
         mock_kid = b"test_kid"
         mock_parsed.phdr = {CWTClaims: mock_cwt, KID: mock_kid}
         mock_sign1.decode.return_value = mock_parsed
-        mock_public_key = Mock()
-        mock_public_numbers = Mock()
-        mock_public_numbers.public_key.return_value = mock_public_key
-        mock_ec.EllipticCurvePublicNumbers.return_value = mock_public_numbers
-        mock_ec.SECP256R1.return_value = "mock_curve"
+        mock_matched_jwk = MagicMock()
+        mock_matched_jwk.export_to_pem.return_value = b"mock_pem"
+        mock_jwk_from_json.return_value = mock_matched_jwk
+        mock_return_key = Mock()
+        mock_load_key.return_value = mock_return_key
         mock_client = Mock()
-        mock_client.get_scitt_keys.return_value = [
-            {1: 2, 2: "test_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
-        ]
+        mock_client.get_jwks.return_value = {
+            "keys": [{"kid": "test_kid", "kty": "RSA"}]
+        }
 
         # Create instance and call method
         trust_store = DynamicTrustStore(mock_client)
@@ -66,9 +70,12 @@ class TestDynamicTrustStore:
 
         # Assertions
         mock_sign1.decode.assert_called_once_with(mock_receipt)
-        mock_client.get_scitt_keys.assert_called_once_with("example.com")
-        mock_ec.EllipticCurvePublicNumbers.assert_called_once()
-        assert result == mock_public_key
+        mock_client.get_jwks.assert_called_once_with("example.com")
+        mock_load_key.assert_called_once_with(
+            b"mock_pem",
+            pytest.importorskip("cryptography.hazmat.backends").default_backend(),
+        )
+        assert result == mock_return_key
 
 
 class TestDynamicTrustStoreClient:
@@ -143,39 +150,38 @@ class TestDynamicTrustStoreClient:
             client.get_configuration("")
 
     @patch("pyscitt.verify.DynamicTrustStoreClient.get_confidential_ledger_tls_pem")
-    @patch("pyscitt.verify.DynamicTrustStoreClient._assert_tls_in_cose_keys")
-    def test_get_scitt_keys_validates_tls_cert(
-        self, mock_assert_tls_in_cose_keys, mock_get_confidential_ledger_tls_pem
+    @patch("pyscitt.verify.DynamicTrustStoreClient._assert_tls_in_jwks")
+    def test_get_jwks_validates_tls_cert(
+        self, mock_assert_tls_in_jwks, mock_get_confidential_ledger_tls_pem
     ):
         # Setup mocks
         mock_get_confidential_ledger_tls_pem.return_value = "mock_pem_cert"
         mock_httpx_client = Mock()
-        test_cose_keys = [
-            {1: 2, 2: "test_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
-        ]
 
         def get_side_effect(*args, **kwargs):
             if (
                 args[0]
                 == "https://foobar.confidential-ledger.azure.com/.well-known/transparency-configuration"
             ):
+                with BytesIO() as fp:
+                    cbor2.CBOREncoder(fp).encode(
+                        {
+                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/jwks"
+                        }
+                    )
+
                 return httpx.Response(
                     200,
                     content=cbor2.dumps(
                         {
-                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/.well-known/scitt-keys"
+                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/jwks"
                         }
                     ),
                     request=httpx.Request("GET", args[0]),
                 )
-            if (
-                args[0]
-                == "https://foobar.confidential-ledger.azure.com/.well-known/scitt-keys"
-            ):
+            if args[0] == "https://foobar.confidential-ledger.azure.com/jwks":
                 return httpx.Response(
-                    200,
-                    content=cbor2.dumps(test_cose_keys),
-                    request=httpx.Request("GET", args[0]),
+                    200, json={"keys": ["test"]}, request=httpx.Request("GET", args[0])
                 )
 
         mock_httpx_client.get = Mock(side_effect=get_side_effect)
@@ -184,82 +190,139 @@ class TestDynamicTrustStoreClient:
         trust_store_client = DynamicTrustStoreClient(
             forced_httpclient=mock_httpx_client
         )
-        result = trust_store_client.get_scitt_keys(
-            "foobar.confidential-ledger.azure.com"
-        )
+        result = trust_store_client.get_jwks("foobar.confidential-ledger.azure.com")
 
         # Assertions
-        mock_assert_tls_in_cose_keys.assert_called_once_with(
-            "mock_pem_cert", test_cose_keys
+        mock_assert_tls_in_jwks.assert_called_once_with(
+            "mock_pem_cert", {"keys": ["test"]}
         )
-        assert result == test_cose_keys
+        assert result == {"keys": ["test"]}
 
-    def test_assert_tls_in_cose_keys_raises_for_empty_tls_pem(self):
+    def test_assert_tls_in_jwks_raises_for_empty_tls_pem(self):
         client = DynamicTrustStoreClient()
         with pytest.raises(ValueError, match="TLS PEM certificate is required"):
-            client._assert_tls_in_cose_keys("", [])
+            client._assert_tls_in_jwks("", {"keys": []})
 
-    def test_assert_tls_in_cose_keys_raises_for_none_cose_keys(self):
+    def test_assert_tls_in_jwks_raises_for_none_jwks(self):
         client = DynamicTrustStoreClient()
-        with pytest.raises(ValueError, match="COSE Key Set is required"):
-            client._assert_tls_in_cose_keys("certificate", None)
+        with pytest.raises(ValueError, match="JWKS is required"):
+            client._assert_tls_in_jwks("certificate", None)
 
-    def test_assert_tls_in_cose_keys_raises_for_empty_cose_keys(self):
+    def test_assert_tls_in_jwks_raises_for_missing_keys(self):
         client = DynamicTrustStoreClient()
-        with pytest.raises(ValueError, match="COSE Key Set is required"):
-            client._assert_tls_in_cose_keys("certificate", [])
+        with pytest.raises(ValueError, match="JWKS does not contain 'keys'"):
+            client._assert_tls_in_jwks("certificate", {"other_key": []})
 
+    @patch("pyscitt.verify.load_pem_public_key")
     @patch("pyscitt.verify.x509.load_pem_x509_certificate")
     @patch("pyscitt.verify.sha256")
-    def test_assert_tls_in_cose_keys_raises_when_key_not_found(
-        self, mock_sha256, mock_load_cert
+    @patch("pyscitt.verify.jwk.JWK.from_json")
+    def test_assert_tls_in_jwks_raises_when_key_not_found(
+        self, mock_jwk_from_json, mock_sha256, mock_load_cert, mock_load_pub_key
     ):
+        # Mock certificate loading and hashing
         mock_cert = Mock()
         mock_public_key = Mock()
         mock_cert.public_key.return_value = mock_public_key
         mock_public_key.public_bytes.return_value = b"mock_public_bytes"
         mock_load_cert.return_value = mock_cert
 
-        mock_digest = Mock()
-        mock_digest.digest.return_value.hex.return_value = "tls_cert_digest"
-        mock_sha256.return_value = mock_digest
+        # Mock digests
+        mock_tls_digest = Mock()
+        mock_tls_digest.digest.return_value.hex.return_value = "tls_cert_digest"
+        mock_sha256.side_effect = lambda x: (
+            mock_tls_digest if x == b"mock_public_bytes" else DEFAULT
+        )
 
-        cose_keys = [{1: 2, 2: "other_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}]
+        # JWKS key setup
+        mock_jwks_key = Mock()
+        mock_jwks_key.export_to_pem.return_value = b"jwks_pem"
+        mock_jwk_from_json.return_value = mock_jwks_key
+
+        # Mock JWK pub key loading
+        mock_jwks_public_key = Mock()
+        mock_jwks_public_key.public_bytes.return_value = b"jwks_public_bytes"
+        mock_load_pub_key.return_value = mock_jwks_public_key
+
+        jwks = {"keys": [{"kid": "test_kid"}]}
         client = DynamicTrustStoreClient()
 
         with pytest.raises(
-            ValueError,
-            match="TLS public key digest tls_cert_digest not found in COSE Key Set",
+            ValueError, match="TLS public key digest tls_cert_digest not found in JWKS"
         ):
-            client._assert_tls_in_cose_keys("certificate", cose_keys)
+            client._assert_tls_in_jwks("certificate", jwks)
 
+        # Verify all expected calls
         mock_load_cert.assert_called_once()
-        mock_sha256.assert_called_once()
+        mock_load_pub_key.assert_called_once()
+        mock_sha256.assert_called()
+        assert len(mock_sha256.call_args_list) == 2
+        mock_jwk_from_json.assert_called_once_with('{"kid": "test_kid"}')
 
+    @patch("pyscitt.verify.load_pem_public_key")
     @patch("pyscitt.verify.x509.load_pem_x509_certificate")
     @patch("pyscitt.verify.sha256")
-    def test_assert_tls_in_cose_keys_succeeds_when_key_found(
-        self, mock_sha256, mock_load_cert
+    @patch("pyscitt.verify.jwk.JWK.from_json")
+    def test_assert_tls_in_jwks_succeeds_when_key_found(
+        self, mock_jwk_from_json, mock_sha256, mock_load_cert, mock_load_pub_key
     ):
+        # Mock certificate loading and hashing
         mock_cert = Mock()
         mock_public_key = Mock()
         mock_cert.public_key.return_value = mock_public_key
         mock_public_key.public_bytes.return_value = b"mock_public_bytes"
         mock_load_cert.return_value = mock_cert
 
+        # Mock digests
         mock_digest = Mock()
-        mock_digest.digest.return_value.hex.return_value = "matching_digest"
+        mock_digest.digest.return_value.hex.return_value = "same_digest"
         mock_sha256.return_value = mock_digest
 
-        cose_keys = [
-            {1: 2, 2: "matching_digest", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
-        ]
-        client = DynamicTrustStoreClient()
-        # Should not raise
-        client._assert_tls_in_cose_keys("certificate", cose_keys)
+        # JWKS key setup
+        mock_jwks_key = Mock()
+        mock_jwks_key.export_to_pem.return_value = b"jwks_pem"
+        mock_jwk_from_json.return_value = mock_jwks_key
 
+        # Mock JWK pub key loading
+        mock_jwks_public_key = Mock()
+        mock_jwks_public_key.public_bytes.return_value = b"jwks_public_bytes"
+        mock_load_pub_key.return_value = mock_jwks_public_key
+
+        client = DynamicTrustStoreClient()
+        client._assert_tls_in_jwks("certificate", {"keys": [{"kid": "test_kid"}]})
+
+        # Verify all expected calls
         mock_load_cert.assert_called_once()
-        mock_sha256.assert_called_once()
+        mock_load_pub_key.assert_called_once()
+        mock_sha256.assert_called()
+        assert len(mock_sha256.call_args_list) == 2
+        mock_jwk_from_json.assert_called_once_with('{"kid": "test_kid"}')
+
+    @patch("pyscitt.verify.x509.load_pem_x509_certificate")
+    @patch("pyscitt.verify.jwk.JWK.from_json")
+    @patch("builtins.print")
+    def test_assert_tls_in_jwks_handles_invalid_jwks_key(
+        self, mock_print, mock_jwk_from_json, mock_load_cert
+    ):
+        # Mock certificate loading for TLS cert
+        mock_cert = Mock()
+        mock_public_key = Mock()
+        mock_cert.public_key.return_value = mock_public_key
+        mock_public_key.public_bytes.return_value = b"mock_public_bytes"
+        mock_load_cert.return_value = mock_cert
+
+        # Mock JWK parsing to raise exception
+        mock_jwk_from_json.side_effect = Exception("Invalid JWK")
+
+        client = DynamicTrustStoreClient()
+        # Should raise because no valid keys were found
+        with pytest.raises(
+            ValueError, match="TLS public key digest .* not found in JWKS"
+        ):
+            client._assert_tls_in_jwks("certificate", {"keys": [{"kid": "test_kid"}]})
+
+        # Verify warning was printed
+        mock_print.assert_called_with("Warning: Could not parse JWKS key: Invalid JWK")
 
 
 class TestVerifyTransparentStatement:

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -2,9 +2,8 @@
 # Licensed under the MIT License.
 
 from datetime import datetime, timedelta
-from io import BytesIO
 from pathlib import Path
-from unittest.mock import ANY, DEFAULT, MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import cbor2
 import httpx
@@ -41,11 +40,10 @@ class TestDynamicTrustStore:
         with pytest.raises(NotImplementedError):
             _ = trust_store.services
 
-    @patch("pyscitt.verify.jwk.JWK.from_json")
+    @patch("pyscitt.verify.ec")
     @patch("pyscitt.verify.Sign1Message")
-    @patch("pyscitt.verify.load_pem_public_key")
-    def test_get_key_retrieves_from_jwks(
-        self, mock_load_key, mock_sign1, mock_jwk_from_json
+    def test_get_key_retrieves_from_cose_keys(
+        self, mock_sign1, mock_ec
     ):
         # Setup mocks
         mock_receipt = b"test_receipt"
@@ -54,15 +52,15 @@ class TestDynamicTrustStore:
         mock_kid = b"test_kid"
         mock_parsed.phdr = {CWTClaims: mock_cwt, KID: mock_kid}
         mock_sign1.decode.return_value = mock_parsed
-        mock_matched_jwk = MagicMock()
-        mock_matched_jwk.export_to_pem.return_value = b"mock_pem"
-        mock_jwk_from_json.return_value = mock_matched_jwk
-        mock_return_key = Mock()
-        mock_load_key.return_value = mock_return_key
+        mock_public_key = Mock()
+        mock_public_numbers = Mock()
+        mock_public_numbers.public_key.return_value = mock_public_key
+        mock_ec.EllipticCurvePublicNumbers.return_value = mock_public_numbers
+        mock_ec.SECP256R1.return_value = "mock_curve"
         mock_client = Mock()
-        mock_client.get_jwks.return_value = {
-            "keys": [{"kid": "test_kid", "kty": "RSA"}]
-        }
+        mock_client.get_scitt_keys.return_value = [
+            {1: 2, 2: "test_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
+        ]
 
         # Create instance and call method
         trust_store = DynamicTrustStore(mock_client)
@@ -70,12 +68,9 @@ class TestDynamicTrustStore:
 
         # Assertions
         mock_sign1.decode.assert_called_once_with(mock_receipt)
-        mock_client.get_jwks.assert_called_once_with("example.com")
-        mock_load_key.assert_called_once_with(
-            b"mock_pem",
-            pytest.importorskip("cryptography.hazmat.backends").default_backend(),
-        )
-        assert result == mock_return_key
+        mock_client.get_scitt_keys.assert_called_once_with("example.com")
+        mock_ec.EllipticCurvePublicNumbers.assert_called_once()
+        assert result == mock_public_key
 
 
 class TestDynamicTrustStoreClient:
@@ -150,38 +145,39 @@ class TestDynamicTrustStoreClient:
             client.get_configuration("")
 
     @patch("pyscitt.verify.DynamicTrustStoreClient.get_confidential_ledger_tls_pem")
-    @patch("pyscitt.verify.DynamicTrustStoreClient._assert_tls_in_jwks")
-    def test_get_jwks_validates_tls_cert(
-        self, mock_assert_tls_in_jwks, mock_get_confidential_ledger_tls_pem
+    @patch("pyscitt.verify.DynamicTrustStoreClient._assert_tls_in_cose_keys")
+    def test_get_scitt_keys_validates_tls_cert(
+        self, mock_assert_tls_in_cose_keys, mock_get_confidential_ledger_tls_pem
     ):
         # Setup mocks
         mock_get_confidential_ledger_tls_pem.return_value = "mock_pem_cert"
         mock_httpx_client = Mock()
+        test_cose_keys = [
+            {1: 2, 2: "test_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
+        ]
 
         def get_side_effect(*args, **kwargs):
             if (
                 args[0]
                 == "https://foobar.confidential-ledger.azure.com/.well-known/transparency-configuration"
             ):
-                with BytesIO() as fp:
-                    cbor2.CBOREncoder(fp).encode(
-                        {
-                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/jwks"
-                        }
-                    )
-
                 return httpx.Response(
                     200,
                     content=cbor2.dumps(
                         {
-                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/jwks"
+                            "jwks_uri": "https://foobar.confidential-ledger.azure.com/.well-known/scitt-keys"
                         }
                     ),
                     request=httpx.Request("GET", args[0]),
                 )
-            if args[0] == "https://foobar.confidential-ledger.azure.com/jwks":
+            if (
+                args[0]
+                == "https://foobar.confidential-ledger.azure.com/.well-known/scitt-keys"
+            ):
                 return httpx.Response(
-                    200, json={"keys": ["test"]}, request=httpx.Request("GET", args[0])
+                    200,
+                    content=cbor2.dumps(test_cose_keys),
+                    request=httpx.Request("GET", args[0]),
                 )
 
         mock_httpx_client.get = Mock(side_effect=get_side_effect)
@@ -190,139 +186,84 @@ class TestDynamicTrustStoreClient:
         trust_store_client = DynamicTrustStoreClient(
             forced_httpclient=mock_httpx_client
         )
-        result = trust_store_client.get_jwks("foobar.confidential-ledger.azure.com")
+        result = trust_store_client.get_scitt_keys(
+            "foobar.confidential-ledger.azure.com"
+        )
 
         # Assertions
-        mock_assert_tls_in_jwks.assert_called_once_with(
-            "mock_pem_cert", {"keys": ["test"]}
+        mock_assert_tls_in_cose_keys.assert_called_once_with(
+            "mock_pem_cert", test_cose_keys
         )
-        assert result == {"keys": ["test"]}
+        assert result == test_cose_keys
 
-    def test_assert_tls_in_jwks_raises_for_empty_tls_pem(self):
+    def test_assert_tls_in_cose_keys_raises_for_empty_tls_pem(self):
         client = DynamicTrustStoreClient()
         with pytest.raises(ValueError, match="TLS PEM certificate is required"):
-            client._assert_tls_in_jwks("", {"keys": []})
+            client._assert_tls_in_cose_keys("", [])
 
-    def test_assert_tls_in_jwks_raises_for_none_jwks(self):
+    def test_assert_tls_in_cose_keys_raises_for_none_cose_keys(self):
         client = DynamicTrustStoreClient()
-        with pytest.raises(ValueError, match="JWKS is required"):
-            client._assert_tls_in_jwks("certificate", None)
+        with pytest.raises(ValueError, match="COSE Key Set is required"):
+            client._assert_tls_in_cose_keys("certificate", None)
 
-    def test_assert_tls_in_jwks_raises_for_missing_keys(self):
+    def test_assert_tls_in_cose_keys_raises_for_empty_cose_keys(self):
         client = DynamicTrustStoreClient()
-        with pytest.raises(ValueError, match="JWKS does not contain 'keys'"):
-            client._assert_tls_in_jwks("certificate", {"other_key": []})
+        with pytest.raises(ValueError, match="COSE Key Set is required"):
+            client._assert_tls_in_cose_keys("certificate", [])
 
-    @patch("pyscitt.verify.load_pem_public_key")
     @patch("pyscitt.verify.x509.load_pem_x509_certificate")
     @patch("pyscitt.verify.sha256")
-    @patch("pyscitt.verify.jwk.JWK.from_json")
-    def test_assert_tls_in_jwks_raises_when_key_not_found(
-        self, mock_jwk_from_json, mock_sha256, mock_load_cert, mock_load_pub_key
+    def test_assert_tls_in_cose_keys_raises_when_key_not_found(
+        self, mock_sha256, mock_load_cert
     ):
-        # Mock certificate loading and hashing
         mock_cert = Mock()
         mock_public_key = Mock()
         mock_cert.public_key.return_value = mock_public_key
         mock_public_key.public_bytes.return_value = b"mock_public_bytes"
         mock_load_cert.return_value = mock_cert
 
-        # Mock digests
-        mock_tls_digest = Mock()
-        mock_tls_digest.digest.return_value.hex.return_value = "tls_cert_digest"
-        mock_sha256.side_effect = lambda x: (
-            mock_tls_digest if x == b"mock_public_bytes" else DEFAULT
-        )
-
-        # JWKS key setup
-        mock_jwks_key = Mock()
-        mock_jwks_key.export_to_pem.return_value = b"jwks_pem"
-        mock_jwk_from_json.return_value = mock_jwks_key
-
-        # Mock JWK pub key loading
-        mock_jwks_public_key = Mock()
-        mock_jwks_public_key.public_bytes.return_value = b"jwks_public_bytes"
-        mock_load_pub_key.return_value = mock_jwks_public_key
-
-        jwks = {"keys": [{"kid": "test_kid"}]}
-        client = DynamicTrustStoreClient()
-
-        with pytest.raises(
-            ValueError, match="TLS public key digest tls_cert_digest not found in JWKS"
-        ):
-            client._assert_tls_in_jwks("certificate", jwks)
-
-        # Verify all expected calls
-        mock_load_cert.assert_called_once()
-        mock_load_pub_key.assert_called_once()
-        mock_sha256.assert_called()
-        assert len(mock_sha256.call_args_list) == 2
-        mock_jwk_from_json.assert_called_once_with('{"kid": "test_kid"}')
-
-    @patch("pyscitt.verify.load_pem_public_key")
-    @patch("pyscitt.verify.x509.load_pem_x509_certificate")
-    @patch("pyscitt.verify.sha256")
-    @patch("pyscitt.verify.jwk.JWK.from_json")
-    def test_assert_tls_in_jwks_succeeds_when_key_found(
-        self, mock_jwk_from_json, mock_sha256, mock_load_cert, mock_load_pub_key
-    ):
-        # Mock certificate loading and hashing
-        mock_cert = Mock()
-        mock_public_key = Mock()
-        mock_cert.public_key.return_value = mock_public_key
-        mock_public_key.public_bytes.return_value = b"mock_public_bytes"
-        mock_load_cert.return_value = mock_cert
-
-        # Mock digests
         mock_digest = Mock()
-        mock_digest.digest.return_value.hex.return_value = "same_digest"
+        mock_digest.digest.return_value.hex.return_value = "tls_cert_digest"
         mock_sha256.return_value = mock_digest
 
-        # JWKS key setup
-        mock_jwks_key = Mock()
-        mock_jwks_key.export_to_pem.return_value = b"jwks_pem"
-        mock_jwk_from_json.return_value = mock_jwks_key
-
-        # Mock JWK pub key loading
-        mock_jwks_public_key = Mock()
-        mock_jwks_public_key.public_bytes.return_value = b"jwks_public_bytes"
-        mock_load_pub_key.return_value = mock_jwks_public_key
-
+        cose_keys = [
+            {1: 2, 2: "other_kid", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
+        ]
         client = DynamicTrustStoreClient()
-        client._assert_tls_in_jwks("certificate", {"keys": [{"kid": "test_kid"}]})
 
-        # Verify all expected calls
+        with pytest.raises(
+            ValueError,
+            match="TLS public key digest tls_cert_digest not found in COSE Key Set",
+        ):
+            client._assert_tls_in_cose_keys("certificate", cose_keys)
+
         mock_load_cert.assert_called_once()
-        mock_load_pub_key.assert_called_once()
-        mock_sha256.assert_called()
-        assert len(mock_sha256.call_args_list) == 2
-        mock_jwk_from_json.assert_called_once_with('{"kid": "test_kid"}')
+        mock_sha256.assert_called_once()
 
     @patch("pyscitt.verify.x509.load_pem_x509_certificate")
-    @patch("pyscitt.verify.jwk.JWK.from_json")
-    @patch("builtins.print")
-    def test_assert_tls_in_jwks_handles_invalid_jwks_key(
-        self, mock_print, mock_jwk_from_json, mock_load_cert
+    @patch("pyscitt.verify.sha256")
+    def test_assert_tls_in_cose_keys_succeeds_when_key_found(
+        self, mock_sha256, mock_load_cert
     ):
-        # Mock certificate loading for TLS cert
         mock_cert = Mock()
         mock_public_key = Mock()
         mock_cert.public_key.return_value = mock_public_key
         mock_public_key.public_bytes.return_value = b"mock_public_bytes"
         mock_load_cert.return_value = mock_cert
 
-        # Mock JWK parsing to raise exception
-        mock_jwk_from_json.side_effect = Exception("Invalid JWK")
+        mock_digest = Mock()
+        mock_digest.digest.return_value.hex.return_value = "matching_digest"
+        mock_sha256.return_value = mock_digest
 
+        cose_keys = [
+            {1: 2, 2: "matching_digest", -1: 1, -2: b"\x01" * 32, -3: b"\x02" * 32}
+        ]
         client = DynamicTrustStoreClient()
-        # Should raise because no valid keys were found
-        with pytest.raises(
-            ValueError, match="TLS public key digest .* not found in JWKS"
-        ):
-            client._assert_tls_in_jwks("certificate", {"keys": [{"kid": "test_kid"}]})
+        # Should not raise
+        client._assert_tls_in_cose_keys("certificate", cose_keys)
 
-        # Verify warning was printed
-        mock_print.assert_called_with("Warning: Could not parse JWKS key: Invalid JWK")
+        mock_load_cert.assert_called_once()
+        mock_sha256.assert_called_once()
 
 
 class TestVerifyTransparentStatement:


### PR DESCRIPTION
Implement Transparency Service Keys Endpoints As per IETF Document

Document Link : https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/

This pull request transitions the SCITT service and client code from using JSON Web Key Sets (JWKS) to using COSE Key Sets encoded in CBOR, aligning with the latest SCITT API draft. It introduces new endpoints for retrieving trusted service keys in COSE format, updates the Python client and verifier to consume and process these endpoints, and removes legacy JWKS logic. The most important changes are:

**Service-side changes (C++):**
* Add  new endpoints: `/.well-known/scitt-keys` (returns all trusted service keys as a COSE_Key_Set in CBOR) and `/.well-known/scitt-keys/{kid_value}` (returns a single key by kid) (`app/src/service_endpoints.h`).
* Implements utility functions to encode EC public keys as COSE_Key structures and assemble COSE_Key_Sets, including mapping CCF curve IDs to COSE curve identifiers and constructing COSE_Key with proper parameters (`app/src/cbor.h`, `app/src/service_endpoints.h`). [[1]](diffhunk://#diff-a4bf62ca187eb5a5c67dadd7ffbed0ddcfd5a2fef81c8e0695f2892386f4b8d7R219-R324) [[2]](diffhunk://#diff-c077ff9defb5ca811889cad67a0fc1f3289b96fcce738d330eebdf90b6dd3ad5L36-R67)

**Client and verification changes (Python):**
* Updates the Python client to fetch and parse the new COSE Key Set endpoints, replacing the old JWKS logic (`pyscitt/pyscitt/client.py`).
* Refactors the verifier to validate the presence of the correct public key in the COSE Key Set, parse COSE_Key structures, and reconstruct EC public keys for verification, removing all JWKS/JWK dependencies (`pyscitt/pyscitt/verify.py`). [[1]](diffhunk://#diff-5242d415d9441f154540a158329de4e27f167016d4cef577990d02108e4da73bL244-R248) [[2]](diffhunk://#diff-5242d415d9441f154540a158329de4e27f167016d4cef577990d02108e4da73bL262-R288) [[3]](diffhunk://#diff-5242d415d9441f154540a158329de4e27f167016d4cef577990d02108e4da73bL359-R371)

**API and configuration changes:**
* Updates the transparency configuration to advertise the new `jwks_uri` location as `/.well-known/scitt-keys` (`app/src/service_endpoints.h`).

**Code cleanup:**
* Removes the old JWKS indexing strategy and related code from the service implementation (`app/src/service_endpoints.h`). [[1]](diffhunk://#diff-c077ff9defb5ca811889cad67a0fc1f3289b96fcce738d330eebdf90b6dd3ad5L36-R67) [[2]](diffhunk://#diff-c077ff9defb5ca811889cad67a0fc1f3289b96fcce738d330eebdf90b6dd3ad5L183-L191)
* Removes unused imports and JWKS-related test code (`test/test_ccf.py`).
* Removes the /parameters endpoint and related code from the same.


**Tests Added**

test_scitt_keys - Verifies endpoint returns correct COSE_Keys
test_scitt_key_by_kid - Verifies single key retrieval
test_scitt_key_by_kid_not_found - Verifies 404 for unknown keys

