### PR TITLE
Gate SCRAPI v09 behavior on api-version query parameter

### DIFF
--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -21,7 +21,7 @@ namespace scitt
   const std::string CT_SCITT_STATEMENT = "application/scitt-statement+cose";
 
   // API versioning for SCITT endpoints.
-  // The new version enables SCRAPI v09 behavior (303, 302, new content types).
+  // SCRAPI v9 enables new behavior (303, 302, new content types).
   // Older versions (or absent api-version) get legacy behavior.
   const std::string SCITT_API_VERSION_2026_03_26 = "2026-03-26";
 

--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -20,6 +20,11 @@ namespace scitt
   const std::string CT_SCITT_RECEIPT = "application/scitt-receipt+cose";
   const std::string CT_SCITT_STATEMENT = "application/scitt-statement+cose";
 
+  // API versioning for SCITT endpoints.
+  // The new version enables SCRAPI v09 behavior (303, 302, new content types).
+  // Older versions (or absent api-version) get legacy behavior.
+  const std::string SCITT_API_VERSION_SCRAPI = "2026-01-11-preview";
+
   namespace errors
   {
     const std::string IndexingInProgressRetryLater =

--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -15,6 +15,11 @@ namespace scitt
 
   const std::chrono::seconds OPERATION_EXPIRY{60 * 60};
 
+  // IANA-registered SCITT content types
+  // https://www.iana.org/assignments/media-types/
+  const std::string CT_SCITT_RECEIPT = "application/scitt-receipt+cose";
+  const std::string CT_SCITT_STATEMENT = "application/scitt-statement+cose";
+
   namespace errors
   {
     const std::string IndexingInProgressRetryLater =

--- a/app/src/constants.h
+++ b/app/src/constants.h
@@ -23,7 +23,7 @@ namespace scitt
   // API versioning for SCITT endpoints.
   // The new version enables SCRAPI v09 behavior (303, 302, new content types).
   // Older versions (or absent api-version) get legacy behavior.
-  const std::string SCITT_API_VERSION_SCRAPI = "2026-03-26";
+  const std::string SCITT_API_VERSION_2026_03_26 = "2026-03-26";
 
   namespace errors
   {

--- a/app/src/historical/historical_queries_adapter.h
+++ b/app/src/historical/historical_queries_adapter.h
@@ -102,4 +102,43 @@ namespace scitt::historical
       f(ctx, state);
     };
   }
+
+  /**
+   * A variant of entry_adapter that returns 302 Found instead of 503
+   * when the transaction is pending or not yet cached, per SCRAPI v09
+   * section 2.4.1. This is used for the GET /entries/{txid} endpoint
+   * to support polling-based registration status queries.
+   *
+   * When the transaction is ready, the handler is called as normal and
+   * returns 200 OK with the receipt (section 2.4.2 / 2.5.1).
+   */
+  static EndpointFunction entry_adapter_with_polling(
+    const HandleHistoricalQuery& f,
+    AbstractStateCache& state_cache,
+    const CheckHistoricalTxStatus& available)
+  {
+    return [f, &state_cache, available](EndpointContext& ctx) {
+      try
+      {
+        auto state = get_historical_entry_state(state_cache, available, ctx);
+        f(ctx, state);
+      }
+      catch (const ServiceUnavailableCborError&)
+      {
+        // Transaction is pending or not yet cached. Per SCRAPI v09
+        // section 2.4.1, return 302 Found with Location pointing to
+        // the same URL, so the client can retry.
+        auto tx_id_str = ctx.rpc_ctx->get_request_path_params().at("txid");
+        ctx.rpc_ctx->set_response_status(HTTP_STATUS_FOUND);
+        if (
+          auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+        {
+          ctx.rpc_ctx->set_response_header(
+            ccf::http::headers::LOCATION,
+            fmt::format("https://{}/entries/{}", host.value(), tx_id_str));
+        }
+        ctx.rpc_ctx->set_response_header(ccf::http::headers::RETRY_AFTER, "1");
+      }
+    };
+  }
 }

--- a/app/src/historical/historical_queries_adapter.h
+++ b/app/src/historical/historical_queries_adapter.h
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "constants.h"
 #include "http_error.h"
 #include "tracing.h"
 
 #include <ccf/endpoint_context.h>
 #include <ccf/historical_queries_adapter.h>
 #include <ccf/http_consts.h>
+#include <ccf/http_query.h>
 #include <ccf/json_handler.h>
 #include <ccf/odata_error.h>
 #include <ccf/rpc_context.h>
@@ -125,19 +127,34 @@ namespace scitt::historical
       }
       catch (const ServiceUnavailableCborError&)
       {
-        // Transaction is pending or not yet cached. Per SCRAPI v09
-        // section 2.4.1, return 302 Found with Location pointing to
-        // the same URL, so the client can retry.
-        auto tx_id_str = ctx.rpc_ctx->get_request_path_params().at("txid");
-        ctx.rpc_ctx->set_response_status(HTTP_STATUS_FOUND);
-        if (
-          auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+        // Transaction is pending or not yet cached.
+        // Check api-version to decide response style.
+        const auto parsed_query =
+          ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
+        auto it = parsed_query.find("api-version");
+        bool scrapi =
+          it != parsed_query.end() && it->second == SCITT_API_VERSION_SCRAPI;
+
+        if (scrapi)
         {
-          ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::LOCATION,
-            fmt::format("https://{}/entries/{}", host.value(), tx_id_str));
+          // SCRAPI v09 section 2.4.1: return 302 Found with Location
+          // pointing to the same URL, so the client can retry.
+          auto tx_id_str = ctx.rpc_ctx->get_request_path_params().at("txid");
+          ctx.rpc_ctx->set_response_status(HTTP_STATUS_FOUND);
+          if (
+            auto host =
+              ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+          {
+            ctx.rpc_ctx->set_response_header(
+              ccf::http::headers::LOCATION,
+              fmt::format("https://{}/entries/{}", host.value(), tx_id_str));
+          }
         }
-        ctx.rpc_ctx->set_response_header(ccf::http::headers::RETRY_AFTER, "1");
+        else
+        {
+          // Legacy clients expect 503 Service Unavailable.
+          throw;
+        }
       }
     };
   }

--- a/app/src/historical/historical_queries_adapter.h
+++ b/app/src/historical/historical_queries_adapter.h
@@ -5,6 +5,7 @@
 #include "constants.h"
 #include "http_error.h"
 #include "tracing.h"
+#include "util.h"
 
 #include <ccf/endpoint_context.h>
 #include <ccf/historical_queries_adapter.h>
