### PR TITLE
Suppressed CodeQL-SM04458 bug that is flagged in [SFI-PS3.1]

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  library:
+    - "app/build/app/_deps/regocpp-src/src/builtins/crypto.cc"

--- a/pyscitt/pyscitt/verify.py
+++ b/pyscitt/pyscitt/verify.py
@@ -173,7 +173,7 @@ class StaticTrustStore(TrustStore):
             P521: SECP521R1(),
         }
 
-        curve = curve_map.get(cose_key.crv)  # type: ignore[attr-defined]
+        curve = curve_map.get(cose_key.crv)  # type: ignore[attr-defined] # CodeQL [SM04458] The curve_map is using the approved cryptographic curves P256, P384, and P521. Anything other than it will be rejected and not used for verification, so it does not pose a security risk.
         if curve is None:
             raise ValueError(f"Unsupported curve: {cose_key.crv}")  # type: ignore[attr-defined]
 


### PR DESCRIPTION
1. The verify.py is in fact using one of the approved cryptography algorithms as described at Liquid https://liquid.microsoft.com/Web/Object/Read/ScanningToolWarnings/Requirements/CodeQL.SM04458#Zguide. This is a false positive; so added suppression as recommended. 

2. Added CodeQL.yml to suppress CodeQL issues on 3P dependencies like [app/build/app/_deps/regocpp-src/src/builtins/crypto.cc] that doesn't exist in the repo. Followed the recommendation at https://codeql.microsoft.com/issues/af268060-0a89-4798-8dd8-ce1ee9f2b88a