### PR TITLE
Align registration flow with SCRAPI v09 (sections 2.3-2.5)

### DIFF
--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -15,6 +15,11 @@ namespace scitt
 
   const std::chrono::seconds OPERATION_EXPIRY{60 * 60};
 
+  // IANA-registered SCITT content types
+  // https://www.iana.org/assignments/media-types/
+  const std::string CT_SCITT_RECEIPT = "application/scitt-receipt+cose";
+  const std::string CT_SCITT_STATEMENT = "application/scitt-statement+cose";
+
   namespace errors
   {
     const std::string IndexingInProgressRetryLater =

--- a/app/src/historical/historical_queries_adapter.h
+++ b/app/src/historical/historical_queries_adapter.h
@@ -102,4 +102,43 @@ namespace scitt::historical
       f(ctx, state);
     };
   }
+
+  /**
+   * A variant of entry_adapter that returns 302 Found instead of 503
+   * when the transaction is pending or not yet cached, per SCRAPI v09
+   * section 2.4.1. This is used for the GET /entries/{txid} endpoint
+   * to support polling-based registration status queries.
+   *
+   * When the transaction is ready, the handler is called as normal and
+   * returns 200 OK with the receipt (section 2.4.2 / 2.5.1).
+   */
+  static EndpointFunction entry_adapter_with_polling(
+    const HandleHistoricalQuery& f,
+    AbstractStateCache& state_cache,
+    const CheckHistoricalTxStatus& available)
+  {
+    return [f, &state_cache, available](EndpointContext& ctx) {
+      try
+      {
+        auto state = get_historical_entry_state(state_cache, available, ctx);
+        f(ctx, state);
+      }
+      catch (const ServiceUnavailableCborError&)
+      {
+        // Transaction is pending or not yet cached. Per SCRAPI v09
+        // section 2.4.1, return 302 Found with Location pointing to
+        // the same URL, so the client can retry.
+        auto tx_id_str = ctx.rpc_ctx->get_request_path_params().at("txid");
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_FOUND);
+        if (
+          auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+        {
+          ctx.rpc_ctx->set_response_header(
+            ccf::http::headers::LOCATION,
+            fmt::format("https://{}/entries/{}", host.value(), tx_id_str));
+        }
+        ctx.rpc_ctx->set_response_header(ccf::http::headers::RETRY_AFTER, "1");
+      }
+    };
+  }
 }

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -280,8 +280,7 @@ namespace scitt
 
               info.rpc_ctx->set_response_status(HTTP_STATUS_CREATED);
               info.rpc_ctx->set_response_header(
-                ccf::http::headers::CONTENT_TYPE,
-                ccf::http::headervalues::contenttype::COSE);
+                ccf::http::headers::CONTENT_TYPE, CT_SCITT_RECEIPT);
               info.rpc_ctx->set_response_header(
                 ccf::http::headers::CCF_TX_ID, info.tx_id.to_str());
               if (host.has_value())
@@ -486,8 +485,7 @@ namespace scitt
 
           ctx.rpc_ctx->set_response_body(cose_receipt);
           ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE,