@@ -129,11 +130,7 @@ namespace scitt::historical
       {
         // Transaction is pending or not yet cached.
         // Check api-version to decide response style.
-        const auto parsed_query =
-          ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
-        auto it = parsed_query.find("api-version");
-        bool scrapi =
-          it != parsed_query.end() && it->second == SCITT_API_VERSION_SCRAPI;
+        bool scrapi = is_scrapi_api_version(ctx);
 
         if (scrapi)
         {

--- a/app/src/historical/historical_queries_adapter.h
+++ b/app/src/historical/historical_queries_adapter.h
@@ -130,7 +130,7 @@ namespace scitt::historical
       {
         // Transaction is pending or not yet cached.
         // Check api-version to decide response style.
-        bool scrapi = is_scrapi_api_version(ctx);
+        bool scrapi = is_scrapi_v9(ctx);
 
         if (scrapi)
         {

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -249,7 +249,7 @@ namespace scitt
           ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
         const auto wait_for_commit =
           get_query_value<bool>(parsed_query, "waitForCommit").value_or(false);
-        const bool scrapi = is_scrapi_api_version(ctx);
+        const bool scrapi = is_scrapi_v9(ctx);
         if (wait_for_commit)
         {
           ctx.rpc_ctx->set_consensus_committed_function(
@@ -489,9 +489,8 @@ namespace scitt
           ctx.rpc_ctx->set_response_body(cose_receipt);
           ctx.rpc_ctx->set_response_header(
             ccf::http::headers::CONTENT_TYPE,
-            is_scrapi_api_version(ctx) ?
-              CT_SCITT_RECEIPT :
-              ccf::http::headervalues::contenttype::COSE);
+            is_scrapi_v9(ctx) ? CT_SCITT_RECEIPT :
+                                ccf::http::headervalues::contenttype::COSE);
         };
 
       /**
@@ -550,9 +549,8 @@ namespace scitt
           ctx.rpc_ctx->set_response_body(statement);
           ctx.rpc_ctx->set_response_header(
             ccf::http::headers::CONTENT_TYPE,
-            is_scrapi_api_version(ctx) ?
-              CT_SCITT_STATEMENT :
-              ccf::http::headervalues::contenttype::COSE);
+            is_scrapi_v9(ctx) ? CT_SCITT_STATEMENT :
+                                ccf::http::headervalues::contenttype::COSE);
         };
 
       /**

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -280,8 +280,7 @@ namespace scitt
 
               info.rpc_ctx->set_response_status(HTTP_STATUS_CREATED);
               info.rpc_ctx->set_response_header(
-                ccf::http::headers::CONTENT_TYPE,
-                ccf::http::headervalues::contenttype::COSE);
+                ccf::http::headers::CONTENT_TYPE, CT_SCITT_RECEIPT);
               info.rpc_ctx->set_response_header(
                 ccf::http::headers::CCF_TX_ID, info.tx_id.to_str());
               if (host.has_value())
@@ -486,8 +485,7 @@ namespace scitt
 
           ctx.rpc_ctx->set_response_body(cose_receipt);
           ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE,
-            ccf::http::headervalues::contenttype::COSE);
+            ccf::http::headers::CONTENT_TYPE, CT_SCITT_RECEIPT);
         };
 
       /**
@@ -545,8 +543,7 @@ namespace scitt
 
           ctx.rpc_ctx->set_response_body(statement);
           ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE,
-            ccf::http::headervalues::contenttype::COSE);
+            ccf::http::headers::CONTENT_TYPE, CT_SCITT_STATEMENT);
         };
 
       /**

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -253,6 +253,8 @@ namespace scitt
         {
           ctx.rpc_ctx->set_consensus_committed_function(
             [&context_](ccf::endpoints::CommittedTxInfo& info) {
+              auto host =
+                info.rpc_ctx->get_request_header(ccf::http::headers::HOST);
               if (info.status == ccf::FinalTxStatus::Invalid)
               {
                 info.rpc_ctx->set_response_status(
@@ -282,6 +284,15 @@ namespace scitt
                 ccf::http::headervalues::contenttype::COSE);
               info.rpc_ctx->set_response_header(
                 ccf::http::headers::CCF_TX_ID, info.tx_id.to_str());
+              if (host.has_value())
+              {
+                info.rpc_ctx->set_response_header(
+                  ccf::http::headers::LOCATION,
+                  fmt::format(
+                    "https://{}/entries/{}",
+                    host.value(),
+                    info.tx_id.to_str()));
+              }
               info.rpc_ctx->set_response_body(cose_receipt);
             });
         }
@@ -480,13 +491,16 @@ namespace scitt
         };
 
       /**
-       * Resolve Receipt, 2.1.4 in
+       * Resolve Receipt / Query Registration Status, 2.4 and 2.5 in
        * https://datatracker.ietf.org/doc/draft-ietf-scitt-scrapi/
+       *
+       * Returns 302 Found with Retry-After if the transaction is still
+       * pending, or 200 OK with the COSE receipt when committed.
        */
       make_endpoint(
         get_entry_receipt_path,
         HTTP_GET,
-        scitt::historical::entry_adapter(
+        scitt::historical::entry_adapter_with_polling(
           get_entry_receipt, state_cache, is_tx_committed),
         authn_policy)
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -77,7 +77,7 @@ namespace scitt
     std::string_view value = it->second;
     if constexpr (std::is_same_v<T, std::string>)
     {
-      return value;
+      return std::string(value);
     }
     else if constexpr (std::is_same_v<T, bool>)
     {
@@ -115,6 +115,20 @@ namespace scitt
       static_assert(ccf::nonstd::dependent_false<T>::value, "Unsupported type");
       return std::nullopt;
     }
+  }
+
+  /**
+   * Returns true if the request includes api-version=SCITT_API_VERSION_SCRAPI.
+   * Used to gate SCRAPI v09 behavior (303 See Other, 302 Found, new content
+   * types) and preserve backward compatibility for older clients.
+   * Unknown or absent api-version values are treated as legacy.
+   */
+  static bool is_scrapi_api_version(const ccf::endpoints::EndpointContext& ctx)
+  {
+    const auto parsed_query =
+      ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
+    auto version = get_query_value<std::string>(parsed_query, "api-version");
+    return version.has_value() && version.value() == SCITT_API_VERSION_SCRAPI;
   }
 
   /**
@@ -249,10 +263,11 @@ namespace scitt
           ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
         const auto wait_for_commit =
           get_query_value<bool>(parsed_query, "waitForCommit").value_or(false);
+        const bool scrapi = is_scrapi_api_version(ctx);
         if (wait_for_commit)
         {
           ctx.rpc_ctx->set_consensus_committed_function(
-            [&context_](ccf::endpoints::CommittedTxInfo& info) {
+            [&context_, scrapi](ccf::endpoints::CommittedTxInfo& info) {
               auto host =
                 info.rpc_ctx->get_request_header(ccf::http::headers::HOST);
               if (info.status == ccf::FinalTxStatus::Invalid)
@@ -280,7 +295,9 @@ namespace scitt
 
               info.rpc_ctx->set_response_status(HTTP_STATUS_CREATED);
               info.rpc_ctx->set_response_header(
-                ccf::http::headers::CONTENT_TYPE, CT_SCITT_RECEIPT);
+                ccf::http::headers::CONTENT_TYPE,
+                scrapi ? CT_SCITT_RECEIPT :
+                         ccf::http::headervalues::contenttype::COSE);
               info.rpc_ctx->set_response_header(
                 ccf::http::headers::CCF_TX_ID, info.tx_id.to_str());
               if (host.has_value())
@@ -485,7 +502,10 @@ namespace scitt
 
           ctx.rpc_ctx->set_response_body(cose_receipt);
           ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE, CT_SCITT_RECEIPT);
+            ccf::http::headers::CONTENT_TYPE,
+            is_scrapi_api_version(ctx) ?
+              CT_SCITT_RECEIPT :
+              ccf::http::headervalues::contenttype::COSE);
         };
 
       /**
@@ -543,7 +563,10 @@ namespace scitt
 
           ctx.rpc_ctx->set_response_body(statement);
           ctx.rpc_ctx->set_response_header(
-            ccf::http::headers::CONTENT_TYPE, CT_SCITT_STATEMENT);
+            ccf::http::headers::CONTENT_TYPE,
+            is_scrapi_api_version(ctx) ?
+              CT_SCITT_STATEMENT :
+              ccf::http::headervalues::contenttype::COSE);
         };
 
       /**

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -117,24 +117,6 @@ namespace scitt
     }
   }
 
-  namespace
-  {
-    /**
-     * Returns true if the request includes
-     * api-version=SCITT_API_VERSION_SCRAPI. Used to gate SCRAPI v09 behavior
-     * (303 See Other, 302 Found, new content types) and preserve backward
-     * compatibility for older clients. Unknown or absent api-version values are
-     * treated as legacy.
-     */
-    bool is_scrapi_api_version(const ccf::endpoints::EndpointContext& ctx)
-    {
-      const auto parsed_query =
-        ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
-      auto version = get_query_value<std::string>(parsed_query, "api-version");
-      return version.has_value() && version.value() == SCITT_API_VERSION_SCRAPI;
-    }
-  } // anonymous namespace
-
   /**
    * Obtain COSE receipt in the format described in
    * https://datatracker.ietf.org/doc/draft-ietf-cose-merkle-tree-proofs/

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -117,19 +117,23 @@ namespace scitt
     }
   }
 
-  /**
-   * Returns true if the request includes api-version=SCITT_API_VERSION_SCRAPI.
-   * Used to gate SCRAPI v09 behavior (303 See Other, 302 Found, new content
-   * types) and preserve backward compatibility for older clients.
-   * Unknown or absent api-version values are treated as legacy.
-   */
-  static bool is_scrapi_api_version(const ccf::endpoints::EndpointContext& ctx)
+  namespace
   {
-    const auto parsed_query =
-      ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
-    auto version = get_query_value<std::string>(parsed_query, "api-version");
-    return version.has_value() && version.value() == SCITT_API_VERSION_SCRAPI;
-  }
+    /**
+     * Returns true if the request includes
+     * api-version=SCITT_API_VERSION_SCRAPI. Used to gate SCRAPI v09 behavior
+     * (303 See Other, 302 Found, new content types) and preserve backward
+     * compatibility for older clients. Unknown or absent api-version values are
+     * treated as legacy.
+     */
+    bool is_scrapi_api_version(const ccf::endpoints::EndpointContext& ctx)
+    {
+      const auto parsed_query =
+        ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
+      auto version = get_query_value<std::string>(parsed_query, "api-version");
+      return version.has_value() && version.value() == SCITT_API_VERSION_SCRAPI;
+    }
+  } // anonymous namespace
 
   /**
    * Obtain COSE receipt in the format described in

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -496,7 +496,7 @@ namespace scitt
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
 
     // Check if the client requested SCRAPI v09 behavior via api-version.
-    bool scrapi = is_scrapi_api_version(ctx);
+    bool scrapi = is_scrapi_v9(ctx);
 
     if (!scrapi)
     {

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -479,6 +479,8 @@ namespace scitt
    * In this case, it is assumed the handler has set a response body when it set
    * the erroneous status code.
    *
+   * Per SCRAPI v09 section 2.3.2, async registration returns 303 See Other
+   * with Location pointing to /entries/{txid}.
    */
   static void operation_locally_committed_func(
     ccf::endpoints::CommandEndpointContext& ctx, const ccf::TxID& tx_id)
@@ -486,27 +488,17 @@ namespace scitt
     std::string tx_str = tx_id.to_str();
     SCITT_DEBUG("New operation was locally committed with tx={}", tx_str);
 
-    // Even though synchronous operations are set to "Succeeded" in the KV,
-    // they still need to go through consensus, so we tell the client it is
-    // still "running".
-    GetOperation::Out operation{
-      .operation_id = tx_id,
-      .status = OperationStatus::Running,
-      .entry_id = {},
-      .error = {}};
-
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
-    ctx.rpc_ctx->set_response_header(
-      ccf::http::headers::CONTENT_TYPE,
-      ccf::http::headervalues::contenttype::CBOR);
-    ctx.rpc_ctx->set_response_body(operation_to_cbor(operation));
-    ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
 
     if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
     {
+      // SCRAPI v09 2.3.2: Location points to /entries/{txid}
       ctx.rpc_ctx->set_response_header(
         ccf::http::headers::LOCATION,
-        fmt::format("https://{}/operations/{}", *host, tx_str));
+        fmt::format("https://{}/entries/{}", *host, tx_str));
     }
+
+    // SCRAPI v09 2.3.2: Return 303 See Other with empty body
+    ctx.rpc_ctx->set_response_status(HTTP_STATUS_SEE_OTHER);
   }
 }

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -497,8 +497,7 @@ namespace scitt
 
     // Check if the client is a legacy client expecting CBOR (eg. .NET SDK).
     // Legacy clients send Accept: application/cbor and expect 202 + CBOR body.
