### PR TITLE
add dotnet sdk evaluation regression test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install dotnet test dependencies
         if: "${{ matrix.platform.name != 'snp' }}"
         run: |
-          tdnf install -y tdnf install dotnet-sdk-8.0.x86_64
+          tdnf install -y dotnet-sdk-8.0.x86_64
       - run: ./run_functional_tests.sh
         if: "${{ matrix.platform.name != 'snp' }}" # Functional tests are not supported on SNP platform
       - name: "Upload logs for ${{ matrix.platform.name }}"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,6 +48,7 @@ jobs:
         # Additional CMake flags.
         PLATFORM: ${{ matrix.platform.name }}
         ENABLE_CLANG_TIDY: ON
+        ENABLE_DOTNET_TESTS: 1
     steps:
       - name: Setup environment
         run: |
@@ -66,7 +67,7 @@ jobs:
       - run: ./scripts/setup-env.sh
       - run: ./build.sh
       - run: ./run_functional_tests.sh
-        if: "${{ matrix.platform.name != 'snp' }}" # Functional tests are not supported on SNP platform for the moment
+        if: "${{ matrix.platform.name != 'snp' }}" # Functional tests are not supported on SNP platform
       - name: "Upload logs for ${{ matrix.platform.name }}"
         uses: actions/upload-artifact@v4
         if: success() || failure()

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,6 +66,10 @@ jobs:
 
       - run: ./scripts/setup-env.sh
       - run: ./build.sh
+      - name: Install dotnet test dependencies
+        if: "${{ matrix.platform.name != 'snp' }}"
+        run: |
+          tdnf install -y tdnf install dotnet-sdk-8.0.x86_64
       - run: ./run_functional_tests.sh
         if: "${{ matrix.platform.name != 'snp' }}" # Functional tests are not supported on SNP platform
       - name: "Upload logs for ${{ matrix.platform.name }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,12 @@ jobs:
     name: Analyze
     
     runs-on: [self-hosted, 1ES.Pool=gha-scitt-pool]
-    container: mcr.microsoft.com/azurelinux/base/core:3.0
+    container:
+      image: mcr.microsoft.com/azurelinux/base/core:3.0
+      options: --user root --publish-all --cap-add NET_ADMIN --cap-add NET_RAW --cap-add SYS_PTRACE -v /lib/modules:/lib/modules:ro
+      env:
+        SCITT_CI: 1
+        PLATFORM: virtual
     
     permissions:
       actions: read
@@ -77,8 +82,7 @@ jobs:
     
     - if: matrix.language == 'cpp'
       name: Build C++