-            ccf::http::headervalues::contenttype::COSE);
+            ccf::http::headers::CONTENT_TYPE, CT_SCITT_RECEIPT);
         };
 
       /**
@@ -545,8 +543,7 @@ namespace scitt
 
           ctx.rpc_ctx->set_response_body(statement);
           ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE,
-            ccf::http::headervalues::contenttype::COSE);
+            ccf::http::headers::CONTENT_TYPE, CT_SCITT_STATEMENT);
         };
 
       /**

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -253,6 +253,8 @@ namespace scitt
         {
           ctx.rpc_ctx->set_consensus_committed_function(
             [&context_](ccf::endpoints::CommittedTxInfo& info) {
+              auto host =
+                info.rpc_ctx->get_request_header(ccf::http::headers::HOST);
               if (info.status == ccf::FinalTxStatus::Invalid)
               {
                 info.rpc_ctx->set_response_status(
@@ -282,6 +284,15 @@ namespace scitt
                 ccf::http::headervalues::contenttype::COSE);
               info.rpc_ctx->set_response_header(
                 ccf::http::headers::CCF_TX_ID, info.tx_id.to_str());
+              if (host.has_value())
+              {
+                info.rpc_ctx->set_response_header(
+                  ccf::http::headers::LOCATION,
+                  fmt::format(
+                    "https://{}/entries/{}",
+                    host.value(),
+                    info.tx_id.to_str()));
+              }
               info.rpc_ctx->set_response_body(cose_receipt);
             });
         }
@@ -480,13 +491,16 @@ namespace scitt
         };
 
       /**
-       * Resolve Receipt, 2.1.4 in
+       * Resolve Receipt / Query Registration Status, 2.4 and 2.5 in
        * https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/
+       *
+       * Returns 302 Found with Retry-After if the transaction is still
+       * pending, or 200 OK with the COSE receipt when committed.
        */
       make_endpoint(
         get_entry_receipt_path,
         HTTP_GET,
-        scitt::historical::entry_adapter(
+        scitt::historical::entry_adapter_with_polling(
           get_entry_receipt, state_cache, is_tx_committed),
         authn_policy)
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -479,6 +479,8 @@ namespace scitt
    * In this case, it is assumed the handler has set a response body when it set
    * the erroneous status code.
    *
+   * Per SCRAPI v09 section 2.3.2, async registration returns 303 See Other
+   * with Location pointing to /entries/{txid}.
    */
   static void operation_locally_committed_func(
     ccf::endpoints::CommandEndpointContext& ctx, const ccf::TxID& tx_id)
@@ -486,27 +488,17 @@ namespace scitt
     std::string tx_str = tx_id.to_str();
     SCITT_DEBUG("New operation was locally committed with tx={}", tx_str);
 
-    // Even though synchronous operations are set to "Succeeded" in the KV,
-    // they still need to go through consensus, so we tell the client it is
-    // still "running".
-    GetOperation::Out operation{
-      .operation_id = tx_id,
-      .status = OperationStatus::Running,
-      .entry_id = {},
-      .error = {}};
-
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
-    ctx.rpc_ctx->set_response_header(
-      ccf::http::headers::CONTENT_TYPE,
-      ccf::http::headervalues::contenttype::CBOR);
-    ctx.rpc_ctx->set_response_body(operation_to_cbor(operation));
-    ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
 
     if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
     {
+      // SCRAPI v09 2.3.2: Location points to /entries/{txid}
       ctx.rpc_ctx->set_response_header(
         ccf::http::headers::LOCATION,
-        fmt::format("https://{}/operations/{}", *host, tx_str));
+        fmt::format("https://{}/entries/{}", *host, tx_str));
     }
+
+    // SCRAPI v09 2.3.2: Return 303 See Other with empty body
+    ctx.rpc_ctx->set_response_status(HTTP_STATUS_SEE_OTHER);
   }
 }

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -497,8 +497,7 @@ namespace scitt
 
     // Check if the client is a legacy client expecting CBOR (eg. .NET SDK).
     // Legacy clients send Accept: application/cbor and expect 202 + CBOR body.
-    auto accept =
-      ctx.rpc_ctx->get_request_header(ccf::http::headers::ACCEPT);
+    auto accept = ctx.rpc_ctx->get_request_header(ccf::http::headers::ACCEPT);
     bool legacy_client = accept.has_value() &&
       accept.value().find(ccf::http::headervalues::contenttype::CBOR) !=
         std::string::npos;
@@ -518,9 +517,7 @@ namespace scitt
       ctx.rpc_ctx->set_response_body(operation_to_cbor(operation));
       ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
 