-    auto accept =
-      ctx.rpc_ctx->get_request_header(ccf::http::headers::ACCEPT);
+    auto accept = ctx.rpc_ctx->get_request_header(ccf::http::headers::ACCEPT);
     bool legacy_client = accept.has_value() &&
       accept.value().find(ccf::http::headervalues::contenttype::CBOR) !=
         std::string::npos;
@@ -518,9 +517,7 @@ namespace scitt
       ctx.rpc_ctx->set_response_body(operation_to_cbor(operation));
       ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
 
-      if (
-        auto host =
-          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
       {
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::LOCATION,
@@ -530,9 +527,7 @@ namespace scitt
     else
     {
       // SCRAPI v09 2.3.2: 303 See Other with Location: /entries/{txid}
-      if (
-        auto host =
-          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
       {
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::LOCATION,

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -483,9 +483,9 @@ namespace scitt
    * with Location pointing to /entries/{txid}.
    *
    * For backward compatibility with legacy clients (eg. .NET SDK) that expect
-   * 202 Accepted with a CBOR body: if the request includes
-   * Accept: application/cbor, the old 202 + CBOR response is returned with
-   * Location: /operations/{txid}.
+   * 202 Accepted with a CBOR body: if the request does not include
+   * api-version=SCITT_API_VERSION_SCRAPI, the old 202 + CBOR response is
+   * returned with Location: /operations/{txid}.
    */
   static void operation_locally_committed_func(
     ccf::endpoints::CommandEndpointContext& ctx, const ccf::TxID& tx_id)
@@ -495,14 +495,14 @@ namespace scitt
 
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
 
-    // Check if the client is a legacy client expecting CBOR (eg. .NET SDK).
-    // Legacy clients send Accept: application/cbor and expect 202 + CBOR body.
-    auto accept = ctx.rpc_ctx->get_request_header(ccf::http::headers::ACCEPT);
-    bool legacy_client = accept.has_value() &&
-      accept.value().find(ccf::http::headervalues::contenttype::CBOR) !=
-        std::string::npos;
+    // Check if the client requested SCRAPI v09 behavior via api-version.
+    const auto parsed_query =
+      ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
+    auto it = parsed_query.find("api-version");
+    bool scrapi =
+      it != parsed_query.end() && it->second == SCITT_API_VERSION_SCRAPI;
 
-    if (legacy_client)
+    if (!scrapi)
     {
       // Legacy flow: 202 Accepted with CBOR body and Location: /operations/
       GetOperation::Out operation{

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -484,7 +484,7 @@ namespace scitt
    *
    * For backward compatibility with legacy clients (eg. .NET SDK) that expect
    * 202 Accepted with a CBOR body: if the request does not include
-   * api-version=SCITT_API_VERSION_SCRAPI, the old 202 + CBOR response is
+   * api-version=SCITT_API_VERSION_2026_03_26, the old 202 + CBOR response is
    * returned with Location: /operations/{txid}.
    */
   static void operation_locally_committed_func(
@@ -496,11 +496,7 @@ namespace scitt
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
 
     // Check if the client requested SCRAPI v09 behavior via api-version.
-    const auto parsed_query =
-      ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
-    auto it = parsed_query.find("api-version");
-    bool scrapi =
-      it != parsed_query.end() && it->second == SCITT_API_VERSION_SCRAPI;
+    bool scrapi = is_scrapi_api_version(ctx);
 
     if (!scrapi)
     {

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -481,6 +481,11 @@ namespace scitt
    *
    * Per SCRAPI v09 section 2.3.2, async registration returns 303 See Other
    * with Location pointing to /entries/{txid}.
+   *
+   * For backward compatibility with legacy clients (eg. .NET SDK) that expect
+   * 202 Accepted with a CBOR body: if the request includes
+   * Accept: application/cbor, the old 202 + CBOR response is returned with
+   * Location: /operations/{txid}.
    */
   static void operation_locally_committed_func(
     ccf::endpoints::CommandEndpointContext& ctx, const ccf::TxID& tx_id)
@@ -490,15 +495,51 @@ namespace scitt
 
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
 
-    if (auto host = ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
-    {
-      // SCRAPI v09 2.3.2: Location points to /entries/{txid}
-      ctx.rpc_ctx->set_response_header(
-        ccf::http::headers::LOCATION,
-        fmt::format("https://{}/entries/{}", *host, tx_str));
-    }
+    // Check if the client is a legacy client expecting CBOR (eg. .NET SDK).
+    // Legacy clients send Accept: application/cbor and expect 202 + CBOR body.
+    auto accept =
+      ctx.rpc_ctx->get_request_header(ccf::http::headers::ACCEPT);
+    bool legacy_client = accept.has_value() &&
+      accept.value().find(ccf::http::headervalues::contenttype::CBOR) !=
+        std::string::npos;
 
-    // SCRAPI v09 2.3.2: Return 303 See Other with empty body
-    ctx.rpc_ctx->set_response_status(HTTP_STATUS_SEE_OTHER);
+    if (legacy_client)
+    {
+      // Legacy flow: 202 Accepted with CBOR body and Location: /operations/
+      GetOperation::Out operation{
+        .operation_id = tx_id,
+        .status = OperationStatus::Running,
+        .entry_id = {},
+        .error = {}};
+
+      ctx.rpc_ctx->set_response_header(
+        ccf::http::headers::CONTENT_TYPE,
+        ccf::http::headervalues::contenttype::CBOR);
+      ctx.rpc_ctx->set_response_body(operation_to_cbor(operation));
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_ACCEPTED);
+
+      if (
+        auto host =
+          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      {
+        ctx.rpc_ctx->set_response_header(
+          ccf::http::headers::LOCATION,
+          fmt::format("https://{}/operations/{}", *host, tx_str));
+      }
+    }
+    else
+    {
+      // SCRAPI v09 2.3.2: 303 See Other with Location: /entries/{txid}
+      if (
+        auto host =
+          ctx.rpc_ctx->get_request_header(ccf::http::headers::HOST))
+      {
+        ctx.rpc_ctx->set_response_header(
+          ccf::http::headers::LOCATION,
+          fmt::format("https://{}/entries/{}", *host, tx_str));
+      }
+
+      ctx.rpc_ctx->set_response_status(HTTP_STATUS_SEE_OTHER);
+    }
   }
 }

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -484,7 +484,7 @@ namespace scitt
    *
    * For backward compatibility with legacy clients (eg. .NET SDK) that expect
    * 202 Accepted with a CBOR body: if the request does not include
-   * api-version=SCITT_API_VERSION_2026_03_26, the old 202 + CBOR response is
+   * api-version=2026-03-26, the old 202 + CBOR response is
    * returned with Location: /operations/{txid}.
    */
   static void operation_locally_committed_func(

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -17,14 +17,13 @@
 namespace scitt
 {
   /**
-   * Returns true if the request includes
-   * api-version=SCITT_API_VERSION_2026_03_26.
-   * Used to gate SCRAPI v09 behavior and preserve backward compatibility
+   * Returns true if the request includes the SCRAPI v9 api-version.
+   * Used to gate SCRAPI v9 behavior and preserve backward compatibility
    * for older clients. Unknown or absent api-version values are treated
    * as legacy.
    */
   template <typename ContextT>
-  bool is_scrapi_api_version(const ContextT& ctx)
+  bool is_scrapi_v9(const ContextT& ctx)
   {
     const auto parsed_query =
       ccf::http::parse_query(ctx.rpc_ctx->get_request_query());

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -3,8 +3,12 @@
 
 #pragma once
 
+#include "constants.h"
+
 #include <ccf/crypto/entropy.h>
 #include <ccf/crypto/pem.h>
+#include <ccf/http_query.h>
+#include <ccf/rpc_context.h>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -12,6 +16,22 @@
 
 namespace scitt
 {
+  /**
+   * Returns true if the request includes
+   * api-version=SCITT_API_VERSION_2026_03_26.
+   * Used to gate SCRAPI v09 behavior and preserve backward compatibility
+   * for older clients. Unknown or absent api-version values are treated
+   * as legacy.
+   */
+  template <typename ContextT>
+  bool is_scrapi_api_version(const ContextT& ctx)
+  {
+    const auto parsed_query =
+      ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
+    auto it = parsed_query.find("api-version");
+    return it != parsed_query.end() &&
+      it->second == SCITT_API_VERSION_2026_03_26;
+  }
   const static ccf::crypto::EntropyPtr ENTROPY = ccf::crypto::get_entropy();
 
   template <typename T, typename U>

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -432,9 +432,7 @@ class BaseClient:
                             kwargs["headers"].pop("content-type", None)
 
                     url = str(httpx.URL(location))
-                    LOG.debug(
-                        f"Following {response.status_code} redirect to {url}"
-                    )
+                    LOG.debug(f"Following {response.status_code} redirect to {url}")
                     continue
 
             log_parts = [method, url]

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -285,7 +285,7 @@ class BaseClient:
         """
         Parse the error response from the server and return a ServiceError instance.
         """
-        if response.is_success:
+        if response.is_success or response.is_redirect:
             return None
 
         content_type = response.headers.get("content-type", CT_APPLICATION_JSON)
@@ -483,11 +483,15 @@ class BaseClient:
         """
         Issue a request, retrying on codes commonly used by CCF applications to indicate that a
         historical query to the KV is in progress and needs to be retried.
+
+        Also retries on 302 Found per SCRAPI v09 section 2.4.1, which
+        indicates the transaction is still pending.
         """
         return self.get(
             *args,
             **kwargs,
             retry_on=[
+                HTTPStatus.FOUND.value,
                 (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
             ]
             + retry_on,
@@ -558,13 +562,28 @@ class Client(BaseClient):
         self,
         signed_statement: bytes,
     ) -> PendingSubmission:
+        """
+        Submit a signed statement asynchronously.
+
+        Per SCRAPI v09, POST /entries returns 303 See Other with a Location
+        header pointing to /entries/{txid}. The txid is extracted from the
+        Location header.
+
+        Falls back to the legacy 202 + CBOR OperationId flow if the server
+        returns 202.
+        """
         headers = {"Content-Type": CT_APPLICATION_COSE}
         resp = self.post(
             "/entries",
             headers=headers,
             content=signed_statement,
         )
+        if resp.status_code == HTTPStatus.SEE_OTHER:
+            location = resp.headers.get("location", "")
+            tx = location.rsplit("/entries/", 1)[-1]
+            return PendingSubmission(tx)
         resp.raise_for_status()
+        # Legacy fallback: 202 with CBOR body
         operation = cbor2.loads(resp.read())
         operation_id = operation["OperationId"]
         return PendingSubmission(operation_id)
@@ -573,13 +592,30 @@ class Client(BaseClient):
         self,
         signed_statement: bytes,
     ) -> Submission:
+        """
+        Submit a signed statement and wait for the transparent statement.
+
+        Per SCRAPI v09, POST /entries returns 303, then polling
+        GET /entries/{txid} returns 302 while running and 200 with the
+        receipt when committed.
+
+        Falls back to the legacy /operations/ polling flow if the server
+        returns 202.
+        """
         headers = {"Content-Type": CT_APPLICATION_COSE}
         resp = self.post(
             "/entries",
             headers=headers,
             content=signed_statement,
         )
+        if resp.status_code == HTTPStatus.SEE_OTHER:
+            location = resp.headers.get("location", "")
+            tx = location.rsplit("/entries/", 1)[-1]
+            self.wait_for_entry(tx)
+            statement = self.get_transparent_statement(tx)
+            return Submission(tx, tx, statement, False)
         resp.raise_for_status()
+        # Legacy fallback
         operation = cbor2.loads(resp.read())
         operation_id = operation["OperationId"]
         tx = self.wait_for_operation(operation_id)
@@ -590,13 +626,29 @@ class Client(BaseClient):
         self,
         signed_statement: bytes,
     ) -> Submission:
+        """
+        Submit a signed statement and wait for the receipt.
+
+        Per SCRAPI v09, POST /entries returns 303, then polling
+        GET /entries/{txid} returns 302 while running and 200 with the
+        receipt when committed.
+
+        Falls back to the legacy /operations/ polling flow if the server
+        returns 202.
+        """
         headers = {"Content-Type": CT_APPLICATION_COSE}
         resp = self.post(
             "/entries",
             headers=headers,
             content=signed_statement,
         )
+        if resp.status_code == HTTPStatus.SEE_OTHER:
+            location = resp.headers.get("location", "")
+            tx = location.rsplit("/entries/", 1)[-1]
+            receipt = self.wait_for_entry(tx)
+            return Submission(tx, tx, receipt, False)
         resp.raise_for_status()
+        # Legacy fallback
         operation = cbor2.loads(resp.read())
         operation_id = operation["OperationId"]
         tx = self.wait_for_operation(operation_id)
@@ -627,6 +679,12 @@ class Client(BaseClient):
         return Submission("", tx, receipt, False)
 
     def wait_for_operation(self, operation: str) -> str:
+        """
+        Legacy polling method using GET /operations/{id}.
+
+        Kept for backward compatibility with older servers that return 202
+        with CBOR operation status.
+        """
         resp = self.get(
             f"/operations/{operation}",
             retry_on=[
@@ -647,6 +705,24 @@ class Client(BaseClient):
             )
         else:
             raise ValueError("Invalid status {}".format(response["Status"]))
+
+    def wait_for_entry(self, tx: str) -> bytes:
+        """
+        Poll GET /entries/{txid} per SCRAPI v09 section 2.4.
+
+        Returns 302 Found while the registration is still running, and
+        200 OK with the COSE receipt when committed.
+        """
+        resp = self.get(
+            f"/entries/{tx}",
+            retry_on=[
+                HTTPStatus.FOUND.value,
+                HTTPStatus.TOO_MANY_REQUESTS.value,
+                HTTPStatus.SERVICE_UNAVAILABLE.value,
+                (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
+            ],
+        )
+        return resp.content
 
     def get_claim(self, tx: str) -> bytes:
         response = self.get_historical(f"/entries/{tx}")

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -33,7 +33,7 @@ CT_APPLICATION_CBOR_ERROR = "application/concise-problem-details+cbor"
 CBOR_ERR_TITLE_TAG = -1
 CBOR_ERR_DETAIL_TAG = -2
 
-SCITT_API_VERSION_SCRAPI = "2026-03-26"
+SCITT_API_VERSION_2026_03_26 = "2026-03-26"
 
 
 class MemberAuthenticationMethod(ABC):
@@ -248,7 +248,7 @@ class BaseClient:
 
         api_version:
             The api-version query parameter sent with SCITT requests.
-            Set to SCITT_API_VERSION_SCRAPI for SCRAPI v09 behavior.
+            Set to SCITT_API_VERSION_2026_03_26 for SCRAPI v09 behavior.
             Defaults to None (legacy behavior).
         """
 

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -332,8 +332,11 @@ class BaseClient:
             rolled-back.
 
         follow_redirects:
-            If True (default), automatically follow 307 and 308 redirect responses, preserving
-            all headers and request metadata. If False, return the redirect response as-is.
+            If True (default), automatically follow redirect responses:
+            - 302 Found: follow Location with Retry-After delay (polling pattern)
+            - 303 See Other: follow Location as GET, dropping the request body
+            - 307/308: follow Location, preserving the HTTP method and body
+            If False, return the redirect response as-is.
 
         Other keyword-arguments are passed to httpx.
         """
@@ -394,18 +397,44 @@ class BaseClient:
         while True:
             response = self.session.request(method, url, **kwargs)
 
-            # Handle 307/308 redirects while preserving headers and request metadata
-            if follow_redirects and response.status_code in (307, 308):
+            # Handle redirects (302 Found, 303 See Other, 307/308)
+            if follow_redirects and response.status_code in (302, 303, 307, 308):
                 location = response.headers.get("location")
                 if location:
-                    redirects += 1
-                    if redirects > max_redirects:
-                        raise ValueError(
-                            f"Too many redirects (exceeded {max_redirects})"
+                    # For 302 with Retry-After (polling pattern), use the
+                    # attempt/deadline counters rather than the redirect counter.
+                    retry_after = response.headers.get("retry-after")
+                    if retry_after:
+                        wait = (
+                            int(retry_after)
+                            if self.wait_time is None
+                            else self.wait_time
                         )
-                    # Resolve relative URLs against the current base URL
+                        if time.monotonic() + wait > deadline:
+                            raise ValueError("Too many retries")
+                        time.sleep(wait)
+                        attempt += 1
+                    else:
+                        redirects += 1
+                        if redirects > max_redirects:
+                            raise ValueError(
+                                f"Too many redirects (exceeded {max_redirects})"
+                            )
+
+                    # 302/303: switch to GET and drop the request body
+                    # (standard HTTP redirect semantics)
+                    if response.status_code in (302, 303):
+                        method = "GET"
+                        kwargs.pop("content", None)
+                        kwargs.pop("json", None)
+                        if "headers" in kwargs:
+                            kwargs["headers"].pop("Content-Type", None)
+                            kwargs["headers"].pop("content-type", None)
+
                     url = str(httpx.URL(location))
-                    LOG.debug(f"Following redirect to {url}")
+                    LOG.debug(
+                        f"Following {response.status_code} redirect to {url}"
+                    )
                     continue
 
             log_parts = [method, url]
@@ -484,14 +513,13 @@ class BaseClient:
         Issue a request, retrying on codes commonly used by CCF applications to indicate that a
         historical query to the KV is in progress and needs to be retried.
 
-        Also retries on 302 Found per SCRAPI v09 section 2.4.1, which
-        indicates the transaction is still pending.
+        302 Found (SCRAPI v09 section 2.4.1, transaction still pending) is
+        handled automatically by the request method's redirect logic.
         """
         return self.get(
             *args,
             **kwargs,
             retry_on=[
-                HTTPStatus.FOUND.value,
                 (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),
             ]
             + retry_on,
@@ -577,6 +605,7 @@ class Client(BaseClient):
             "/entries",
             headers=headers,
             content=signed_statement,
+            follow_redirects=False,
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
@@ -607,6 +636,7 @@ class Client(BaseClient):
             "/entries",
             headers=headers,
             content=signed_statement,
+            follow_redirects=False,
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
@@ -641,6 +671,7 @@ class Client(BaseClient):
             "/entries",
             headers=headers,
             content=signed_statement,
+            follow_redirects=False,
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
@@ -710,13 +741,13 @@ class Client(BaseClient):
         """
         Poll GET /entries/{txid} per SCRAPI v09 section 2.4.
 
-        Returns 302 Found while the registration is still running, and
-        200 OK with the COSE receipt when committed.
+        302 Found (transaction still pending) is handled automatically by
+        the request method's redirect logic with Retry-After support.
+        Returns the COSE receipt when the server responds with 200 OK.
         """
         resp = self.get(
             f"/entries/{tx}",
             retry_on=[
-                HTTPStatus.FOUND.value,
                 HTTPStatus.TOO_MANY_REQUESTS.value,
                 HTTPStatus.SERVICE_UNAVAILABLE.value,
                 (HTTPStatus.SERVICE_UNAVAILABLE, "TransactionNotCached"),

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -225,7 +225,7 @@ class BaseClient:
         wait_time: Optional[float] = None,
         development: bool = False,
         cacert: Optional[str] = None,
-        api_version: Optional[str] = None,
+        api_version: Optional[str] = SCITT_API_VERSION_2026_03_26,
     ):
         """
         Create a new BaseClient instance.
@@ -248,8 +248,8 @@ class BaseClient:
 
         api_version:
             The api-version query parameter sent with SCITT requests.
-            Set to SCITT_API_VERSION_2026_03_26 for SCRAPI v09 behavior.
-            Defaults to None (legacy behavior).
+            Defaults to SCITT_API_VERSION_2026_03_26.
+            Set to None for legacy behavior.
         """
 
         # Even though these are passed to the httpx.Client and not used

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -4,6 +4,7 @@
 import base64
 import hashlib
 import json
+import re
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -31,6 +32,8 @@ CT_SCITT_STATEMENT = "application/scitt-statement+cose"
 CT_APPLICATION_CBOR_ERROR = "application/concise-problem-details+cbor"
 CBOR_ERR_TITLE_TAG = -1
 CBOR_ERR_DETAIL_TAG = -2
+
+SCITT_API_VERSION_SCRAPI = "2026-01-11-preview"
 
 
 class MemberAuthenticationMethod(ABC):
@@ -222,6 +225,7 @@ class BaseClient:
         wait_time: Optional[float] = None,
         development: bool = False,
         cacert: Optional[str] = None,
+        api_version: Optional[str] = None,
     ):
         """
         Create a new BaseClient instance.
@@ -241,6 +245,11 @@ class BaseClient:
 
         cacert:
             If set and development is False, will be used in TLS verification instead of the default bundle.
+
+        api_version:
+            The api-version query parameter sent with SCITT requests.
+            Set to SCITT_API_VERSION_SCRAPI for SCRAPI v09 behavior.
+            Defaults to None (legacy behavior).
         """
 
         # Even though these are passed to the httpx.Client and not used
@@ -252,17 +261,22 @@ class BaseClient:
         self.wait_time = wait_time
         self.development = development
         self.cacert = cacert
+        self.api_version = api_version
 
         headers = {}
         if auth_token:
             headers["Authorization"] = "Bearer " + auth_token
+
+        params = {}
+        if api_version:
+            params["api-version"] = api_version
 
         tls_verification: Union[str, bool] = (
             cacert if cacert is not None else not development
         )
 
         self.session = httpx.Client(
-            base_url=url, headers=headers, verify=tls_verification
+            base_url=url, headers=headers, params=params, verify=tls_verification
         )
 
     def replace(self: SelfClient, **kwargs) -> SelfClient:
@@ -279,6 +293,7 @@ class BaseClient:
             "wait_time": self.wait_time,
             "development": self.development,
             "cacert": self.cacert,
+            "api_version": self.api_version,
         }
         values.update(kwargs)
         return self.__class__(**values)
@@ -337,7 +352,7 @@ class BaseClient:
 
         follow_redirects:
             If True (default), automatically follow redirect responses:
-            - 302 Found: follow Location with Retry-After delay (polling pattern)
+            - 302 Found: poll same Location with default wait (polling pattern)
             - 303 See Other: follow Location as GET, dropping the request body
             - 307/308: follow Location, preserving the HTTP method and body
             If False, return the redirect response as-is.
@@ -405,14 +420,18 @@ class BaseClient:
             if follow_redirects and response.status_code in (302, 303, 307, 308):
                 location = response.headers.get("location")
                 if location:
-                    # For 302 with Retry-After (polling pattern), use the
-                    # attempt/deadline counters rather than the redirect counter.
-                    retry_after = response.headers.get("retry-after")
-                    if retry_after:
+                    if response.status_code == 302:
+                        # 302 Found is used as a polling pattern (same URL).
+                        # Use Retry-After if present, otherwise default wait.
+                        retry_after = response.headers.get("retry-after")
                         wait = (
                             int(retry_after)
-                            if self.wait_time is None
-                            else self.wait_time
+                            if retry_after and self.wait_time is None
+                            else (
+                                self.wait_time
+                                if self.wait_time is not None
+                                else default_wait_time
+                            )
                         )
                         if time.monotonic() + wait > deadline:
                             raise ValueError("Too many retries")
@@ -588,6 +607,17 @@ class Client(BaseClient):
         resp.raise_for_status()
         return resp.json()
 
+    @staticmethod
+    def _extract_tx_from_location(location: str) -> str:
+        """Extract and validate the transaction ID from a Location header."""
+        parts = location.rsplit("/entries/", 1)
+        if len(parts) != 2:
+            raise ValueError(f"Location header does not contain /entries/: {location}")
+        tx = parts[1]
+        if not re.match(r"^\d+\.\d+$", tx):
+            raise ValueError(f"Invalid transaction ID in Location header: {tx}")
+        return tx
+
     def submit_signed_statement(
         self,
         signed_statement: bytes,
@@ -611,7 +641,7 @@ class Client(BaseClient):
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
-            tx = location.rsplit("/entries/", 1)[-1]
+            tx = self._extract_tx_from_location(location)
             return PendingSubmission(tx)
         resp.raise_for_status()
         # Legacy fallback: 202 with CBOR body
@@ -642,7 +672,7 @@ class Client(BaseClient):
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
-            tx = location.rsplit("/entries/", 1)[-1]
+            tx = self._extract_tx_from_location(location)
             self.wait_for_entry(tx)
             statement = self.get_transparent_statement(tx)
             return Submission(tx, tx, statement, False)
@@ -677,7 +707,7 @@ class Client(BaseClient):
         )
         if resp.status_code == HTTPStatus.SEE_OTHER:
             location = resp.headers.get("location", "")
-            tx = location.rsplit("/entries/", 1)[-1]
+            tx = self._extract_tx_from_location(location)
             receipt = self.wait_for_entry(tx)
             return Submission(tx, tx, receipt, False)
         resp.raise_for_status()
@@ -744,7 +774,7 @@ class Client(BaseClient):
         Poll GET /entries/{txid} per SCRAPI v09 section 2.4.
 
         302 Found (transaction still pending) is handled automatically by
-        the request method's redirect logic with Retry-After support.
+        the request method's redirect logic.
         Returns the COSE receipt when the server responds with 200 OK.
         """
         resp = self.get(

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -26,6 +26,8 @@ CCF_TX_ID_HEADER = "x-ms-ccf-transaction-id"
 CT_APPLICATION_JSON = "application/json"
 CT_APPLICATION_CBOR = "application/cbor"
 CT_APPLICATION_COSE = "application/cose"
+CT_SCITT_RECEIPT = "application/scitt-receipt+cose"
+CT_SCITT_STATEMENT = "application/scitt-statement+cose"
 CT_APPLICATION_CBOR_ERROR = "application/concise-problem-details+cbor"
 CBOR_ERR_TITLE_TAG = -1
 CBOR_ERR_DETAIL_TAG = -2
@@ -292,6 +294,8 @@ class BaseClient:
         if (
             content_type == CT_APPLICATION_CBOR
             or content_type == CT_APPLICATION_COSE
+            or content_type == CT_SCITT_RECEIPT
+            or content_type == CT_SCITT_STATEMENT
             or content_type == CT_APPLICATION_CBOR_ERROR
         ):
             error = cbor2.loads(response.read())

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -193,6 +193,46 @@ def test_submit_wait_for_commit(run, tmp_path, cert_authority, configure_service
     assert msg is not None
 
 
+def test_submit_default_async_flow(run, tmp_path, cert_authority, configure_service):
+    """
+    Test the CLI submit command without --wait-for-commit (default).
+    This uses the SCRAPI v09 async flow (POST /entries → 303 → poll → receipt)
+    and saves the transparent statement to the --transparent-statement output path.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    cose_path = tmp_path / "statement.cose"
+    cose_path.write_bytes(signed_statement)
+
+    output_path = tmp_path / "transparent_statement.cose"
+
+    run(
+        "submit",
+        cose_path,
+        "--transparent-statement",
+        output_path,
+        with_service_url=True,
+    )
+
+    assert output_path.exists()
+    receipt_bytes = output_path.read_bytes()
+    assert len(receipt_bytes) > 0
+
+    # Verify the output is valid COSE
+    msg = CoseMessage.decode(receipt_bytes)
+    assert msg is not None
+
+
 @pytest.mark.parametrize(
     "filepath",
     [

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -193,6 +193,46 @@ def test_submit_wait_for_commit(run, tmp_path, cert_authority, configure_service
     assert msg is not None
 
 
+def test_submit_default_async_flow(run, tmp_path, cert_authority, configure_service):
+    """
+    Test the CLI submit command without --wait-for-commit (default).
+    This uses the async flow (POST /entries → poll → receipt)
+    and saves the transparent statement to the --transparent-statement output path.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    cose_path = tmp_path / "statement.cose"
+    cose_path.write_bytes(signed_statement)
+
+    output_path = tmp_path / "transparent_statement.cose"
+
+    run(
+        "submit",
+        cose_path,
+        "--transparent-statement",
+        output_path,
+        with_service_url=True,
+    )
+
+    assert output_path.exists()
+    receipt_bytes = output_path.read_bytes()
+    assert len(receipt_bytes) > 0
+
+    # Verify the output is valid COSE
+    msg = CoseMessage.decode(receipt_bytes)
+    assert msg is not None
+
+
 @pytest.mark.parametrize(
     "filepath",
     [

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -193,46 +193,6 @@ def test_submit_wait_for_commit(run, tmp_path, cert_authority, configure_service
     assert msg is not None
 
 
-def test_submit_default_async_flow(run, tmp_path, cert_authority, configure_service):
-    """
-    Test the CLI submit command without --wait-for-commit (default).
-    This uses the SCRAPI v09 async flow (POST /entries → 303 → poll → receipt)
-    and saves the transparent statement to the --transparent-statement output path.
-    """
-    identity = cert_authority.create_identity(
-        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
-    )
-    configure_service(
-        {
-            "policy": {
-                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
-            }
-        }
-    )
-
-    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
-    cose_path = tmp_path / "statement.cose"
-    cose_path.write_bytes(signed_statement)
-
-    output_path = tmp_path / "transparent_statement.cose"
-
-    run(
-        "submit",
-        cose_path,
-        "--transparent-statement",
-        output_path,
-        with_service_url=True,
-    )
-
-    assert output_path.exists()
-    receipt_bytes = output_path.read_bytes()
-    assert len(receipt_bytes) > 0
-
-    # Verify the output is valid COSE
-    msg = CoseMessage.decode(receipt_bytes)
-    assert msg is not None
-
-
 @pytest.mark.parametrize(
     "filepath",
     [

--- a/test/test_scrapi_registration.py
+++ b/test/test_scrapi_registration.py
@@ -11,18 +11,25 @@ endpoints, including status codes, Location headers, and polling behavior.
 import re
 from http import HTTPStatus
 
+import pytest
 from loguru import logger as LOG
 
 from pyscitt import crypto
-from pyscitt.client import Client
+from pyscitt.client import SCITT_API_VERSION_SCRAPI, Client
 
 CT_APPLICATION_COSE = "application/cose"
 CT_SCITT_RECEIPT = "application/scitt-receipt+cose"
 CT_SCITT_STATEMENT = "application/scitt-statement+cose"
 
 
+@pytest.fixture(scope="class")
+def scrapi_client(client: Client) -> Client:
+    """Client configured with the SCRAPI v09 api-version."""
+    return client.replace(api_version=SCITT_API_VERSION_SCRAPI)
+
+
 def test_async_registration_returns_303(
-    client: Client, cert_authority, configure_service
+    scrapi_client: Client, cert_authority, configure_service
 ):
     """
     POST /entries returns 303 See Other with a Location header pointing
@@ -43,7 +50,7 @@ def test_async_registration_returns_303(
 
     # Make a raw POST without the client's high-level submit logic,
     # so we can inspect the actual HTTP response.
-    resp = client.session.request(
+    resp = scrapi_client.session.request(
         "POST",
         "/entries",
         headers={"Content-Type": CT_APPLICATION_COSE},
@@ -88,7 +95,7 @@ def test_async_registration_returns_303(
 
 
 def test_entry_polling_returns_302_then_200(
-    client: Client, cert_authority, trust_store, configure_service
+    scrapi_client: Client, cert_authority, trust_store, configure_service
 ):
     """
     GET /entries/{txid} returns 302 Found while pending and 200 OK with
@@ -108,15 +115,15 @@ def test_entry_polling_returns_302_then_200(
     signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
 
     # Submit and get the transaction ID
-    submission = client.submit_signed_statement(signed_statement)
+    submission = scrapi_client.submit_signed_statement(signed_statement)
     tx = submission.operation_tx
     LOG.info(f"Submitted, tx={tx}")
 
     # Poll GET /entries/{txid} - first request may return 302 or 200
     # depending on timing. We verify that:
-    # 1. If 302, it has Location and Retry-After headers
+    # 1. If 302, it has Location header
     # 2. Eventually it returns 200 with the receipt
-    first_resp = client.session.request("GET", f"/entries/{tx}")
+    first_resp = scrapi_client.session.request("GET", f"/entries/{tx}")
     LOG.info(f"First GET /entries/{tx} status: {first_resp.status_code}")
     LOG.info(f"First GET /entries/{tx} headers: {dict(first_resp.headers)}")
 
@@ -127,19 +134,16 @@ def test_entry_polling_returns_302_then_200(
         assert (
             f"/entries/{tx}" in location
         ), f"302 Location must point to /entries/{{txid}}, got: {location}"
-
-        retry_after = first_resp.headers.get("retry-after")
-        assert retry_after is not None, "302 response must include Retry-After header"
-        LOG.info(f"302 Location: {location}, Retry-After: {retry_after}")
+        LOG.info(f"302 Location: {location}")
 
     # Now use the client's polling method to wait for the final 200
-    receipt = client.wait_for_entry(tx)
+    receipt = scrapi_client.wait_for_entry(tx)
     assert len(receipt) > 0, "200 response must contain the COSE receipt"
     LOG.info(f"Got receipt, {len(receipt)} bytes")
 
 
 def test_sync_registration_returns_201_with_location(
-    client: Client, cert_authority, configure_service
+    scrapi_client: Client, cert_authority, configure_service
 ):
     """
     POST /entries?waitForCommit=true returns 201 Created with Location header
@@ -158,7 +162,7 @@ def test_sync_registration_returns_201_with_location(
 
     signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
 
-    submission = client.submit_signed_statement_wait_for_commit(signed_statement)
+    submission = scrapi_client.submit_signed_statement_wait_for_commit(signed_statement)
 
     assert submission.tx is not None
     assert (
@@ -170,7 +174,7 @@ def test_sync_registration_returns_201_with_location(
 
 
 def test_submit_and_wait_scrapi_flow(
-    client: Client, cert_authority, trust_store, configure_service
+    scrapi_client: Client, cert_authority, trust_store, configure_service
 ):
     """
     End-to-end test of the SCRAPI v09 registration flow using the
@@ -194,7 +198,7 @@ def test_submit_and_wait_scrapi_flow(
 
     # Use the high-level method that exercises the full SCRAPI v09 flow:
     # POST /entries → 303 → parse Location → poll GET /entries/{txid} → 200
-    submission = client.submit_signed_statement_and_wait(signed_statement)
+    submission = scrapi_client.submit_signed_statement_and_wait(signed_statement)
 
     assert submission.tx is not None
     assert len(submission.response_bytes) > 0
@@ -204,7 +208,7 @@ def test_submit_and_wait_scrapi_flow(
 
 
 def test_submit_and_wait_for_receipt_scrapi_flow(
-    client: Client, cert_authority, trust_store, configure_service
+    scrapi_client: Client, cert_authority, trust_store, configure_service
 ):
     """
     End-to-end test using submit_signed_statement_and_wait_for_receipt(),
@@ -223,7 +227,9 @@ def test_submit_and_wait_for_receipt_scrapi_flow(
 
     signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
 
-    submission = client.submit_signed_statement_and_wait_for_receipt(signed_statement)
+    submission = scrapi_client.submit_signed_statement_and_wait_for_receipt(
+        signed_statement
+    )
 
     assert submission.tx is not None
     assert len(submission.response_bytes) > 0
@@ -232,7 +238,7 @@ def test_submit_and_wait_for_receipt_scrapi_flow(
     )
 
 
-def test_receipt_content_type(client: Client, cert_authority, configure_service):
+def test_receipt_content_type(scrapi_client: Client, cert_authority, configure_service):
     """
     GET /entries/{txid} returns Content-Type: application/scitt-receipt+cose
     per IANA-registered SCITT media types.
@@ -249,15 +255,15 @@ def test_receipt_content_type(client: Client, cert_authority, configure_service)
     )
 
     signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
-    submission = client.submit_signed_statement(signed_statement)
+    submission = scrapi_client.submit_signed_statement(signed_statement)
     tx = submission.operation_tx
 
     # Wait for entry and check the content type on the raw response
-    receipt = client.wait_for_entry(tx)
+    receipt = scrapi_client.wait_for_entry(tx)
     assert len(receipt) > 0
 
     # Make a direct request to verify Content-Type header
-    resp = client.get_historical(f"/entries/{tx}")
+    resp = scrapi_client.get_historical(f"/entries/{tx}")
     content_type = resp.headers.get("content-type")
     LOG.info(f"GET /entries/{tx} Content-Type: {content_type}")
     assert (
@@ -265,7 +271,9 @@ def test_receipt_content_type(client: Client, cert_authority, configure_service)
     ), f"Expected Content-Type {CT_SCITT_RECEIPT}, got {content_type}"
 
 
-def test_sync_receipt_content_type(client: Client, cert_authority, configure_service):
+def test_sync_receipt_content_type(
+    scrapi_client: Client, cert_authority, configure_service
+):
     """
     POST /entries?waitForCommit=true returns Content-Type: application/scitt-receipt+cose.
     """
@@ -282,7 +290,7 @@ def test_sync_receipt_content_type(client: Client, cert_authority, configure_ser
 
     signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
 
-    resp = client.post(
+    resp = scrapi_client.post(
         "/entries",
         params={"waitForCommit": "true"},
         headers={"Content-Type": CT_APPLICATION_COSE},
@@ -298,7 +306,7 @@ def test_sync_receipt_content_type(client: Client, cert_authority, configure_ser
 
 
 def test_transparent_statement_content_type(
-    client: Client, cert_authority, configure_service
+    scrapi_client: Client, cert_authority, configure_service
 ):
     """
     GET /entries/{txid}/statement returns Content-Type: application/scitt-statement+cose.
@@ -315,10 +323,10 @@ def test_transparent_statement_content_type(
     )
 
     signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
-    submission = client.submit_signed_statement_and_wait(signed_statement)
+    submission = scrapi_client.submit_signed_statement_and_wait(signed_statement)
     tx = submission.tx
 
-    resp = client.get_historical(f"/entries/{tx}/statement")
+    resp = scrapi_client.get_historical(f"/entries/{tx}/statement")
     content_type = resp.headers.get("content-type")
     LOG.info(f"GET /entries/{tx}/statement Content-Type: {content_type}")
     assert (

--- a/test/test_scrapi_registration.py
+++ b/test/test_scrapi_registration.py
@@ -17,6 +17,8 @@ from pyscitt import crypto
 from pyscitt.client import Client
 
 CT_APPLICATION_COSE = "application/cose"
+CT_SCITT_RECEIPT = "application/scitt-receipt+cose"
+CT_SCITT_STATEMENT = "application/scitt-statement+cose"
 
 
 def test_async_registration_returns_303(
@@ -228,3 +230,97 @@ def test_submit_and_wait_for_receipt_scrapi_flow(
     LOG.info(
         f"submit_and_wait_for_receipt tx={submission.tx}, receipt={len(submission.response_bytes)} bytes"
     )
+
+
+def test_receipt_content_type(client: Client, cert_authority, configure_service):
+    """
+    GET /entries/{txid} returns Content-Type: application/scitt-receipt+cose
+    per IANA-registered SCITT media types.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    submission = client.submit_signed_statement(signed_statement)
+    tx = submission.operation_tx
+
+    # Wait for entry and check the content type on the raw response
+    receipt = client.wait_for_entry(tx)
+    assert len(receipt) > 0
+
+    # Make a direct request to verify Content-Type header
+    resp = client.get_historical(f"/entries/{tx}")
+    content_type = resp.headers.get("content-type")
+    LOG.info(f"GET /entries/{tx} Content-Type: {content_type}")
+    assert (
+        content_type == CT_SCITT_RECEIPT
+    ), f"Expected Content-Type {CT_SCITT_RECEIPT}, got {content_type}"
+
+
+def test_sync_receipt_content_type(client: Client, cert_authority, configure_service):
+    """
+    POST /entries?waitForCommit=true returns Content-Type: application/scitt-receipt+cose.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    resp = client.post(
+        "/entries",
+        params={"waitForCommit": "true"},
+        headers={"Content-Type": CT_APPLICATION_COSE},
+        content=signed_statement,
+    )
+    resp.raise_for_status()
+
+    content_type = resp.headers.get("content-type")
+    LOG.info(f"POST /entries?waitForCommit=true Content-Type: {content_type}")
+    assert (
+        content_type == CT_SCITT_RECEIPT
+    ), f"Expected Content-Type {CT_SCITT_RECEIPT}, got {content_type}"
+
+
+def test_transparent_statement_content_type(
+    client: Client, cert_authority, configure_service
+):
+    """
+    GET /entries/{txid}/statement returns Content-Type: application/scitt-statement+cose.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+    submission = client.submit_signed_statement_and_wait(signed_statement)
+    tx = submission.tx
+
+    resp = client.get_historical(f"/entries/{tx}/statement")
+    content_type = resp.headers.get("content-type")
+    LOG.info(f"GET /entries/{tx}/statement Content-Type: {content_type}")
+    assert (
+        content_type == CT_SCITT_STATEMENT
+    ), f"Expected Content-Type {CT_SCITT_STATEMENT}, got {content_type}"

--- a/test/test_scrapi_registration.py
+++ b/test/test_scrapi_registration.py
@@ -1,0 +1,230 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Tests for SCRAPI v09 registration flow (sections 2.3-2.5).
+
+These tests verify the HTTP-level behavior of the SCRAPI v09 registration
+endpoints, including status codes, Location headers, and polling behavior.
+"""
+
+import re
+from http import HTTPStatus
+
+from loguru import logger as LOG
+
+from pyscitt import crypto
+from pyscitt.client import Client
+
+CT_APPLICATION_COSE = "application/cose"
+
+
+def test_async_registration_returns_303(
+    client: Client, cert_authority, configure_service
+):
+    """
+    POST /entries returns 303 See Other with a Location header pointing
+    to /entries/{txid} per SCRAPI v09 section 2.3.2.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    # Make a raw POST without the client's high-level submit logic,
+    # so we can inspect the actual HTTP response.
+    resp = client.session.request(
+        "POST",
+        "/entries",
+        headers={"Content-Type": CT_APPLICATION_COSE},
+        content=signed_statement,
+    )
+
+    LOG.info(f"POST /entries status: {resp.status_code}")
+    LOG.info(f"POST /entries headers: {dict(resp.headers)}")
+
+    assert (
+        resp.status_code == HTTPStatus.SEE_OTHER
+    ), f"Expected 303 See Other, got {resp.status_code}"
+
+    # Verify Location header exists and points to /entries/{txid}
+    location = resp.headers.get("location")
+    assert location is not None, "303 response must include Location header"
+    assert (
+        "/entries/" in location
+    ), f"Location header must point to /entries/{{txid}}, got: {location}"
+
+    # Verify the Location contains a valid transaction ID (view.seqno format)
+    tx_match = re.search(r"/entries/(\d+\.\d+)", location)
+    assert (
+        tx_match is not None
+    ), f"Location must contain a txid in view.seqno format, got: {location}"
+    tx_id = tx_match.group(1)
+    LOG.info(f"Transaction ID from Location: {tx_id}")
+
+    # Verify x-ms-ccf-transaction-id header is present
+    ccf_tx_id = resp.headers.get("x-ms-ccf-transaction-id")
+    assert (
+        ccf_tx_id is not None
+    ), "303 response must include x-ms-ccf-transaction-id header"
+    assert (
+        ccf_tx_id == tx_id
+    ), f"Transaction ID mismatch: Location has {tx_id}, header has {ccf_tx_id}"
+
+    # Verify body is empty (SCRAPI v09 2.3.2: empty body on 303)
+    assert (
+        len(resp.content) == 0
+    ), f"303 response body must be empty, got {len(resp.content)} bytes"
+
+
+def test_entry_polling_returns_302_then_200(
+    client: Client, cert_authority, trust_store, configure_service
+):
+    """
+    GET /entries/{txid} returns 302 Found while pending and 200 OK with
+    the receipt when committed, per SCRAPI v09 sections 2.4.1 and 2.4.2.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    # Submit and get the transaction ID
+    submission = client.submit_signed_statement(signed_statement)
+    tx = submission.operation_tx
+    LOG.info(f"Submitted, tx={tx}")
+
+    # Poll GET /entries/{txid} - first request may return 302 or 200
+    # depending on timing. We verify that:
+    # 1. If 302, it has Location and Retry-After headers
+    # 2. Eventually it returns 200 with the receipt
+    first_resp = client.session.request("GET", f"/entries/{tx}")
+    LOG.info(f"First GET /entries/{tx} status: {first_resp.status_code}")
+    LOG.info(f"First GET /entries/{tx} headers: {dict(first_resp.headers)}")
+
+    if first_resp.status_code == HTTPStatus.FOUND:
+        # Verify 302 response has required headers per SCRAPI v09 2.4.1
+        location = first_resp.headers.get("location")
+        assert location is not None, "302 response must include Location header"
+        assert (
+            f"/entries/{tx}" in location
+        ), f"302 Location must point to /entries/{{txid}}, got: {location}"
+
+        retry_after = first_resp.headers.get("retry-after")
+        assert retry_after is not None, "302 response must include Retry-After header"
+        LOG.info(f"302 Location: {location}, Retry-After: {retry_after}")
+
+    # Now use the client's polling method to wait for the final 200
+    receipt = client.wait_for_entry(tx)
+    assert len(receipt) > 0, "200 response must contain the COSE receipt"
+    LOG.info(f"Got receipt, {len(receipt)} bytes")
+
+
+def test_sync_registration_returns_201_with_location(
+    client: Client, cert_authority, configure_service
+):
+    """
+    POST /entries?waitForCommit=true returns 201 Created with Location header
+    and the COSE receipt in the response body.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    submission = client.submit_signed_statement_wait_for_commit(signed_statement)
+
+    assert submission.tx is not None
+    assert (
+        len(submission.response_bytes) > 0
+    ), "Sync mode must return the COSE receipt in the response body"
+    LOG.info(
+        f"Sync submit tx={submission.tx}, receipt={len(submission.response_bytes)} bytes"
+    )
+
+
+def test_submit_and_wait_scrapi_flow(
+    client: Client, cert_authority, trust_store, configure_service
+):
+    """
+    End-to-end test of the SCRAPI v09 registration flow using the
+    high-level client methods: submit → poll → get transparent statement.
+
+    Verifies that submit_signed_statement_and_wait() works correctly
+    with the 303 → 302/200 polling flow.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    # Use the high-level method that exercises the full SCRAPI v09 flow:
+    # POST /entries → 303 → parse Location → poll GET /entries/{txid} → 200
+    submission = client.submit_signed_statement_and_wait(signed_statement)
+
+    assert submission.tx is not None
+    assert len(submission.response_bytes) > 0
+    LOG.info(
+        f"submit_and_wait tx={submission.tx}, response={len(submission.response_bytes)} bytes"
+    )
+
+
+def test_submit_and_wait_for_receipt_scrapi_flow(
+    client: Client, cert_authority, trust_store, configure_service
+):
+    """
+    End-to-end test using submit_signed_statement_and_wait_for_receipt(),
+    which exercises the SCRAPI v09 303 → polling → receipt flow.
+    """
+    identity = cert_authority.create_identity(
+        alg="ES256", kty="ec", ec_curve="P-256", add_eku="2.999"
+    )
+    configure_service(
+        {
+            "policy": {
+                "policyScript": f'export function apply(phdr) {{ return phdr.cwt.iss === "{identity.issuer}"; }}'
+            }
+        }
+    )
+
+    signed_statement = crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    submission = client.submit_signed_statement_and_wait_for_receipt(signed_statement)
+
+    assert submission.tx is not None
+    assert len(submission.response_bytes) > 0
+    LOG.info(
+        f"submit_and_wait_for_receipt tx={submission.tx}, receipt={len(submission.response_bytes)} bytes"
+    )

--- a/test/test_scrapi_registration.py
+++ b/test/test_scrapi_registration.py
@@ -15,7 +15,7 @@ import pytest
 from loguru import logger as LOG
 
 from pyscitt import crypto
-from pyscitt.client import SCITT_API_VERSION_SCRAPI, Client
+from pyscitt.client import SCITT_API_VERSION_2026_03_26, Client
 
 CT_APPLICATION_COSE = "application/cose"
 CT_SCITT_RECEIPT = "application/scitt-receipt+cose"
@@ -25,7 +25,7 @@ CT_SCITT_STATEMENT = "application/scitt-statement+cose"
 @pytest.fixture(scope="class")
 def scrapi_client(client: Client) -> Client:
     """Client configured with the SCRAPI v09 api-version."""
-    return client.replace(api_version=SCITT_API_VERSION_SCRAPI)
+    return client.replace(api_version=SCITT_API_VERSION_2026_03_26)
 
 
 def test_async_registration_returns_303(


### PR DESCRIPTION
## Summary

This PR aligns the SCITT CCF ledger registration flow with **SCRAPI v09 sections 2.3-2.5**, gated behind the `api-version` query parameter for full backward compatibility.

All SCRAPI v9 behavior changes are opt-in via `?api-version=2026-03-26`. Clients that do not send this parameter (or send any other value) continue to get the existing legacy behavior with **zero changes** to request/response format.

## How api-version gating works

| Behavior | `api-version=2026-03-26` (SCRAPI v9) | No api-version / other value (Legacy) |
|---|---|---|
| **POST /entries** (async) | `303 See Other` + `Location: /entries/{txid}` | `202 Accepted` + CBOR body + `Location: /operations/{txid}` |
| **POST /entries?waitForCommit=true** (sync) | `201 Created` with `Content-Type: application/scitt-receipt+cose` | `201 Created` with `Content-Type: application/cose` |
| **Polling (SCRAPI)**: GET /entries/{txid} | `302 Found` + `Location` while pending, `200` with receipt when committed | N/A |
| **Polling (Legacy)**: GET /operations/{txid} | N/A | `503 Service Unavailable` while pending, `200` with CBOR status when committed |
| **GET /entries/{txid}** (committed) | `Content-Type: application/scitt-receipt+cose` | `Content-Type: application/cose` |
| **GET /entries/{txid}/statement** | `Content-Type: application/scitt-statement+cose` | `Content-Type: application/cose` |

### Endpoint flow comparison

**SCRAPI flow** (`api-version=2026-03-26`):
```
POST /entries -> 303 See Other (Location: /entries/{txid})
GET /entries/{txid} -> 302 Found (retry) ... -> 200 OK (receipt)
```

**Legacy flow** (no api-version):
```
POST /entries -> 202 Accepted (Location: /operations/{txid}, CBOR body)
GET /operations/{txid} -> 503 (retry) ... -> 200 OK (CBOR status)
GET /entries/{txid} -> receipt
```

Key distinction: SCRAPI uses `/entries/{txid}` for both polling and receipt retrieval. Legacy uses `/operations/{txid}` for polling and `/entries/{txid}` only for the final receipt.

## Key design decisions

- **api-version over Accept header**: The .NET SDK sends `Accept: "application/cose; application/cbor"` AND `api-version` on every request. Using Accept for gating was brittle and non-deterministic. The api-version query parameter is explicit and already used by the .NET SDK.
- **Unknown versions treated as legacy**: No 400 error for unrecognized api-version values -- they silently fall through to legacy behavior. This avoids breaking clients that send future or unknown versions.
- **No Retry-After header on 302**: Removed per reviewer feedback. The Python client uses a default 2s wait between 302 polls instead.
- **Python client defaults to SCRAPI v9**: `api_version=SCITT_API_VERSION_2026_03_26` by default. Set to `None` for legacy behavior.

## Changes

### C++ (server-side)
- **`constants.h`**: Added `SCITT_API_VERSION_2026_03_26`, `CT_SCITT_RECEIPT`, `CT_SCITT_STATEMENT` constants
- **`util.h`**: Added `is_scrapi_v9<ContextT>()` template function to check api-version, shared across all endpoints
- **`main.cpp`**: Gated sync 201 content type, GET receipt content type, GET statement content type on `is_scrapi_v9(ctx)`
- **`operations_endpoints.h`**: Gated POST /entries async response on api-version: SCRAPI returns 303 + `Location: /entries/{txid}`, legacy returns 202 + CBOR + `Location: /operations/{txid}`
- **`historical_queries_adapter.h`**: Added `entry_adapter_with_polling()` that returns 302 (SCRAPI) or re-throws 503 (legacy) based on api-version

### Python (client-side)
- **`client.py`**: Added `api_version` parameter to `BaseClient` (defaults to `SCITT_API_VERSION_2026_03_26`); session-level `api-version` query param; tx ID validation with regex; 302 polling with default wait; `_extract_tx_from_location()` helper

### Tests
- **`test_scrapi_registration.py`**: 8 SCRAPI tests using dedicated `scrapi_client` fixture: async 303, 302 polling, sync 201, end-to-end flows, content type assertions
- **`test_cli.py`**: Added `test_submit_default_async_flow` to test the default CLI submit path (async poll without `--wait-for-commit`)
- All **existing tests pass** (110 passed, 2 skipped), confirming backward compatibility
- CI checks pass (clang-format, clang-tidy, black, mypy, isort, copyright)

## Reviewer feedback addressed

- ivarprudnikov: Switch from Accept header to api-version ✅
- ivarprudnikov: Gate 302 vs 503 on api-version ✅
- ivarprudnikov: Remove Retry-After header ✅
- ivarprudnikov: Validate tx ID in Python client ✅
- ivarprudnikov: Rename function to `is_scrapi_v9` ✅
- ivarprudnikov: Default `api_version` to current version ✅
- achamayou: Use httpx follow_redirects ✅
- achamayou: +1 naming to `scrapi_v9` ✅
- andpiccione: IANA-registered SCITT content types ✅
- andpiccione: Rename constant to `SCITT_API_VERSION_2026_03_26` ✅
- andpiccione: Reuse helper function in `operations_endpoints.h` ✅
- andpiccione: Reuse helper function in `historical_queries_adapter.h` ✅