-      run: |
-        PLATFORM=virtual ./build.sh
+      run: ./build.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ perf.json
 **/*.cbor
 demo-poc/
 _codeql_detected_source_root
+
+# dotnet related
+bin
+obj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.17.1]
+### Changes
+- b7c45ce Update CCF version from 6.0.26 to 6.0.27 (#389)
+- 326610f Fix Python warnings from `test_load` (#388)
+
 ## [0.17.0]
 ### Changes
 - 2926513 revert early cache cleanup and update local load test scripts to measure e2e latency (#387)
@@ -426,3 +431,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.16.4]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.16.4
 [0.16.5]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.16.5
 [0.17.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.0
+[0.17.1]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.1

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -10,6 +10,9 @@ PLATFORM=${PLATFORM:-snp}
 # Variable to enable performance tests
 ENABLE_PERF_TESTS=${ENABLE_PERF_TESTS:-}
 
+# Variable to enable .NET SDK tests
+ENABLE_DOTNET_TESTS=${ENABLE_DOTNET_TESTS:-}
+
 # SNP attestation config
 SNP_ATTESTATION_CONFIG=${SNP_ATTESTATION_CONFIG:-}
 
@@ -70,6 +73,18 @@ echo "Using pip index URL: ${PIP_INDEX_URL:-default}"
 pip install --disable-pip-version-check -q -e ./pyscitt
 pip install --disable-pip-version-check -q wheel
 pip install --disable-pip-version-check -q -r test/requirements.txt
+
+# Enable .NET SDK tests if the variable is set
+if [ -n "$ENABLE_DOTNET_TESTS" ]; then
+    TEST_ARGS="$TEST_ARGS --enable-dotnet"
+    echo ".NET SDK tests enabled"
+    echo "Preparing .NET functional test project."
+    if ! command -v dotnet > /dev/null; then
+        echo "dotnet SDK is required to run the .NET functional tests."
+        exit 1
+    fi
+    dotnet restore ./test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj
+fi
 
 # Enable performance tests if the variable is set
 if [ -n "$ENABLE_PERF_TESTS" ]; then

--- a/run_functional_tests.sh
+++ b/run_functional_tests.sh
@@ -11,7 +11,7 @@ PLATFORM=${PLATFORM:-snp}
 ENABLE_PERF_TESTS=${ENABLE_PERF_TESTS:-}
 
 # Variable to enable .NET SDK tests
-ENABLE_DOTNET_TESTS=${ENABLE_DOTNET_TESTS:-}
+ENABLE_DOTNET_TESTS=${ENABLE_DOTNET_TESTS:-0}
 
 # SNP attestation config
 SNP_ATTESTATION_CONFIG=${SNP_ATTESTATION_CONFIG:-}
@@ -75,7 +75,7 @@ pip install --disable-pip-version-check -q wheel
 pip install --disable-pip-version-check -q -r test/requirements.txt
 
 # Enable .NET SDK tests if the variable is set
-if [ -n "$ENABLE_DOTNET_TESTS" ]; then
+if [ "$ENABLE_DOTNET_TESTS" = "1" ]; then
     TEST_ARGS="$TEST_ARGS --enable-dotnet"
     echo ".NET SDK tests enabled"
     echo "Preparing .NET functional test project."

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Enable performance tests",
     )
+    parser.addoption(
+        "--enable-dotnet",
+        action="store_true",
+        help="Enable .NET SDK tests",
+    )
 
 
 def pytest_configure(config):
@@ -23,8 +28,19 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--enable-perf"):
-        perf_skip = pytest.mark.skip(reason="performance testing was not enabled")
+        perf_skip = pytest.mark.skip(
+            reason="performance testing was not enabled; use --enable-perf"
+        )
 
         for item in items:
             if "perf" in item.keywords:
                 item.add_marker(perf_skip)
+
+    if not config.getoption("--enable-dotnet"):
+        dotnet_skip = pytest.mark.skip(
+            reason="dotnet testing was not selected; use --enable-dotnet"
+        )
+
+        for item in items:
+            if "dotnet" in item.keywords:
+                item.add_marker(dotnet_skip)

--- a/test/e2e_dotnet_sdk/Program.cs
+++ b/test/e2e_dotnet_sdk/Program.cs
@@ -2,7 +2,9 @@
 
 using System.Formats.Cbor;
 using System.Net.Http;
+using System.Net.Security;
 using System.Security.Cryptography.Cose;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Azure;
 using Azure.Core.Pipeline;
@@ -17,7 +19,7 @@ class Program
     private const string OperationSubmit = "submit";
     private const string OperationVerify = "verify";
     private const string EndpointArgument = "--endpoint";
-    private const string AllowInsecureTlsArgument = "--allow-insecure-tls";
+    private const string CaCertificateArgument = "--ca-certificate";
 
 
     static void Main(string[] args)
@@ -32,13 +34,16 @@ class Program
         }
 
         Uri? endpoint = parsedArguments.Endpoint;
-        bool allowInsecureTls = parsedArguments.AllowInsecureTls;
+        string? caCertificatePath = parsedArguments.CaCertificatePath;
 
         if (endpoint is not null)
         {
             Console.WriteLine($"Using endpoint {{{endpoint}}}");
         }
-        Console.WriteLine($"Development TLS bypass {{{allowInsecureTls}}}");
+        if (caCertificatePath is not null)
+        {
+            Console.WriteLine($"Using CA certificate {{{caCertificatePath}}}");
+        }
 
         Console.WriteLine("Reading the input file...");
         using FileStream fileStream = File.OpenRead(parsedArguments.InputPath);
@@ -55,16 +60,9 @@ class Program
             {
                 options.IdentityClientEndpoint = resolvedIdentityEndpoint.ToString();
             }
-            // In the development environment, we are likely a self-signed certificate
-            if (allowInsecureTls)
+            if (caCertificatePath is not null)
             {
-                HttpClientHandler handler = new()
-                {
-                    ServerCertificateCustomValidationCallback =
-                        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-                };
-                HttpClient httpClient = new(handler);
-                options.Transport = new HttpClientTransport(httpClient);
+                options.Transport = CreateHttpClientTransport(caCertificatePath);
             }
             CodeTransparencyClient client = new CodeTransparencyClient(submitEndpoint, options);
 
@@ -98,17 +96,10 @@ class Program
                 AuthorizedReceiptBehavior = AuthorizedReceiptBehavior.VerifyAllMatching,
                 UnauthorizedReceiptBehavior = UnauthorizedReceiptBehavior.FailIfPresent
             };
-            // Overriding the client options to make sure it pulls down the public keys from the development server which is using self signed keys
             CodeTransparencyClientOptions clientOptions = new();
-            if (allowInsecureTls)
+            if (caCertificatePath is not null)
             {
-                HttpClientHandler handler = new()
-                {
-                    ServerCertificateCustomValidationCallback =
-                        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-                };
-                HttpClient httpClient = new(handler);
-                clientOptions.Transport = new HttpClientTransport(httpClient);
+                clientOptions.Transport = CreateHttpClientTransport(caCertificatePath);
             }
             CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, clientOptions);
             Console.WriteLine("Verification succeeded: The statement was registered in the immutable ledger.");
@@ -121,7 +112,7 @@ class Program
     {
         List<string> positionals = new();
         Uri? endpoint = null;
-        bool allowInsecureTls = false;
+        string? caCertificatePath = null;
 
         for (int index = 0; index < args.Length; index++)
         {
@@ -138,9 +129,14 @@ class Program
                 continue;
             }
 
-            if (argument == AllowInsecureTlsArgument)
+            if (argument == CaCertificateArgument)
             {
-                allowInsecureTls = true;
+                if (index + 1 >= args.Length)
+                {
+                    throw new ArgumentException($"Missing value for {CaCertificateArgument}");
+                }
+
+                caCertificatePath = args[++index];
                 continue;
             }
 
@@ -182,7 +178,58 @@ class Program
             throw new ArgumentException("Too many positional arguments for verify");
         }
 
-        return new ParsedArguments(operation, inputPath, outputPath, endpoint, allowInsecureTls);
+        return new ParsedArguments(operation, inputPath, outputPath, endpoint, caCertificatePath);
+    }
+
+    private static HttpClientTransport CreateHttpClientTransport(string caCertificatePath)
+    {
+        X509Certificate2 trustedCertificate = LoadCertificate(caCertificatePath);
+        HttpClientHandler handler = new()
+        {
+            ServerCertificateCustomValidationCallback = (_, certificate, _, sslPolicyErrors) =>
+                ValidateServerCertificate(certificate, trustedCertificate, sslPolicyErrors),
+        };
+
+        return new HttpClientTransport(new HttpClient(handler));
+    }
+
+    private static X509Certificate2 LoadCertificate(string certificatePath)
+    {
+        byte[] rawBytes = File.ReadAllBytes(certificatePath);
+        string certificateText = Encoding.ASCII.GetString(rawBytes);
+
+        return certificateText.Contains("BEGIN CERTIFICATE", StringComparison.Ordinal)
+            ? X509Certificate2.CreateFromPem(certificateText)
+            : new X509Certificate2(rawBytes);
+    }
+
+    private static bool ValidateServerCertificate(
+        X509Certificate2? certificate,
+        X509Certificate2 trustedCertificate,
+        SslPolicyErrors sslPolicyErrors)
+    {
+        if (certificate is null)
+        {
+            return false;
+        }
+
+        if (sslPolicyErrors == SslPolicyErrors.None)
+        {
+            return true;
+        }
+
+        if (certificate.RawDataMemory.Span.SequenceEqual(trustedCertificate.RawDataMemory.Span))
+        {
+            return true;
+        }
+
+        using X509Chain chain = new();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+        chain.ChainPolicy.CustomTrustStore.Add(trustedCertificate);
+        chain.ChainPolicy.ExtraStore.Add(trustedCertificate);
+
+        return chain.Build(certificate);
     }
 
     private static Uri ParseAbsoluteUri(string value, string argumentName)
@@ -211,12 +258,12 @@ class Program
         string inputPath,
         string? outputPath,
         Uri? endpoint,
-        bool allowInsecureTls)
+        string? caCertificatePath)
     {
         public string Operation { get; } = operation;
         public string InputPath { get; } = inputPath;
         public string? OutputPath { get; } = outputPath;
         public Uri? Endpoint { get; } = endpoint;
-        public bool AllowInsecureTls { get; } = allowInsecureTls;
+        public string? CaCertificatePath { get; } = caCertificatePath;
     }
 }

--- a/test/e2e_dotnet_sdk/Program.cs
+++ b/test/e2e_dotnet_sdk/Program.cs
@@ -1,0 +1,222 @@
+﻿namespace dotnetctscli;
+
+using System.Formats.Cbor;
+using System.Net.Http;
+using System.Security.Cryptography.Cose;
+using System.Text;
+using Azure;
+using Azure.Core.Pipeline;
+using Azure.Security.CodeTransparency;
+using Azure.Security.CodeTransparency.Receipt;
+
+/// <summary>
+/// The main entry point of this script which will be executed in the python test.
+/// </summary>
+class Program
+{
+    private const string OperationSubmit = "submit";
+    private const string OperationVerify = "verify";
+    private const string EndpointArgument = "--endpoint";
+    private const string AllowInsecureTlsArgument = "--allow-insecure-tls";
+
+
+    static void Main(string[] args)
+    {
+        ParsedArguments parsedArguments = ParseArguments(args);
+
+        string operationArgumentValue = parsedArguments.Operation;
+        if (operationArgumentValue != OperationSubmit && operationArgumentValue != OperationVerify)
+        {
+            Console.WriteLine($"First argument must be the operation name, one of [{OperationSubmit}, {OperationVerify}], got {{{ operationArgumentValue }}}");
+            throw new ArgumentException("Invalid operation name");
+        }
+
+        Uri? endpoint = parsedArguments.Endpoint;
+        bool allowInsecureTls = parsedArguments.AllowInsecureTls;
+
+        if (endpoint is not null)
+        {
+            Console.WriteLine($"Using endpoint {{{endpoint}}}");
+        }
+        Console.WriteLine($"Development TLS bypass {{{allowInsecureTls}}}");
+
+        Console.WriteLine("Reading the input file...");
+        using FileStream fileStream = File.OpenRead(parsedArguments.InputPath);
+        BinaryData content = BinaryData.FromStream(fileStream);
+
+        if (operationArgumentValue == OperationSubmit)
+        {
+            Uri submitEndpoint = endpoint ?? throw new ArgumentException(
+                $"Command line argument {EndpointArgument} must be set when {OperationSubmit} is called");
+            CodeTransparencyClientOptions options = new();
+            // For non-prod endpoints, we expect the identity service to be running in the same environment and can be reached via the same endpoint.
+            Uri? resolvedIdentityEndpoint = ResolveDefaultIdentityEndpoint(submitEndpoint);
+            if (resolvedIdentityEndpoint is not null)
+            {
+                options.IdentityClientEndpoint = resolvedIdentityEndpoint.ToString();
+            }
+            // In the development environment, we are likely a self-signed certificate
+            if (allowInsecureTls)
+            {
+                HttpClientHandler handler = new()
+                {
+                    ServerCertificateCustomValidationCallback =
+                        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+                };
+                HttpClient httpClient = new(handler);
+                options.Transport = new HttpClientTransport(httpClient);
+            }
+            CodeTransparencyClient client = new CodeTransparencyClient(submitEndpoint, options);
+
+            Console.WriteLine("Sending the signature...");
+            Operation<BinaryData> operationResult = client.CreateEntry(WaitUntil.Completed, content);
+            string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
+
+            Console.WriteLine($"Waiting for the transparent statement...");
+            Response<BinaryData> transparentStatement = client.GetEntryStatement(entryId);
+            if (transparentStatement.GetRawResponse().Status != 200)
+            {
+                Console.WriteLine($"Get transparent statement did not succeed {transparentStatement.GetRawResponse().Status}");
+                throw new Exception($"Get transparent statement did not succeed {transparentStatement.GetRawResponse().Status}");
+            }
+
+            BinaryData signatureWithReceipt = transparentStatement.Value;
+            Console.WriteLine($"Writing the receipt bytes {{{signatureWithReceipt.ToMemory().Length}}} to {{{parsedArguments.OutputPath}}}");
+            File.WriteAllBytes(parsedArguments.OutputPath!, signatureWithReceipt.ToArray());
+        }
+        else if (operationArgumentValue == OperationVerify)
+        {
+            Console.WriteLine("Verifying...");
+            byte[] transparentStatementBytes = content.ToArray();
+            var verificationOptions = new CodeTransparencyVerificationOptions
+            {
+                AuthorizedDomains = new string[] {
+                    "127.0.0.1:8000",
+                    "localhost:8000",
+                    endpoint?.Host ?? throw new ArgumentException($"Command line argument {EndpointArgument} must be set when verify is called") },
+
+                AuthorizedReceiptBehavior = AuthorizedReceiptBehavior.VerifyAllMatching,
+                UnauthorizedReceiptBehavior = UnauthorizedReceiptBehavior.FailIfPresent
+            };
+            // Overriding the client options to make sure it pulls down the public keys from the development server which is using self signed keys
+            CodeTransparencyClientOptions clientOptions = new();
+            if (allowInsecureTls)
+            {
+                HttpClientHandler handler = new()
+                {
+                    ServerCertificateCustomValidationCallback =
+                        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+                };
+                HttpClient httpClient = new(handler);
+                clientOptions.Transport = new HttpClientTransport(httpClient);
+            }
+            CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, clientOptions);
+            Console.WriteLine("Verification succeeded: The statement was registered in the immutable ledger.");
+        }
+
+        Console.WriteLine("Done");
+    }
+
+    private static ParsedArguments ParseArguments(string[] args)
+    {
+        List<string> positionals = new();
+        Uri? endpoint = null;
+        bool allowInsecureTls = false;
+
+        for (int index = 0; index < args.Length; index++)
+        {
+            string argument = args[index];
+
+            if (argument == EndpointArgument)
+            {
+                if (index + 1 >= args.Length)
+                {
+                    throw new ArgumentException($"Missing value for {EndpointArgument}");
+                }
+
+                endpoint = ParseAbsoluteUri(args[++index], EndpointArgument);
+                continue;
+            }
+
+            if (argument == AllowInsecureTlsArgument)
+            {
+                allowInsecureTls = true;
+                continue;
+            }
+
+            if (argument.StartsWith("--", StringComparison.Ordinal))
+            {
+                throw new ArgumentException($"Unknown command line argument {{{argument}}}");
+            }
+
+            positionals.Add(argument);
+        }
+
+        string operation = positionals.Count < 1 ? "nothing" : positionals[0];
+        if (positionals.Count < 2)
+        {
+            Console.WriteLine("Second argument must be a path to the input file");
+            throw new ArgumentException("Missing input file path");
+        }
+
+        string inputPath = positionals[1];
+        string? outputPath = null;
+
+        if (operation == OperationSubmit)
+        {
+            if (positionals.Count < 3)
+            {
+                Console.WriteLine("Third argument must be a path to the output file");
+                throw new ArgumentException("Missing output file path");
+            }
+
+            outputPath = positionals[2];
+
+            if (positionals.Count > 3)
+            {
+                throw new ArgumentException("Too many positional arguments for submit");
+            }
+        }
+        else if (operation == OperationVerify && positionals.Count > 2)
+        {
+            throw new ArgumentException("Too many positional arguments for verify");
+        }
+
+        return new ParsedArguments(operation, inputPath, outputPath, endpoint, allowInsecureTls);
+    }
+
+    private static Uri ParseAbsoluteUri(string value, string argumentName)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out Uri? endpoint))
+        {
+            throw new ArgumentException($"Command line argument {argumentName} must be an absolute URI, got {{{value}}}");
+        }
+
+        return endpoint;
+    }
+
+    private static Uri? ResolveDefaultIdentityEndpoint(Uri endpoint)
+    {
+        // If transparent statement was issued in prod then rely on default pod endpoint
+        if (endpoint.Host.EndsWith(".confidential-ledger.azure.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return endpoint;
+    }
+
+    private sealed class ParsedArguments(
+        string operation,
+        string inputPath,
+        string? outputPath,
+        Uri? endpoint,
+        bool allowInsecureTls)
+    {
+        public string Operation { get; } = operation;
+        public string InputPath { get; } = inputPath;
+        public string? OutputPath { get; } = outputPath;
+        public Uri? Endpoint { get; } = endpoint;
+        public bool AllowInsecureTls { get; } = allowInsecureTls;
+    }
+}

--- a/test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj
+++ b/test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+	  <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.8" />
+  </ItemGroup>
+
+</Project>

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -3,7 +3,10 @@
 
 import base64
 import json
+import os
 import os.path
+from pathlib import Path
+import subprocess
 from hashlib import sha256
 
 import cbor2
@@ -354,6 +357,68 @@ class TestPolicyEngine:
         # store statement
         transparent_statement = tmp_path / f"ts_{os.path.basename(filepath)}"
         transparent_statement.write_bytes(statement)
+
+    def test_dotnet_submit_existing_cose_to_local_service(
+        self,
+        tmp_path: Path,
+        service_url: str,
+        configure_service,
+    ):
+        """
+        This test submits an existing COSE message to the service using the .NET SDK, which applies the policy and returns a transparent statement.
+        This allows avoiding unexpected regressions for the exisiting users of the SDK.
+        """
+        configure_service({"policy": policies.SAMPLE["js"]})
+
+        repo_root = Path(__file__).resolve().parent.parent
+        input_path = repo_root / "test/payloads/cts-hashv-cwtclaims-b64url.cose"
+        output_path = tmp_path / f"ts_{input_path.name}"
+        project_path = repo_root / "test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj"
+
+        def run_dotnet(operation: str, *paths: Path) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [
+                    "dotnet",
+                    "run",
+                    "--no-restore",
+                    "--project",
+                    str(project_path),
+                    "--",
+                    "--endpoint",
+                    service_url,
+                    "--allow-insecure-tls",
+                    operation,
+                    *(str(path) for path in paths),
+                ],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        result = run_dotnet("submit", input_path, output_path)
+
+        assert result.returncode == 0, (
+            f"dotnet submit failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        input_statement = input_path.read_bytes()
+        transparent_statement = output_path.read_bytes()
+
+        assert transparent_statement != input_statement
+
+        input_message = pycose.messages.CoseMessage.decode(input_statement)
+        output_message = pycose.messages.CoseMessage.decode(transparent_statement)
+        input_receipts = input_message.uhdr.get(crypto.SCITTReceipts, [])
+        output_receipts = output_message.uhdr.get(crypto.SCITTReceipts, [])
+
+        assert output_receipts
+        if input_receipts:
+            assert output_receipts[0] != input_receipts[0]
+
+        output_receipt = pycose.messages.Sign1Message.decode(output_receipts[0])
+        output_cwt = output_receipt.phdr[crypto.CWTClaims]
+        assert output_cwt[crypto.CWT_ISS] == "127.0.0.1:8000"
 
     def test_cose_sign1_tool_with_scitt_defaults(
         self, tmp_path, client: Client, configure_service

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -363,6 +363,7 @@ class TestPolicyEngine:
         tmp_path: Path,
         service_url: str,
         configure_service,
+        client: Client,
     ):
         """
         This test submits an existing COSE message to the service using the .NET SDK, which applies the policy and returns a transparent statement.
@@ -373,7 +374,11 @@ class TestPolicyEngine:
         repo_root = Path(__file__).resolve().parent.parent
         input_path = repo_root / "test/payloads/cts-hashv-cwtclaims-b64url.cose"
         output_path = tmp_path / f"ts_{input_path.name}"
+        ca_certificate_path = tmp_path / "service-cert.pem"
         project_path = repo_root / "test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj"
+        cacert_der = client.get_parameters().certificate
+        ca_certificate = x509.load_der_x509_certificate(cacert_der, default_backend())
+        ca_certificate_path.write_bytes(ca_certificate.public_bytes(Encoding.PEM))
 
         def run_dotnet(
             operation: str, *paths: Path
@@ -388,7 +393,8 @@ class TestPolicyEngine:
                     "--",
                     "--endpoint",
                     service_url,
-                    "--allow-insecure-tls",
+                    "--ca-certificate",
+                    str(ca_certificate_path),
                     operation,
                     *(str(path) for path in paths),
                 ],

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -5,9 +5,9 @@ import base64
 import json
 import os
 import os.path
-from pathlib import Path
 import subprocess
 from hashlib import sha256
+from pathlib import Path
 
 import cbor2
 import pycose
@@ -375,7 +375,9 @@ class TestPolicyEngine:
         output_path = tmp_path / f"ts_{input_path.name}"
         project_path = repo_root / "test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj"
 
-        def run_dotnet(operation: str, *paths: Path) -> subprocess.CompletedProcess[str]:
+        def run_dotnet(
+            operation: str, *paths: Path
+        ) -> subprocess.CompletedProcess[str]:
             return subprocess.run(
                 [
                     "dotnet",
@@ -398,9 +400,9 @@ class TestPolicyEngine:
 
         result = run_dotnet("submit", input_path, output_path)
 
-        assert result.returncode == 0, (
-            f"dotnet submit failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
+        assert (
+            result.returncode == 0
+        ), f"dotnet submit failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
         input_statement = input_path.read_bytes()
         transparent_statement = output_path.read_bytes()

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -358,6 +358,7 @@ class TestPolicyEngine:
         transparent_statement = tmp_path / f"ts_{os.path.basename(filepath)}"
         transparent_statement.write_bytes(statement)
 
+    @pytest.mark.dotnet
     def test_dotnet_submit_existing_cose_to_local_service(
         self,
         tmp_path: Path,

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -8,6 +8,7 @@ import os.path
 import subprocess
 from hashlib import sha256
 from pathlib import Path
+from urllib.parse import urlparse
 
 import cbor2
 import pycose
@@ -427,7 +428,7 @@ class TestPolicyEngine:
 
         output_receipt = pycose.messages.Sign1Message.decode(output_receipts[0])
         output_cwt = output_receipt.phdr[crypto.CWTClaims]
-        assert output_cwt[crypto.CWT_ISS] == "127.0.0.1:8000"
+        assert output_cwt[crypto.CWT_ISS] == f"127.0.0.1:{urlparse(service_url).port}"
 
     def test_cose_sign1_tool_with_scitt_defaults(
         self, tmp_path, client: Client, configure_service


### PR DESCRIPTION
Related to #396 

- adds a small dotnet program which uses latest preview version of CodeTransparency SDK to submit an entry to the ledger
- adds a python test which uses the dotnet program to submit the example cose file to a configured local ledger
- adds a flag to enable this test on demand
- enables the test in CI environment