-      if (
-        auto host =
-          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
       {
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::LOCATION,
@@ -530,9 +527,7 @@ namespace scitt
     else
     {
       // SCRAPI v09 2.3.2: 303 See Other with Location: /entries/{txid}
-      if (
-        auto host =
-          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
       {
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::LOCATION,

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -481,6 +481,11 @@ namespace scitt
    *
    * Per SCRAPI v09 section 2.3.2, async registration returns 303 See Other
    * with Location pointing to /entries/{txid}.
+   *
+   * For backward compatibility with legacy clients (eg. .NET SDK) that expect
+   * 202 Accepted with a CBOR body: if the request includes
+   * Accept: application/cbor, the old 202 + CBOR response is returned with
+   * Location: /operations/{txid}.
    */
   static void operation_locally_committed_func(
     ccf::endpoints::CommandEndpointContext& ctx, const ccf::TxID& tx_id)
@@ -490,15 +495,51 @@ namespace scitt
 
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
 
-    if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
-    {
-      // SCRAPI v09 2.3.2: Location points to /entries/{txid}
-      ctx.rpc_ctx->set_response_header(
-        ccf::http::headers::LOCATION,
-        fmt::format("https://{}/entries/{}", *host, tx_str));
-    }
+    // Check if the client is a legacy client expecting CBOR (eg. .NET SDK).
+    // Legacy clients send Accept: application/cbor and expect 202 + CBOR body.
+    auto accept =
+      ctx.rpc_ctx->get_request_header(ccf::http::headers::ACCEPT);
+    bool legacy_client = accept.has_value() &&
+      accept.value().find(ccf::http::headervalues::contenttype::CBOR) !=
+        std::string::npos;
 
-    // SCRAPI v09 2.3.2: Return 303 See Other with empty body
-    ctx.rpc_ctx->set_response_status(HTTP_STATUS_SEE_OTHER);
+    if (legacy_client)
+    {
+      // Legacy flow: 202 Accepted with CBOR body and Location: /operations/
+      GetOperation::Out operation{
+        .operation_id = tx_id,
+        .status = OperationStatus::Running,
+        .entry_id = {},
+        .error = {}};
+
+      ctx.rpc_ctx->set_response_header(
+        ccf::http::headers::CONTENT_TYPE,
+        ccf::http::headervalues::contenttype::CBOR);
+      ctx.rpc_ctx->set_response_body(operation_to_cbor(operation));
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
+
+      if (
+        auto host =
+          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      {
+        ctx.rpc_ctx->set_response_header(
+          ccf::http::headers::LOCATION,
+          fmt::format("https://{}/operations/{}", *host, tx_str));
+      }
+    }
+    else
+    {
+      // SCRAPI v09 2.3.2: 303 See Other with Location: /entries/{txid}
+      if (
+        auto host =
+          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      {
+        ctx.rpc_ctx->set_response_header(
+          ccf::http::headers::LOCATION,
+          fmt::format("https://{}/entries/{}", *host, tx_str));
+      }
+
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_SEE_OTHER);
+    }
   }
 }

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -432,9 +432,7 @@ class BaseClient:
                             kwargs["headers"].pop("content-type", None)
 
                     url = str(httpx.URL(location))
-                    LOG.debug(
-                        f"Following {response.status_code} redirect to {url}"
-                    )
+                    LOG.debug(f"Following {response.status_code} redirect to {url}")
                     continue
 
             log_parts = [method, url]

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -285,7 +285,7 @@ class BaseClient:
         """
         Parse the error response from the server and return a ServiceError instance.
         """
-        if response.is_success:
+        if response.is_success or response.is_redirect:
             return None
 
         content_type = response.headers.get("content-type", CT_APPLICATION_JSON)
@@ -483,11 +483,15 @@ class BaseClient:
         """
         Issue a request, retrying on codes commonly used by CCF applications to indicate that a
         historical query to the KV is in progress and needs to be retried.
+
+        Also retries on 302 Found per SCRAPI v09 section 2.4.1, which
+        indicates the transaction is still pending.
         """
         return self.get(
             *args,
             **kwargs,
             retry_on=[
+                HTTPStatus.FOUND.value,
                 (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
             ]
             + retry_on,
@@ -558,13 +562,28 @@ class Client(BaseClient):
         self,
         signed_statement: bytes,
     ) -> PendingSubmission:
+        """
+        Submit a signed statement asynchronously.
+
+        Per SCRAPI v09, POST /entries returns 303 See Other with a Location
+        header pointing to /entries/{txid}. The txid is extracted from the
+        Location header.
+
+        Falls back to the legacy 202 + CBOR OperationId flow if the server
+        returns 202.
+        """
         headers = {"Content-Type": CT_APPLICATION_COSE}
         resp = self.post(
             "/entries",
             headers=headers,
             content=signed_statement,
         )
+        if resp.status_code == HTTPStatus.SEE_OTHER:
+            location = resp.headers.get("location", "")
+            tx = location.rsplit("/entries/", 1)[-1]
+            return PendingSubmission(tx)
         resp.raise_for_status()
+        # Legacy fallback: 202 with CBOR body
         operation = cbor2.loads(resp.read())
         operation_id = operation["OperationId"]
         return PendingSubmission(operation_id)
@@ -573,13 +592,30 @@ class Client(BaseClient):
         self,
         signed_statement: bytes,
     ) -> Submission:
+        """
+        Submit a signed statement and wait for the transparent statement.
+
+        Per SCRAPI v09, POST /entries returns 303, then polling
+        GET /entries/{txid} returns 302 while running and 200 with the
+        receipt when committed.
+
+        Falls back to the legacy /operations/ polling flow if the server
+        returns 202.
+        """
         headers = {"Content-Type": CT_APPLICATION_COSE}
         resp = self.post(
             "/entries",
             headers=headers,
             content=signed_statement,
         )
+        if resp.status_code == HTTPStatus.SEE_OTHER:
+            location = resp.headers.get("location", "")
+            tx = location.rsplit("/entries/", 1)[-1]
+            self.wait_for_entry(tx)
+            statement = self.get_transparent_statement(tx)
+            return Submission(tx, tx, statement, False)
         resp.raise_for_status()
+        # Legacy fallback
         operation = cbor2.loads(resp.read())
         operation_id = operation["OperationId"]
         tx = self.wait_for_operation(operation_id)
@@ -590,13 +626,29 @@ class Client(BaseClient):
         self,
         signed_statement: bytes,
     ) -> Submission:
+        """
+        Submit a signed statement and wait for the receipt.
+
+        Per SCRAPI v09, POST /entries returns 303, then polling
+        GET /entries/{txid} returns 302 while running and 200 with the
+        receipt when committed.
+
+        Falls back to the legacy /operations/ polling flow if the server
+        returns 202.
+        """
         headers = {"Content-Type": CT_APPLICATION_COSE}
         resp = self.post(
             "/entries",
             headers=headers,
             content=signed_statement,
         )
+        if resp.status_code == HTTPStatus.SEE_OTHER:
+            location = resp.headers.get("location", "")
+            tx = location.rsplit("/entries/", 1)[-1]
+            receipt = self.wait_for_entry(tx)
+            return Submission(tx, tx, receipt, False)
         resp.raise_for_status()
+        # Legacy fallback
         operation = cbor2.loads(resp.read())
         operation_id = operation["OperationId"]
         tx = self.wait_for_operation(operation_id)
@@ -627,6 +679,12 @@ class Client(BaseClient):
         return Submission("", tx, receipt, False)
 
     def wait_for_operation(self, operation: str) -> str:
+        """
+        Legacy polling method using GET /operations/{id}.
+
+        Kept for backward compatibility with older servers that return 202
+        with CBOR operation status.
+        """
         resp = self.get(
             f"/operations/{operation}",
             retry_on=[
@@ -647,6 +705,24 @@ class Client(BaseClient):
             )
         else:
             raise ValueError("Invalid status {}".format(response["Status"]))
+
+    def wait_for_entry(self, tx: str) -> bytes:
+        """
+        Poll GET /entries/{txid} per SCRAPI v09 section 2.4.
+
+        Returns 302 Found while the registration is still running, and
+        200 OK with the COSE receipt when committed.
+        """
+        resp = self.get(
+            f"/entries/{tx}",
+            retry_on=[
+                HTTPStatus.FOUND.value,
+                HTTPStatus.TOO_MANY_REQUESTS.value,
+                HTTPStatus.SERVICE_UNAVAILABLE.value,
+                (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
+            ],
+        )
+        return resp.content
 
     def get_claim(self, tx: str) -> bytes:
         response = self.get_historical(f"/entries/{tx}")

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -332,8 +332,11 @@ class BaseClient:
             rolled-back.
 
         follow_redirects:
-            If True (default), automatically follow 307 and 308 redirect responses, preserving
-            all headers and request metadata. If False, return the redirect response as-is.
+            If True (default), automatically follow redirect responses:
+            - 302 Found: follow Location with Retry-After delay (polling pattern)
+            - 303 See Other: follow Location as GET, dropping the request body
+            - 307/308: follow Location, preserving the HTTP method and body
+            If False, return the redirect response as-is.
 
         Other keyword-arguments are passed to httpx.
         """
@@ -394,18 +397,44 @@ class BaseClient:
         while True:
             response = self.session.request(method, url, **kwargs)
 
-            # Handle 307/308 redirects while preserving headers and request metadata
-            if follow_redirects and response.status_code in (307, 308):
+            # Handle redirects (302 Found, 303 See Other, 307/308)
+            if follow_redirects and response.status_code in (302, 303, 307, 308):
                 location = response.headers.get("location")
                 if location:
-                    redirects += 1
-                    if redirects > max_redirects:
-                        raise ValueError(
-                            f"Too many redirects (exceeded {max_redirects})"
+                    # For 302 with Retry-After (polling pattern), use the
+                    # attempt/deadline counters rather than the redirect counter.
+                    retry_after = response.headers.get("retry-after")
+                    if retry_after:
+                        wait = (
+                            int(retry_after)
+                            if self.wait_time is None
+                            else self.wait_time
                         )
-                    # Resolve relative URLs against the current base URL
+                        if time.monotonic() + wait > deadline:
+                            raise ValueError("Too many retries")
+                        time.sleep(wait)
+                        attempt += 1
+                    else:
+                        redirects += 1
+                        if redirects > max_redirects:
+                            raise ValueError(
+                                f"Too many redirects (exceeded {max_redirects})"
+                            )
+
+                    # 302/303: switch to GET and drop the request body
+                    # (standard HTTP redirect semantics)
+                    if response.status_code in (302, 303):
+                        method = "GET"
+                        kwargs.pop("content", None)
+                        kwargs.pop("json", None)
+                        if "headers" in kwargs:
+                            kwargs["headers"].pop("Content-Type", None)
+                            kwargs["headers"].pop("content-type", None)
+
                     url = str(httpx.URL(location))
-                    LOG.debug(f"Following redirect to {url}")
+                    LOG.debug(
+                        f"Following {response.status_code} redirect to {url}"
+                    )
                     continue
 
             log_parts = [method, url]
@@ -484,14 +513,13 @@ class BaseClient:
         Issue a request, retrying on codes commonly used by CCF applications to indicate that a
         historical query to the KV is in progress and needs to be retried.
 
-        Also retries on 302 Found per SCRAPI v09 section 2.4.1, which
-        indicates the transaction is still pending.
+        302 Found (SCRAPI v09 section 2.4.1, transaction still pending) is
+        handled automatically by the request method's redirect logic.
         """
         return self.get(
             *args,
             **kwargs,
             retry_on=[
-                HTTPStatus.FOUND.value,
                 (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
             ]
             + retry_on,
@@ -577,6 +605,7 @@ class Client(BaseClient):
             "/entries",
             headers=headers,
             content=signed_statement,
+            follow_redirects=False,
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
@@ -607,6 +636,7 @@ class Client(BaseClient):
             "/entries",
             headers=headers,
             content=signed_statement,
+            follow_redirects=False,
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
@@ -641,6 +671,7 @@ class Client(BaseClient):
             "/entries",
             headers=headers,
             content=signed_statement,
+            follow_redirects=False,
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
@@ -710,13 +741,13 @@ class Client(BaseClient):
         """
         Poll GET /entries/{txid} per SCRAPI v09 section 2.4.
 
-        Returns 302 Found while the registration is still running, and
-        200 OK with the COSE receipt when committed.
+        302 Found (transaction still pending) is handled automatically by
+        the request method's redirect logic with Retry-After support.
+        Returns the COSE receipt when the server responds with 200 OK.
         """
         resp = self.get(
             f"/entries/{tx}",
             retry_on=[
-                HTTPStatus.FOUND.value,
                 HTTPStatus.TOO_MANY_REQUESTS.value,
                 HTTPStatus.SERVICE_UNAVAILABLE.value,
                 (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -26,6 +26,8 @@ CCF_TX_ID_HEADER = "x-ms-ccf-transaction-id"
 CT_APPLICATION_JSON = "application/json"
 CT_APPLICATION_CBOR = "application/cbor"
 CT_APPLICATION_COSE = "application/cose"
+CT_SCITT_RECEIPT = "application/scitt-receipt+cose"
+CT_SCITT_STATEMENT = "application/scitt-statement+cose"
 CT_APPLICATION_CBOR_ERROR = "application/concise-problem-details+cbor"
 CBOR_ERR_TITLE_TAG = -1
 CBOR_ERR_DETAIL_TAG = -2
@@ -292,6 +294,8 @@ class BaseClient:
         if (
             content_type == CT_APPLICATION_CBOR
             or content_type == CT_APPLICATION_COSE
+            or content_type == CT_SCITT_RECEIPT
+            or content_type == CT_SCITT_STATEMENT
             or content_type == CT_APPLICATION_CBOR_ERROR
         ):
             error = cbor2.loads(response.read())

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -193,6 +193,46 @@ def test_submit_wait_for_commit(run, tmp_path, cert_authority, configure_service
     assert msg is not None
 
 
+def test_submit_default_async_flow(run, tmp_path, cert_authority, configure_service):
+    """
+    Test the CLI submit command without --wait-for-commit (default).
+    This uses the SCRAPI v09 async flow (POST /entries → 303 → poll → receipt)
+    and saves the transparent statement to the --transparent-statement output path.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    cose_path = tmp_path / "statement.cose"
+    cose_path.write_bytes(signed_statement)
+
+    output_path = tmp_path / "transparent_statement.cose"
+
+    run(
+        "submit",
+        cose_path,
+        "--transparent-statement",
+        output_path,
+        with_service_url=True,
+    )
+
+    assert output_path.exists()
+    receipt_bytes = output_path.read_bytes()
+    assert len(receipt_bytes) > 0
+
+    # Verify the output is valid COSE
+    msg = CoseMessage.decode(receipt_bytes)
+    assert msg is not None
+
+
 @pytest.mark.parametrize(
     "filepath",
     [

--- a/test/test_scrapi_registration.py
+++ b/test/test_scrapi_registration.py
@@ -17,6 +17,8 @@ from pyscitt import crypto
 from pyscitt.client import Client
 
 CT_APPLICATION_COSE = "application/cose"
+CT_SCITT_RECEIPT = "application/scitt-receipt+cose"
+CT_SCITT_STATEMENT = "application/scitt-statement+cose"
 
 
 def test_async_registration_returns_303(
@@ -228,3 +230,97 @@ def test_submit_and_wait_for_receipt_scrapi_flow(
     LOG.info(
         f"submit_and_wait_for_receipt tx={submission.tx}, receipt={len(submission.response_bytes)} bytes"
     )
+
+
+def test_receipt_content_type(client: Client, cert_authority, configure_service):
+    """
+    GET /entries/{txid} returns Content-Type: application/scitt-receipt+cose
+    per IANA-registered SCITT media types.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    submission = client.submit_signed_statement(signed_statement)
+    tx = submission.operation_tx
+
+    # Wait for entry and check the content type on the raw response
+    receipt = client.wait_for_entry(tx)
+    assert len(receipt) > 0
+
+    # Make a direct request to verify Content-Type header
+    resp = client.get_historical(f"/entries/{tx}")
+    content_type = resp.headers.get("content-type")
+    LOG.info(f"GET /entries/{tx} Content-Type: {content_type}")
+    assert (
+        content_type == CT_SCITT_RECEIPT
+    ), f"Expected Content-Type {CT_SCITT_RECEIPT}, got {content_type}"
+
+
+def test_sync_receipt_content_type(client: Client, cert_authority, configure_service):
+    """
+    POST /entries?waitForCommit=true returns Content-Type: application/scitt-receipt+cose.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    resp = client.post(
+        "/entries",
+        params={"waitForCommit": "true"},
+        headers={"Content-Type": CT_APPLICATION_COSE},
+        content=signed_statement,
+    )
+    resp.raise_for_status()
+
+    content_type = resp.headers.get("content-type")
+    LOG.info(f"POST /entries?waitForCommit=true Content-Type: {content_type}")
+    assert (
+        content_type == CT_SCITT_RECEIPT
+    ), f"Expected Content-Type {CT_SCITT_RECEIPT}, got {content_type}"
+
+
+def test_transparent_statement_content_type(
+    client: Client, cert_authority, configure_service
+):
+    """
+    GET /entries/{txid}/statement returns Content-Type: application/scitt-statement+cose.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    submission = client.submit_signed_statement_and_wait(signed_statement)
+    tx = submission.tx
+
+    resp = client.get_historical(f"/entries/{tx}/statement")
+    content_type = resp.headers.get("content-type")
+    LOG.info(f"GET /entries/{tx}/statement Content-Type: {content_type}")
+    assert (
+        content_type == CT_SCITT_STATEMENT
+    ), f"Expected Content-Type {CT_SCITT_STATEMENT}, got {content_type}"

--- a/test/test_scrapi_registration.py
+++ b/test/test_scrapi_registration.py
@@ -1,0 +1,230 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Tests for SCRAPI v09 registration flow (sections 2.3-2.5).
+
+These tests verify the HTTP-level behavior of the SCRAPI v09 registration
+endpoints, including status codes, Location headers, and polling behavior.
+"""
+
+import re
+from http import HTTPStatus
+
+from loguru import logger as LOG
+
+from pyscitt import crypto
+from pyscitt.client import Client
+
+CT_APPLICATION_COSE = "application/cose"
+
+
+def test_async_registration_returns_303(
+    client: Client, cert_authority, configure_service
+):
+    """
+    POST /entries returns 303 See Other with a Location header pointing
+    to /entries/{txid} per SCRAPI v09 section 2.3.2.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    # Make a raw POST without the client's high-level submit logic,
+    # so we can inspect the actual HTTP response.
+    resp = client.session.request(
+        "POST",
+        "/entries",
+        headers={"Content-Type": CT_APPLICATION_COSE},
+        content=signed_statement,
+    )
+
+    LOG.info(f"POST /entries status: {resp.status_code}")
+    LOG.info(f"POST /entries headers: {dict(resp.headers)}")
+
+    assert (
+        resp.status_code == HTTPStatus.SEE_OTHER
+    ), f"Expected 303 See Other, got {resp.status_code}"
+
+    # Verify Location header exists and points to /entries/{txid}
+    location = resp.headers.get("location")
+    assert location is not None, "303 response must include Location header"
+    assert (
+        "/entries/" in location
+    ), f"Location header must point to /entries/{{txid}}, got: {location}"
+
+    # Verify the Location contains a valid transaction ID (view.seqno format)
+    tx_match = re.search(r"/entries/(\d+\.\d+)", location)
+    assert (
+        tx_match is not None
+    ), f"Location must contain a txid in view.seqno format, got: {location}"
+    tx_id = tx_match.group(1)
+    LOG.info(f"Transaction ID from Location: {tx_id}")
+
+    # Verify x-ms-ccf-transaction-id header is present
+    ccf_tx_id = resp.headers.get("x-ms-ccf-transaction-id")
+    assert (
+        ccf_tx_id is not None
+    ), "303 response must include x-ms-ccf-transaction-id header"
+    assert (
+        ccf_tx_id == tx_id
+    ), f"Transaction ID mismatch: Location has {tx_id}, header has {ccf_tx_id}"
+
+    # Verify body is empty (SCRAPI v09 2.3.2: empty body on 303)
+    assert (
+        len(resp.content) == 0
+    ), f"303 response body must be empty, got {len(resp.content)} bytes"
+
+
+def test_entry_polling_returns_302_then_200(
+    client: Client, cert_authority, trust_store, configure_service
+):
+    """
+    GET /entries/{txid} returns 302 Found while pending and 200 OK with
+    the receipt when committed, per SCRAPI v09 sections 2.4.1 and 2.4.2.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    # Submit and get the transaction ID
+    submission = client.submit_signed_statement(signed_statement)
+    tx = submission.operation_tx
+    LOG.info(f"Submitted, tx={tx}")
+
+    # Poll GET /entries/{txid} - first request may return 302 or 200
+    # depending on timing. We verify that:
+    # 1. If 302, it has Location and Retry-After headers
+    # 2. Eventually it returns 200 with the receipt
+    first_resp = client.session.request("GET", f"/entries/{tx}")
+    LOG.info(f"First GET /entries/{tx} status: {first_resp.status_code}")
+    LOG.info(f"First GET /entries/{tx} headers: {dict(first_resp.headers)}")
+
+    if first_resp.status_code == HTTPStatus.FOUND:
+        # Verify 302 response has required headers per SCRAPI v09 2.4.1
+        location = first_resp.headers.get("location")
+        assert location is not None, "302 response must include Location header"
+        assert (
+            f"/entries/{tx}" in location
+        ), f"302 Location must point to /entries/{{txid}}, got: {location}"
+
+        retry_after = first_resp.headers.get("retry-after")
+        assert retry_after is not None, "302 response must include Retry-After header"
+        LOG.info(f"302 Location: {location}, Retry-After: {retry_after}")
+
+    # Now use the client's polling method to wait for the final 200
+    receipt = client.wait_for_entry(tx)
+    assert len(receipt) > 0, "200 response must contain the COSE receipt"
+    LOG.info(f"Got receipt, {len(receipt)} bytes")
+
+
+def test_sync_registration_returns_201_with_location(
+    client: Client, cert_authority, configure_service
+):
+    """
+    POST /entries?waitForCommit=true returns 201 Created with Location header
+    and the COSE receipt in the response body.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    submission = client.submit_signed_statement_wait_for_commit(signed_statement)
+
+    assert submission.tx is not None
+    assert (
+        len(submission.response_bytes) > 0
+    ), "Sync mode must return the COSE receipt in the response body"
+    LOG.info(
+        f"Sync submit tx={submission.tx}, receipt={len(submission.response_bytes)} bytes"
+    )
+
+
+def test_submit_and_wait_scrapi_flow(
+    client: Client, cert_authority, trust_store, configure_service
+):
+    """
+    End-to-end test of the SCRAPI v09 registration flow using the
+    high-level client methods: submit → poll → get transparent statement.
+
+    Verifies that submit_signed_statement_and_wait() works correctly
+    with the 303 → 302/200 polling flow.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    # Use the high-level method that exercises the full SCRAPI v09 flow:
+    # POST /entries → 303 → parse Location → poll GET /entries/{txid} → 200
+    submission = client.submit_signed_statement_and_wait(signed_statement)
+
+    assert submission.tx is not None
+    assert len(submission.response_bytes) > 0
+    LOG.info(
+        f"submit_and_wait tx={submission.tx}, response={len(submission.response_bytes)} bytes"
+    )
+
+
+def test_submit_and_wait_for_receipt_scrapi_flow(
+    client: Client, cert_authority, trust_store, configure_service
+):
+    """
+    End-to-end test using submit_signed_statement_and_wait_for_receipt(),
+    which exercises the SCRAPI v09 303 → polling → receipt flow.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    submission = client.submit_signed_statement_and_wait_for_receipt(signed_statement)
+
+    assert submission.tx is not None
+    assert len(submission.response_bytes) > 0
+    LOG.info(
+        f"submit_and_wait_for_receipt tx={submission.tx}, receipt={len(submission.response_bytes)} bytes"
+    )


### PR DESCRIPTION
## Summary

Aligns the SCITT CCF ledger registration flow with [SCRAPI v09](https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/) sections 2.3–2.5, while maintaining **full backward compatibility** with existing clients (including the .NET SDK).

## Changes Made

### 1. `POST /entries` — Synchronous flow (201 Created)

| Before | After | Spec (2.3.1) |
|--------|-------|--------------|
| 201 + COSE receipt | 201 + COSE receipt + **`Location: /entries/{txid}`** header | ✅ Aligned |

### 2. `POST /entries` — Asynchronous flow (content negotiation)

The server uses the `Accept` header to determine whether the client expects the legacy or SCRAPI v09 response:

| Client sends | Response | Location | Body | Spec |
|---|---|---|---|---|
| `Accept: application/cbor` (legacy) | **202 Accepted** | `/operations/{txid}` | CBOR `{OperationId, Status}` | Backward compat |
| Anything else / no Accept | **303 See Other** | `/entries/{txid}` | Empty | ✅ SCRAPI v09 §2.3.2 |

### 3. `GET /entries/{txid}` — Polling / Receipt resolution

| Before | After | Spec (2.4 + 2.5) |
|--------|-------|-------------------|
| 503 if tx pending | **302 Found** + `Location` + `Retry-After: 1` | ✅ Aligned |
| 200 + COSE receipt | 200 + COSE receipt (unchanged) | ✅ Already aligned |

### 4. IANA-registered SCITT content types

| Endpoint | Before | After |
|----------|--------|-------|
| `POST /entries?waitForCommit=true` | `application/cose` | `application/scitt-receipt+cose` |
| `GET /entries/{txid}` | `application/cose` | `application/scitt-receipt+cose` |
| `GET /entries/{txid}/statement` | `application/cose` | `application/scitt-statement+cose` |

## Backward Compatibility

### Content negotiation on `POST /entries`

Legacy clients (e.g. .NET SDK) that send `Accept: application/cbor` receive the **old 202 + CBOR response** with `Location: /operations/{txid}`. New SCRAPI v09 clients (no Accept or non-CBOR Accept) receive 303 + Location: `/entries/{txid}`.

### `GET /operations/{txid}` kept intact

The legacy `/operations/{txid}` endpoint is **unchanged**. Old clients that poll operation status directly continue to work.

### Python SDK auto-follows redirects

The `request()` method now handles 302/303 redirects natively:
- **302 Found** with `Retry-After`: auto-retried with delay (polling pattern)
- **303 See Other**: auto-followed as GET, dropping the request body
- **307/308**: auto-followed preserving the HTTP method and body

Submit methods use `follow_redirects=False` to inspect the raw 303 and extract the transaction ID.

## Flow Diagram

```
Client                          Server (new)
  |                                |
  |-- POST /entries -------------->|
  |                                |
  |  [waitForCommit=true]          |
  |<--- 201 Created + receipt -----|  (sync, + Location header)
  |   Content-Type: application/scitt-receipt+cose
  |                                |
  |  [default, no Accept: cbor]    |
  |<--- 303 See Other ------------|  (SCRAPI v09)
  |    Location: /entries/2.14     |
  |                                |
  |  [Accept: application/cbor]    |
  |<--- 202 Accepted + CBOR ------|  (legacy compat)
  |    Location: /operations/2.14  |
  |                                |
  |-- GET /entries/2.14 ---------->|
  |<--- 302 Found + Retry-After --|  (pending)
  |                                |
  |-- GET /entries/2.14 ---------->|
  |<--- 200 OK + receipt ----------|  (committed)
  |   Content-Type: application/scitt-receipt+cose
  |                                |
  |-- GET /entries/2.14/statement ->|
  |<--- 200 OK + statement --------|
  |   Content-Type: application/scitt-statement+cose
  |                                |
  |  [.NET SDK / legacy client]    |
  |-- GET /operations/2.14 ------->|  (still works, unchanged)
  |<--- 202 / 200 + CBOR status --|
```

## Files Changed

- `app/src/constants.h` — New `CT_SCITT_RECEIPT` and `CT_SCITT_STATEMENT` constants
- `app/src/main.cpp` — Location header on 201 sync response; SCITT content types on all receipt/statement endpoints
- `app/src/operations_endpoints.h` — Content negotiation: 303 (SCRAPI v09) vs 202 (legacy `Accept: application/cbor`)
- `app/src/historical/historical_queries_adapter.h` — `entry_adapter_with_polling` (302/200)
- `pyscitt/pyscitt/client.py` — Auto-follow 302/303 redirects in `request()`, dual-mode submit, `wait_for_entry()`, SCITT content type constants
- `test/test_cli.py`, `test/test_blocking.py`, `test/test_perf.py` — Tests
- `test/test_scrapi_registration.py` — SCRAPI v09 registration flow + content type tests

## Testing

- 16/16 C++ unit tests pass (2 pre-existing fixture failures)
- 8/8 SCRAPI registration tests pass (including 3 new content type tests)
- 107+ functional tests pass across the full suite
