### PR TITLE
Sync CCF version to 7.0.5, update constitution, and clean up constants

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION="7.0.2"
+ARG CCF_VERSION="7.0.5"
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.18.0]
+### Changes
+- 09b5c99 Update CCF to v7 and align API with SCRAPI v09 (#390)
+- ccd92d2 add dotnet sdk evaluation regression test (#398)
+- 7654281 Bump azurelinux/base/core from 3.0.20260304 to 3.0.20260401 in /docker (#391)
+
 ## [0.17.1]
 ### Changes
 - b7c45ce Update CCF version from 6.0.26 to 6.0.27 (#389)
@@ -432,3 +438,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.16.5]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.16.5
 [0.17.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.0
 [0.17.1]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.1
+[0.18.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.18.0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,9 +39,9 @@ It is expected that you have Azure Linux 3.0. Follow the steps below to setup yo
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-7.0.2.tar.gz
-    tar xvzf ccf-7.0.2.tar.gz
-    cd CCF-ccf-7.0.2/scripts/
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-7.0.5.tar.gz
+    tar xvzf ccf-7.0.5.tar.gz
+    cd CCF-ccf-7.0.5/scripts/
     ./setup-dev.sh
     ```
 

--- a/app/constitution/actions.js
+++ b/app/constitution/actions.js
@@ -8,7 +8,7 @@ class Action {
 function parseUrl(url) {
   // From https://tools.ietf.org/html/rfc3986#appendix-B
   const re = new RegExp(
-    "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+    "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?",
   );
   const groups = url.match(re);
   if (!groups) {
@@ -21,6 +21,23 @@ function parseUrl(url) {
     query: groups[7],
     fragment: groups[9],
   };
+}
+
+function hexStrToBuf(hexStr) {
+  const result = [];
+
+  for (let i = 0; i < hexStr.length; i += 2) {
+    const octet = hexStr.slice(i, i + 2);
+    if (octet.length != 2) {
+      throw new Error("Hex string invalid: length must be multiple of 2");
+    }
+    if (octet.match(/[G-Z\s]/i)) {
+      throw new Error(`Hex string invalid: Non-hex character ${octet}`);
+    }
+    result.push(parseInt(octet, 16));
+  }
+
+  return new Uint8Array(result).buffer;
 }
 
 function checkType(value, type, field) {
@@ -59,12 +76,159 @@ function checkBounds(value, low, high, field) {
   }
 }
 
-function checkLength(value, min, max, field) {
+function checkArrayLength(value, min, max, field) {
+  checkType(value, "array", field);
   if (min !== null && value.length < min) {
     throw new Error(`${field} must be an array of minimum ${min} elements`);
   }
   if (max !== null && value.length > max) {
     throw new Error(`${field} must be an array of maximum ${max} elements`);
+  }
+}
+
+function checkArrayBufferLength(value, min, max, field) {
+  if (min !== null && value.length < min) {
+    throw new Error(`${field} must be an array of minimum ${min} elements`);
+  }
+  if (max !== null && value.length > max) {
+    throw new Error(`${field} must be an array of maximum ${max} elements`);
+  }
+}
+
+function checkBase64Url(value, field) {
+  checkType(value, "string", field);
+  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) {
+    throw new Error(`${field} must be base64url encoded`);
+  }
+}
+
+function base64UrlByteLength(value, field) {
+  checkBase64Url(value, field);
+  return Math.floor(value.length / 4) * 3 + [0, 0, 1, 2][value.length % 4];
+}
+
+function splitX509CertBundle(value) {
+  // Match complete PEM certificates with both BEGIN and END markers.
+  // This ensures we only extract valid PEM blocks and reject malformed input.
+  const pemPattern =
+    /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+  const certs = value.match(pemPattern);
+
+  if (!certs || certs.length === 0) {
+    throw new Error("No valid PEM certificates found in bundle");
+  }
+
+  // Verify the input contains only certificates and whitespace.
+  // Use a single-pass approach: replace all matched certificates with empty string
+  // using the global regex, then check if only whitespace remains.
+  const remaining = value.replace(pemPattern, "");
+
+  if (remaining.trim() !== "") {
+    throw new Error(
+      "Certificate bundle contains invalid content between certificates",
+    );
+  }
+
+  return certs;
+}
+
+function checkX509CACertBundle(value, field) {
+  checkX509CertBundle(value, field);
+  // isValidX509RootCACert(pem) is backed by a C++ function that checks both
+  // X509_check_ca (CA:TRUE or self-signed x509v1) and EXFLAG_SS (self-signed).
+  // Every certificate in the bundle must be a root (self-signed) CA; intermediate
+  // CAs are rejected even when their signing root is also present in the bundle.
+  for (const [i, cert] of splitX509CertBundle(value).entries()) {
+    if (!ccf.crypto.isValidX509RootCACert(cert)) {
+      throw new Error(
+        `${field}[${i}] must be a self-signed (root) CA certificate`,
+      );
+    }
+  }
+}
+
+function checkRsaPublicKey(jwk, field) {
+  checkType(jwk.n, "string", `${field}.n`);
+  checkType(jwk.e, "string", `${field}.e`);
+  checkBase64Url(jwk.e, `${field}.e`);
+  // RFC 7518 section 6.3.1.1 requires `n` to be the unsigned big-endian modulus with
+  // no leading zero octets. Under that encoding a 2048-bit modulus is exactly
+  // 256 octets, so anything shorter is conclusively below 2048 bits and the
+  // key is too weak. Encoded length is a sufficient (and cheap) proxy here;
+  // the precise bit length is not exposed to JS, but pubRsaJwkToPem below
+  // catches any structurally-invalid modulus.
+  if (base64UrlByteLength(jwk.n, `${field}.n`) < 256) {
+    throw new Error(`${field}.n must be at least 2048 bits`);
+  }
+  try {
+    ccf.crypto.pubRsaJwkToPem({
+      kty: "RSA",
+      kid: jwk.kid,
+      n: jwk.n,
+      e: jwk.e,
+    });
+  } catch (e) {
+    throw new Error(`${field} must be a valid RSA public key`);
+  }
+}
+
+function checkEcPublicKey(jwk, field) {
+  checkType(jwk.x, "string", `${field}.x`);
+  checkType(jwk.y, "string", `${field}.y`);
+  checkType(jwk.crv, "string", `${field}.crv`);
+  checkEnum(jwk.crv, ["P-256", "P-384", "P-521"], `${field}.crv`);
+  const coordinateLengths = { "P-256": 32, "P-384": 48, "P-521": 66 };
+  const coordinateLength = coordinateLengths[jwk.crv];
+  if (base64UrlByteLength(jwk.x, `${field}.x`) !== coordinateLength) {
+    throw new Error(`${field}.x must be ${coordinateLength} bytes`);
+  }
+  if (base64UrlByteLength(jwk.y, `${field}.y`) !== coordinateLength) {
+    throw new Error(`${field}.y must be ${coordinateLength} bytes`);
+  }
+  try {
+    ccf.crypto.pubJwkToPem({
+      kty: "EC",
+      kid: jwk.kid,
+      crv: jwk.crv,
+      x: jwk.x,
+      y: jwk.y,
+    });
+  } catch (e) {
+    throw new Error(`${field} must be a valid EC public key`);
+  }
+}
+
+const cpuid_length_bytes = 4;
+function checkValidCpuid(value, field) {
+  checkType(value, "string", field);
+  if (value !== value.toLowerCase()) {
+    throw new Error(`${field} must be a lowercase hex string: ${value}`);
+  }
+
+  // This will throw if the string contains non-hex characters
+  const buffer = hexStrToBuf(value);
+  const length = buffer.byteLength;
+  if (length != cpuid_length_bytes) {
+    throw new Error(
+      `${field} must convert to exactly ${cpuid_length_bytes} bytes`,
+    );
+  }
+}
+
+const tcb_version_length_bytes = 8;
+function checkValidTcbVersionHex(value, field) {
+  checkType(value, "string", field);
+  if (value !== value.toLowerCase()) {
+    throw new Error(`${field} must be a lowercase hex string: ${value}`);
+  }
+
+  // This will throw if the string contains non-hex characters
+  const buffer = hexStrToBuf(value);
+  const length = buffer.byteLength;
+  if (length != tcb_version_length_bytes) {
+    throw new Error(
+      `${field} must convert to exactly ${tcb_version_length_bytes} bytes`,
+    );
   }
 }
 
@@ -113,32 +277,100 @@ function getActiveRecoveryMembersCount() {
 function checkJwks(value, field) {
   checkType(value, "object", field);
   checkType(value.keys, "array", `${field}.keys`);
+  const kids = new Set();
   for (const [i, jwk] of value.keys.entries()) {
+    const keyField = `${field}.keys[${i}]`;
     checkType(jwk.kid, "string", `${field}.keys[${i}].kid`);
+    if (kids.has(jwk.kid)) {
+      throw new Error(`${field}.keys[${i}].kid must be unique`);
+    }
+    kids.add(jwk.kid);
     checkType(jwk.kty, "string", `${field}.keys[${i}].kty`);
-    checkType(jwk.x5c, "array", `${field}.keys[${i}].x5c`);
-    checkLength(jwk.x5c, 1, null, `${field}.keys[${i}].x5c`);
-    for (const [j, b64der] of jwk.x5c.entries()) {
-      checkType(b64der, "string", `${field}.keys[${i}].x5c[${j}]`);
-      const pem =
+    checkEnum(jwk.kty, ["RSA", "EC"], `${field}.keys[${i}].kty`);
+    if (jwk.use !== undefined) {
+      checkType(jwk.use, "string", `${keyField}.use`);
+      checkEnum(jwk.use, ["sig"], `${keyField}.use`);
+    }
+    if (jwk.alg !== undefined) {
+      checkType(jwk.alg, "string", `${keyField}.alg`);
+      let allowedAlg;
+      if (jwk.kty === "RSA") {
+        allowedAlg = ["RS256"];
+      } else {
+        // Per RFC 7518 section 3.4, EC alg is determined by the curve. When
+        // only x5c is supplied, crv may not be present on the JWK; in that
+        // case allow any of the supported ES* algorithms and rely on the cert
+        // to bind alg to curve.
+        const ecAlgByCrv = {
+          "P-256": "ES256",
+          "P-384": "ES384",
+          "P-521": "ES512",
+        };
+        allowedAlg =
+          jwk.crv && ecAlgByCrv[jwk.crv]
+            ? [ecAlgByCrv[jwk.crv]]
+            : Object.values(ecAlgByCrv);
+      }
+      checkEnum(jwk.alg, allowedAlg, `${keyField}.alg`);
+    }
+    if (jwk.x5c) {
+      checkArrayLength(jwk.x5c, 1, null, `${field}.keys[${i}].x5c`);
+      let certBundle = "";
+      for (const [j, b64der] of jwk.x5c.entries()) {
+        checkType(b64der, "string", `${field}.keys[${i}].x5c[${j}]`);
+        if (!/^[A-Za-z0-9+/]+={0,2}$/.test(b64der)) {
+          throw new Error(
+            `${field}.keys[${i}].x5c[${j}] must be base64 encoded`,
+          );
+        }
+        const pem =
+          "-----BEGIN CERTIFICATE-----\n" +
+          b64der +
+          "\n-----END CERTIFICATE-----";
+        checkX509CertBundle(pem, `${field}.keys[${i}].x5c[${j}]`);
+        certBundle += pem;
+      }
+      const trustedRoot =
         "-----BEGIN CERTIFICATE-----\n" +
-        b64der +
+        jwk.x5c[jwk.x5c.length - 1] +
         "\n-----END CERTIFICATE-----";
-      checkX509CertBundle(pem, `${field}.keys[${i}].x5c[${j}]`);
+      if (!ccf.crypto.isValidX509CertChain(certBundle, trustedRoot)) {
+        throw new Error(`${field}.keys[${i}].x5c must chain to its root`);
+      }
+      if (jwk.n !== undefined || jwk.e !== undefined) {
+        if (jwk.kty !== "RSA") {
+          throw new Error(`${field}.keys[${i}].kty must be RSA for n/e keys`);
+        }
+        checkRsaPublicKey(jwk, keyField);
+      }
+      if (jwk.x !== undefined || jwk.y !== undefined || jwk.crv !== undefined) {
+        if (jwk.kty !== "EC") {
+          throw new Error(`${field}.keys[${i}].kty must be EC for x/y keys`);
+        }
+        checkEcPublicKey(jwk, keyField);
+      }
+    } else if (jwk.n && jwk.e) {
+      if (jwk.kty !== "RSA") {
+        throw new Error(`${field}.keys[${i}].kty must be RSA for n/e keys`);
+      }
+      checkRsaPublicKey(jwk, keyField);
+    } else if (jwk.x && jwk.y) {
+      if (jwk.kty !== "EC") {
+        throw new Error(`${field}.keys[${i}].kty must be EC for x/y keys`);
+      }
+      checkEcPublicKey(jwk, keyField);
+    } else {
+      throw new Error(
+        "JWK must contain either x5c, or n/e for RSA key type, or x/y/crv for EC key type",
+      );
     }
   }
 }
 
 function checkX509CertBundle(value, field) {
-  let check_func = ccf.crypto.isValidX509CertBundle;
-  // Remove after upgrade to 4.x
-  if (check_func === undefined) {
-    check_func = ccf.isValidX509CertBundle;
-  }
-
-  if (!check_func(value)) {
+  if (!ccf.crypto.isValidX509CertBundle(value)) {
     throw new Error(
-      `${field} must be a valid X509 certificate (bundle) in PEM format`
+      `${field} must be a valid X509 certificate (bundle) in PEM format`,
     );
   }
 }
@@ -158,9 +390,8 @@ function invalidateOtherOpenProposals(proposalIdToRetain) {
 }
 
 function setServiceCertificateValidityPeriod(validFrom, validityPeriodDays) {
-  const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-    getSingletonKvKey()
-  );
+  const rawConfig =
+    ccf.kv["public:ccf.gov.service.config"].get(getSingletonKvKey());
   if (rawConfig === undefined) {
     throw new Error("Service configuration could not be found");
   }
@@ -176,13 +407,13 @@ function setServiceCertificateValidityPeriod(validFrom, validityPeriodDays) {
     validityPeriodDays > max_allowed_cert_validity_period_days
   ) {
     throw new Error(
-      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`
+      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`,
     );
   }
 
   const renewed_service_certificate = ccf.network.generateNetworkCertificate(
     validFrom,
-    validityPeriodDays ?? max_allowed_cert_validity_period_days
+    validityPeriodDays ?? max_allowed_cert_validity_period_days,
   );
 
   const serviceInfoTable = "public:ccf.gov.service.info";
@@ -195,7 +426,7 @@ function setServiceCertificateValidityPeriod(validFrom, validityPeriodDays) {
   serviceInfo.cert = renewed_service_certificate;
   ccf.kv[serviceInfoTable].set(
     getSingletonKvKey(),
-    ccf.jsonCompatibleToBuf(serviceInfo)
+    ccf.jsonCompatibleToBuf(serviceInfo),
   );
 }
 
@@ -203,15 +434,14 @@ function setNodeCertificateValidityPeriod(
   nodeId,
   nodeInfo,
   validFrom,
-  validityPeriodDays
+  validityPeriodDays,
 ) {
   if (nodeInfo.certificate_signing_request === undefined) {
     throw new Error(`Node ${nodeId} has no certificate signing request`);
   }
 
-  const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-    getSingletonKvKey()
-  );
+  const rawConfig =
+    ccf.kv["public:ccf.gov.service.config"].get(getSingletonKvKey());
   if (rawConfig === undefined) {
     throw new Error("Service configuration could not be found");
   }
@@ -227,18 +457,18 @@ function setNodeCertificateValidityPeriod(
     validityPeriodDays > max_allowed_cert_validity_period_days
   ) {
     throw new Error(
-      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`
+      `Validity period ${validityPeriodDays} (days) is not allowed: service max allowed is ${max_allowed_cert_validity_period_days} (days)`,
     );
   }
 
   const endorsed_node_cert = ccf.network.generateEndorsedCertificate(
     nodeInfo.certificate_signing_request,
     validFrom,
-    validityPeriodDays ?? max_allowed_cert_validity_period_days
+    validityPeriodDays ?? max_allowed_cert_validity_period_days,
   );
   ccf.kv["public:ccf.gov.nodes.endorsed_certificates"].set(
     ccf.strToBuf(nodeId),
-    ccf.strToBuf(endorsed_node_cert)
+    ccf.strToBuf(endorsed_node_cert),
   );
 }
 
@@ -259,13 +489,13 @@ function checkRecoveryThreshold(config, new_config) {
 
   if (service.status === "WaitingForRecoveryShares") {
     throw new Error(
-      `Cannot set recovery threshold if service is ${service.status}`
+      `Cannot set recovery threshold if service is ${service.status}`,
     );
   } else if (service.status === "Open") {
     let activeRecoveryMembersCount = getActiveRecoveryMembersCount();
     if (new_config.recovery_threshold > activeRecoveryMembersCount) {
       throw new Error(
-        `Cannot set recovery threshold to ${new_config.recovery_threshold}: recovery threshold would be greater than the number of recovery members ${activeRecoveryMembersCount}`
+        `Cannot set recovery threshold to ${new_config.recovery_threshold}: recovery threshold would be greater than the number of recovery members ${activeRecoveryMembersCount}`,
       );
     }
   }
@@ -282,7 +512,7 @@ function checkReconfigurationType(config, new_config) {
       )
     ) {
       throw new Error(
-        `Cannot change reconfiguration type from ${from} to ${to}.`
+        `Cannot change reconfiguration type from ${from} to ${to}.`,
       );
     }
   }
@@ -314,9 +544,14 @@ function updateServiceConfig(new_config) {
     need_recovery_threshold_refresh = true;
   }
 
+  if (new_config.recent_cose_proposals_window_size !== undefined) {
+    config.recent_cose_proposals_window_size =
+      new_config.recent_cose_proposals_window_size;
+  }
+
   ccf.kv[service_config_table].set(
     getSingletonKvKey(),
-    ccf.jsonCompatibleToBuf(config)
+    ccf.jsonCompatibleToBuf(config),
   );
 
   if (need_recovery_threshold_refresh) {
@@ -329,17 +564,18 @@ const actions = new Map([
     "set_constitution",
     new Action(
       function (args) {
-        checkType(args.constitution, "string");
+        checkType(args.constitution, "string", "constitution");
+        ccf.gov.validateConstitution(args.constitution);
       },
       function (args, proposalId) {
         ccf.kv["public:ccf.gov.constitution"].set(
           getSingletonKvKey(),
-          ccf.jsonCompatibleToBuf(args.constitution)
+          ccf.jsonCompatibleToBuf(args.constitution),
         );
 
         // Changing the constitution changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
         invalidateOtherOpenProposals(proposalId);
-      }
+      },
     ),
   ],
   [
@@ -348,7 +584,33 @@ const actions = new Map([
       function (args) {
         checkX509CertBundle(args.cert, "cert");
         checkType(args.member_data, "object?", "member_data");
-        // Also check that public encryption key is well formed, if it exists
+        const recovery_role = args.recovery_role;
+        if (recovery_role !== undefined) {
+          checkEnum(
+            recovery_role,
+            ["NonParticipant", "Participant", "Owner"],
+            "recovery_role",
+          );
+        }
+
+        if (
+          args.encryption_pub_key == null &&
+          args.recovery_role !== null &&
+          args.recovery_role !== undefined
+        ) {
+          throw new Error(
+            "Cannot specify a recovery_role value when encryption_pub_key is not specified",
+          );
+        }
+        if (
+          args.encryption_pub_key !== null &&
+          args.encryption_pub_key !== undefined
+        ) {
+          checkRsaPublicKey(
+            ccf.crypto.pubRsaPemToJwk(args.encryption_pub_key),
+            "encryption_pub_key",
+          );
+        }
       },
 
       function (args) {
@@ -357,31 +619,31 @@ const actions = new Map([
 
         ccf.kv["public:ccf.gov.members.certs"].set(
           rawMemberId,
-          ccf.strToBuf(args.cert)
+          ccf.strToBuf(args.cert),
         );
 
         if (args.encryption_pub_key == null) {
           ccf.kv["public:ccf.gov.members.encryption_public_keys"].delete(
-            rawMemberId
+            rawMemberId,
           );
         } else {
           ccf.kv["public:ccf.gov.members.encryption_public_keys"].set(
             rawMemberId,
-            ccf.strToBuf(args.encryption_pub_key)
+            ccf.strToBuf(args.encryption_pub_key),
           );
         }
 
         let member_info = {};
         member_info.member_data = args.member_data;
+        member_info.recovery_role = args.recovery_role;
         member_info.status = "Accepted";
         ccf.kv["public:ccf.gov.members.info"].set(
           rawMemberId,
-          ccf.jsonCompatibleToBuf(member_info)
+          ccf.jsonCompatibleToBuf(member_info),
         );
 
-        const rawSignature = ccf.kv["public:ccf.internal.signatures"].get(
-          getSingletonKvKey()
-        );
+        const rawSignature =
+          ccf.kv["public:ccf.internal.signatures"].get(getSingletonKvKey());
         if (rawSignature === undefined) {
           ccf.kv["public:ccf.gov.members.acks"].set(rawMemberId);
         } else {
@@ -390,10 +652,10 @@ const actions = new Map([
           ack.state_digest = signature.root;
           ccf.kv["public:ccf.gov.members.acks"].set(
             rawMemberId,
-            ccf.jsonCompatibleToBuf(ack)
+            ccf.jsonCompatibleToBuf(ack),
           );
         }
-      }
+      },
     ),
   ],
   [
@@ -423,9 +685,8 @@ const actions = new Map([
         // would still be a sufficient number of recovery members left
         // to recover the service
         if (isActiveMember && isRecoveryMember) {
-          const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-            getSingletonKvKey()
-          );
+          const rawConfig =
+            ccf.kv["public:ccf.gov.service.config"].get(getSingletonKvKey());
           if (rawConfig === undefined) {
             throw new Error("Service configuration could not be found");
           }
@@ -435,14 +696,14 @@ const actions = new Map([
             getActiveRecoveryMembersCount() - 1;
           if (activeRecoveryMembersCountAfter < config.recovery_threshold) {
             throw new Error(
-              `Number of active recovery members (${activeRecoveryMembersCountAfter}) would be less than recovery threshold (${config.recovery_threshold})`
+              `Number of active recovery members (${activeRecoveryMembersCountAfter}) would be less than recovery threshold (${config.recovery_threshold})`,
             );
           }
         }
 
         ccf.kv["public:ccf.gov.members.info"].delete(rawMemberId);
         ccf.kv["public:ccf.gov.members.encryption_public_keys"].delete(
-          rawMemberId
+          rawMemberId,
         );
         ccf.kv["public:ccf.gov.members.certs"].delete(rawMemberId);
         ccf.kv["public:ccf.gov.members.acks"].delete(rawMemberId);
@@ -454,7 +715,7 @@ const actions = new Map([
           // remaining active recovery members
           ccf.node.triggerLedgerRekey();
         }
-      }
+      },
     ),
   ],
   [
@@ -475,7 +736,7 @@ const actions = new Map([
         let mi = ccf.bufToJsonCompatible(member_info);
         mi.member_data = args.member_data;
         members_info.set(member_id, ccf.jsonCompatibleToBuf(mi));
-      }
+      },
     ),
   ],
   [
@@ -491,18 +752,20 @@ const actions = new Map([
 
         ccf.kv["public:ccf.gov.users.certs"].set(
           rawUserId,
-          ccf.strToBuf(args.cert)
+          ccf.strToBuf(args.cert),
         );
 
         if (args.user_data !== null && args.user_data !== undefined) {
+          let userInfo = {};
+          userInfo.user_data = args.user_data;
           ccf.kv["public:ccf.gov.users.info"].set(
             rawUserId,
-            ccf.jsonCompatibleToBuf(args.user_data)
+            ccf.jsonCompatibleToBuf(userInfo),
           );
         } else {
           ccf.kv["public:ccf.gov.users.info"].delete(rawUserId);
         }
-      }
+      },
     ),
   ],
   [
@@ -515,7 +778,7 @@ const actions = new Map([
         const user_id = ccf.strToBuf(args.user_id);
         ccf.kv["public:ccf.gov.users.certs"].delete(user_id);
         ccf.kv["public:ccf.gov.users.info"].delete(user_id);
-      }
+      },
     ),
   ],
   [
@@ -533,12 +796,12 @@ const actions = new Map([
           userInfo.user_data = args.user_data;
           ccf.kv["public:ccf.gov.users.info"].set(
             userId,
-            ccf.jsonCompatibleToBuf(userInfo)
+            ccf.jsonCompatibleToBuf(userInfo),
           );
         } else {
           ccf.kv["public:ccf.gov.users.info"].delete(userId);
         }
-      }
+      },
     ),
   ],
   [
@@ -550,7 +813,7 @@ const actions = new Map([
       },
       function (args) {
         updateServiceConfig(args);
-      }
+      },
     ),
   ],
   [
@@ -561,7 +824,7 @@ const actions = new Map([
       },
       function (args) {
         ccf.node.triggerRecoverySharesRefresh();
-      }
+      },
     ),
   ],
   [
@@ -573,7 +836,7 @@ const actions = new Map([
 
       function (args) {
         ccf.node.triggerLedgerRekey();
-      }
+      },
     ),
   ],
   [
@@ -583,22 +846,22 @@ const actions = new Map([
         checkType(
           args.next_service_identity,
           "string",
-          "next service identity (PEM certificate)"
+          "next service identity (PEM certificate)",
         );
         checkX509CertBundle(
           args.next_service_identity,
-          "next_service_identity"
+          "next_service_identity",
         );
 
         checkType(
           args.previous_service_identity,
           "string?",
-          "previous service identity (PEM certificate)"
+          "previous service identity (PEM certificate)",
         );
         if (args.previous_service_identity !== undefined) {
           checkX509CertBundle(
             args.previous_service_identity,
-            "previous_service_identity"
+            "previous_service_identity",
           );
         }
       },
@@ -618,7 +881,7 @@ const actions = new Map([
             args.next_service_identity === undefined)
         ) {
           throw new Error(
-            `Opening a recovering network requires both, the previous and the next service identity`
+            `Opening a recovering network requires both, the previous and the next service identity`,
           );
         }
 
@@ -628,7 +891,7 @@ const actions = new Map([
             : undefined;
         const next_identity = ccf.strToBuf(args.next_service_identity);
         ccf.node.transitionServiceToOpen(previous_identity, next_identity);
-      }
+      },
     ),
   ],
   [
@@ -650,7 +913,7 @@ const actions = new Map([
         checkType(bundle.metadata, "object", prefix);
         checkType(bundle.metadata.endpoints, "object", `${prefix}.endpoints`);
         for (const [url, endpoint] of Object.entries(
-          bundle.metadata.endpoints
+          bundle.metadata.endpoints,
         )) {
           checkType(endpoint, "object", `${prefix}.endpoints["${url}"]`);
           for (const [method, info] of Object.entries(endpoint)) {
@@ -661,26 +924,57 @@ const actions = new Map([
             checkEnum(
               info.mode,
               ["readwrite", "readonly", "historical"],
-              `${prefix2}.mode`
+              `${prefix2}.mode`,
             );
             checkEnum(
               info.forwarding_required,
               ["sometimes", "always", "never"],
-              `${prefix2}.forwarding_required`
+              `${prefix2}.forwarding_required`,
             );
+
+            const redirection_strategy = info.redirection_strategy;
+            if (redirection_strategy !== undefined) {
+              checkEnum(
+                info.redirection_strategy,
+                ["none", "to_primary", "to_backup"],
+                `${prefix2}.redirection_strategy`,
+              );
+            }
+
             checkType(info.openapi, "object?", `${prefix2}.openapi`);
             checkType(
               info.openapi_hidden,
               "boolean?",
-              `${prefix2}.openapi_hidden`
+              `${prefix2}.openapi_hidden`,
             );
             checkType(
               info.authn_policies,
               "array",
-              `${prefix2}.authn_policies`
+              `${prefix2}.authn_policies`,
             );
             for (const [i, policy] of info.authn_policies.entries()) {
-              checkType(policy, "string", `${prefix2}.authn_policies[${i}]`);
+              if (typeof policy === "string") {
+                // May still be an unrecognised value. That will only throw later
+                continue;
+              } else if (typeof policy === "object") {
+                const constituents = policy["all_of"];
+                checkType(
+                  constituents,
+                  "array",
+                  `${prefix2}.authn_policies[${i}].all_of`,
+                );
+                for (const [j, sub_policy] of constituents.entries()) {
+                  checkType(
+                    sub_policy,
+                    "string",
+                    `${prefix2}.authn_policies[${i}].all_of[${j}]`,
+                  );
+                }
+              } else {
+                throw new Error(
+                  `${prefix2}.authn_policies[${i}] must be of type string or object but is ${typeof policy}`,
+                );
+              }
             }
             if (!bundle.modules.some((m) => m.name === info.js_module)) {
               throw new Error(`module '${info.js_module}' not found in bundle`);
@@ -691,7 +985,7 @@ const actions = new Map([
         checkType(
           args.disable_bytecode_cache,
           "boolean?",
-          "disable_bytecode_cache"
+          "disable_bytecode_cache",
         );
       },
       function (args) {
@@ -700,6 +994,7 @@ const actions = new Map([
           ccf.kv["public:ccf.gov.modules_quickjs_bytecode"];
         const modulesQuickJsVersionVal =
           ccf.kv["public:ccf.gov.modules_quickjs_version"];
+        const interpreterFlushVal = ccf.kv["public:ccf.gov.interpreter.flush"];
         const endpointsMap = ccf.kv["public:ccf.gov.endpoints"];
         modulesMap.clear();
         endpointsMap.clear();
@@ -719,8 +1014,13 @@ const actions = new Map([
           ccf.refreshAppBytecodeCache();
         }
 
+        interpreterFlushVal.set(
+          getSingletonKvKey(),
+          ccf.jsonCompatibleToBuf(true),
+        );
+
         for (const [url, endpoint] of Object.entries(
-          bundle.metadata.endpoints
+          bundle.metadata.endpoints,
         )) {
           for (const [method, info] of Object.entries(endpoint)) {
             const key = `${method.toUpperCase()} ${url}`;
@@ -731,7 +1031,7 @@ const actions = new Map([
             endpointsMap.set(keyBuf, infoBuf);
           }
         }
-      }
+      },
     ),
   ],
   [
@@ -742,14 +1042,49 @@ const actions = new Map([
         const modulesMap = ccf.kv["public:ccf.gov.modules"];
         const modulesQuickJsBytecodeMap =
           ccf.kv["public:ccf.gov.modules_quickjs_bytecode"];
+        const interpreterFlushVal = ccf.kv["public:ccf.gov.interpreter.flush"];
         const modulesQuickJsVersionVal =
           ccf.kv["public:ccf.gov.modules_quickjs_version"];
         const endpointsMap = ccf.kv["public:ccf.gov.endpoints"];
         modulesMap.clear();
         modulesQuickJsBytecodeMap.clear();
         modulesQuickJsVersionVal.clear();
+        interpreterFlushVal.clear();
         endpointsMap.clear();
-      }
+      },
+    ),
+  ],
+  [
+    "set_js_runtime_options",
+    new Action(
+      function (args) {
+        checkType(args.max_heap_bytes, "integer", "max_heap_bytes");
+        checkType(args.max_stack_bytes, "integer", "max_stack_bytes");
+        checkType(
+          args.max_execution_time_ms,
+          "integer",
+          "max_execution_time_ms",
+        );
+        checkType(
+          args.log_exception_details,
+          "boolean?",
+          "log_exception_details",
+        );
+        checkType(
+          args.return_exception_details,
+          "boolean?",
+          "return_exception_details",
+        );
+        checkType(
+          args.max_cached_interpreters,
+          "integer?",
+          "max_cached_interpreters",
+        );
+      },
+      function (args) {
+        const js_engine_map = ccf.kv["public:ccf.gov.js_runtime_options"];
+        js_engine_map.set(getSingletonKvKey(), ccf.jsonCompatibleToBuf(args));
+      },
     ),
   ],
   [
@@ -758,7 +1093,7 @@ const actions = new Map([
       function (args) {},
       function (args) {
         ccf.refreshAppBytecodeCache();
-      }
+      },
     ),
   ],
   [
@@ -766,7 +1101,7 @@ const actions = new Map([
     new Action(
       function (args) {
         checkType(args.name, "string", "name");
-        checkX509CertBundle(args.cert_bundle, "cert_bundle");
+        checkX509CACertBundle(args.cert_bundle, "cert_bundle");
       },
       function (args) {
         const name = args.name;
@@ -774,7 +1109,7 @@ const actions = new Map([
         const nameBuf = ccf.strToBuf(name);
         const bundleBuf = ccf.jsonCompatibleToBuf(bundle);
         ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].set(nameBuf, bundleBuf);
-      }
+      },
     ),
   ],
   [
@@ -787,7 +1122,7 @@ const actions = new Map([
         const name = args.name;
         const nameBuf = ccf.strToBuf(name);
         ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].delete(nameBuf);
-      }
+      },
     ),
   ],
   [
@@ -801,26 +1136,22 @@ const actions = new Map([
         if (args.jwks) {
           checkJwks(args.jwks, "jwks");
         }
+        let url;
+        try {
+          url = parseUrl(args.issuer);
+        } catch (e) {
+          throw new Error("issuer must be a URL");
+        }
+        if (url.scheme != "https" || !url.authority) {
+          throw new Error("issuer must be a URL starting with https://");
+        }
+        if (url.query || url.fragment) {
+          throw new Error("issuer must be a URL without query/fragment");
+        }
         if (args.auto_refresh) {
           if (!args.ca_cert_bundle_name) {
             throw new Error(
-              "ca_cert_bundle_name is missing but required if auto_refresh is true"
-            );
-          }
-          let url;
-          try {
-            url = parseUrl(args.issuer);
-          } catch (e) {
-            throw new Error("issuer must be a URL if auto_refresh is true");
-          }
-          if (url.scheme != "https") {
-            throw new Error(
-              "issuer must be a URL starting with https:// if auto_refresh is true"
-            );
-          }
-          if (url.query || url.fragment) {
-            throw new Error(
-              "issuer must be a URL without query/fragment if auto_refresh is true"
+              "ca_cert_bundle_name is missing but required if auto_refresh is true",
             );
           }
         }
@@ -831,11 +1162,11 @@ const actions = new Map([
           const caCertBundleNameBuf = ccf.strToBuf(args.ca_cert_bundle_name);
           if (
             !ccf.kv["public:ccf.gov.tls.ca_cert_bundles"].has(
-              caCertBundleNameBuf
+              caCertBundleNameBuf,
             )
           ) {
             throw new Error(
-              `No CA cert bundle found with name '${caCertBundleName}'`
+              `No CA cert bundle found with name '${caCertBundleName}'`,
             );
           }
         }
@@ -849,7 +1180,7 @@ const actions = new Map([
         const issuerBuf = ccf.strToBuf(issuer);
         const metadataBuf = ccf.jsonCompatibleToBuf(metadata);
         ccf.kv["public:ccf.gov.jwt.issuers"].set(issuerBuf, metadataBuf);
-      }
+      },
     ),
   ],
   [
@@ -869,7 +1200,7 @@ const actions = new Map([
         const metadata = ccf.bufToJsonCompatible(metadataBuf);
         const jwks = args.jwks;
         ccf.setJwtPublicSigningKeys(issuer, metadata, jwks);
-      }
+      },
     ),
   ],
   [
@@ -880,11 +1211,208 @@ const actions = new Map([
       },
       function (args) {
         const issuerBuf = ccf.strToBuf(args.issuer);
-        if (!ccf.kv["public:ccf.gov.jwt.issuers"].delete(issuerBuf)) {
+        if (!ccf.kv["public:ccf.gov.jwt.issuers"].has(issuerBuf)) {
           return;
         }
+        ccf.kv["public:ccf.gov.jwt.issuers"].delete(issuerBuf);
         ccf.removeJwtPublicSigningKeys(args.issuer);
-      }
+      },
+    ),
+  ],
+  [
+    "add_snp_measurement",
+    new Action(
+      function (args) {
+        checkType(args.measurement, "string", "measurement");
+      },
+      function (args, proposalId) {
+        const measurement = ccf.strToBuf(args.measurement);
+        const ALLOWED = ccf.jsonCompatibleToBuf("AllowedToJoin");
+        ccf.kv["public:ccf.gov.nodes.snp.measurements"].set(
+          measurement,
+          ALLOWED,
+        );
+
+        // Adding a new allowed measurement changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
+        invalidateOtherOpenProposals(proposalId);
+      },
+    ),
+  ],
+  [
+    "add_snp_uvm_endorsement",
+    new Action(
+      function (args) {
+        checkType(args.did, "string", "did");
+        checkType(args.feed, "string", "feed");
+        checkType(args.svn, "string", "svn");
+      },
+      function (args, proposalId) {
+        let uvmEndorsementsForDID = ccf.kv[
+          "public:ccf.gov.nodes.snp.uvm_endorsements"
+        ].get(ccf.strToBuf(args.did));
+        let uvme = {};
+        if (uvmEndorsementsForDID !== undefined) {
+          uvme = ccf.bufToJsonCompatible(uvmEndorsementsForDID);
+        }
+        uvme[args.feed] = { svn: args.svn };
+        ccf.kv["public:ccf.gov.nodes.snp.uvm_endorsements"].set(
+          ccf.strToBuf(args.did),
+          ccf.jsonCompatibleToBuf(uvme),
+        );
+        // Adding a new allowed UVM endorsement changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
+        invalidateOtherOpenProposals(proposalId);
+      },
+    ),
+  ],
+  [
+    "add_snp_host_data",
+    new Action(
+      function (args) {
+        checkType(args.security_policy, "string", "security_policy");
+        checkType(args.host_data, "string", "host_data");
+
+        // If optional security policy is specified, make sure its
+        // SHA-256 digest is the specified host data
+        if (args.security_policy != "") {
+          const securityPolicyDigest = ccf.bufToStr(
+            ccf.crypto.digest("SHA-256", ccf.strToBuf(args.security_policy)),
+          );
+          const hostData = ccf.bufToStr(hexStrToBuf(args.host_data));
+          if (securityPolicyDigest != hostData) {
+            throw new Error(
+              `The hash of raw policy ${securityPolicyDigest} does not match digest ${hostData}`,
+            );
+          }
+        }
+      },
+      function (args, proposalId) {
+        ccf.kv["public:ccf.gov.nodes.snp.host_data"].set(
+          ccf.strToBuf(args.host_data),
+          ccf.jsonCompatibleToBuf(args.security_policy),
+        );
+
+        // Adding a new allowed host data changes the semantics of any other open proposals, so invalidate them to avoid confusion or malicious vote modification
+        invalidateOtherOpenProposals(proposalId);
+      },
+    ),
+  ],
+  [
+    "set_snp_minimum_tcb_version",
+    new Action(
+      function (args) {
+        checkValidCpuid(args.cpuid, "cpuid");
+
+        checkType(args.tcb_version, "object", "tcb_version");
+        checkType(
+          args.tcb_version?.boot_loader,
+          "number",
+          "tcb_version.boot_loader",
+        );
+        checkType(args.tcb_version?.tee, "number", "tcb_version.tee");
+        checkType(args.tcb_version?.snp, "number", "tcb_version.snp");
+        checkType(
+          args.tcb_version?.microcode,
+          "number",
+          "tcb_version.microcode",
+        );
+      },
+      function (args, proposalId) {
+        ccf.kv["public:ccf.gov.nodes.snp.tcb_versions"].set(
+          ccf.strToBuf(args.cpuid),
+          ccf.jsonCompatibleToBuf(args.tcb_version),
+        );
+
+        invalidateOtherOpenProposals(proposalId);
+      },
+    ),
+  ],
+  [
+    "set_snp_minimum_tcb_version_hex",
+    new Action(
+      function (args) {
+        checkValidCpuid(args.cpuid, "cpuid");
+        checkValidTcbVersionHex(args.tcb_version, "tcb_version");
+      },
+      function (args, proposalId) {
+        let tcb_policy = ccf.tcbHexToPolicy(args.cpuid, args.tcb_version);
+        ccf.kv["public:ccf.gov.nodes.snp.tcb_versions"].set(
+          ccf.strToBuf(args.cpuid),
+          ccf.jsonCompatibleToBuf(tcb_policy),
+        );
+
+        invalidateOtherOpenProposals(proposalId);
+      },
+    ),
+  ],
+  [
+    "remove_snp_host_data",
+    new Action(
+      function (args) {
+        checkType(args.host_data, "string", "host_data");
+      },
+      function (args) {
+        const hostData = ccf.strToBuf(args.host_data);
+        ccf.kv["public:ccf.gov.nodes.snp.host_data"].delete(hostData);
+      },
+    ),
+  ],
+  [
+    "remove_snp_measurement",
+    new Action(
+      function (args) {
+        checkType(args.measurement, "string", "measurement");
+      },
+      function (args) {
+        const measurement = ccf.strToBuf(args.measurement);
+        ccf.kv["public:ccf.gov.nodes.snp.measurements"].delete(measurement);
+      },
+    ),
+  ],
+  [
+    "remove_snp_uvm_endorsement",
+    new Action(
+      function (args) {
+        checkType(args.did, "string", "did");
+        checkType(args.feed, "string", "feed");
+      },
+      function (args) {
+        let uvmEndorsementsForDID = ccf.kv[
+          "public:ccf.gov.nodes.snp.uvm_endorsements"
+        ].get(ccf.strToBuf(args.did));
+        let uvme = {};
+        if (uvmEndorsementsForDID !== undefined) {
+          uvme = ccf.bufToJsonCompatible(uvmEndorsementsForDID);
+        }
+        delete uvme[args.feed];
+
+        if (Object.keys(uvme).length === 0) {
+          // Delete DID if no feed are left
+          ccf.kv["public:ccf.gov.nodes.snp.uvm_endorsements"].delete(
+            ccf.strToBuf(args.did),
+          );
+        } else {
+          ccf.kv["public:ccf.gov.nodes.snp.uvm_endorsements"].set(
+            ccf.strToBuf(args.did),
+            ccf.jsonCompatibleToBuf(uvme),
+          );
+        }
+      },
+    ),
+  ],
+  [
+    "remove_snp_minimum_tcb_version",
+    new Action(
+      function (args) {
+        checkValidCpuid(args.cpuid, "cpuid");
+      },
+      function (args) {
+        const cpuid = ccf.strToBuf(args.cpuid);
+        if (ccf.kv["public:ccf.gov.nodes.snp.tcb_versions"].has(cpuid)) {
+          ccf.kv["public:ccf.gov.nodes.snp.tcb_versions"].delete(cpuid);
+        } else {
+          throw new Error(`CPUID ${args.cpuid} not found`);
+        }
+      },
     ),
   ],
   [
@@ -903,7 +1431,7 @@ const actions = new Map([
         let ni = ccf.bufToJsonCompatible(node_info);
         ni.node_data = args.node_data;
         nodes_info.set(node_id, ccf.jsonCompatibleToBuf(ni));
-      }
+      },
     ),
   ],
   [
@@ -916,48 +1444,44 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
       function (args) {
-        const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-          getSingletonKvKey()
-        );
+        const rawConfig =
+          ccf.kv["public:ccf.gov.service.config"].get(getSingletonKvKey());
         if (rawConfig === undefined) {
           throw new Error("Service configuration could not be found");
         }
         const serviceConfig = ccf.bufToJsonCompatible(rawConfig);
         const node = ccf.kv["public:ccf.gov.nodes.info"].get(
-          ccf.strToBuf(args.node_id)
+          ccf.strToBuf(args.node_id),
         );
         if (node === undefined) {
           throw new Error(`No such node: ${args.node_id}`);
         }
         const nodeInfo = ccf.bufToJsonCompatible(node);
         if (nodeInfo.status === "Pending") {
-          nodeInfo.status =
-            serviceConfig.reconfiguration_type == "TwoTransaction"
-              ? "Learner"
-              : "Trusted";
+          nodeInfo.status = "Trusted";
           nodeInfo.ledger_secret_seqno =
             ccf.network.getLatestLedgerSecretSeqno();
           ccf.kv["public:ccf.gov.nodes.info"].set(
             ccf.strToBuf(args.node_id),
-            ccf.jsonCompatibleToBuf(nodeInfo)
+            ccf.jsonCompatibleToBuf(nodeInfo),
           );
+          if (ccf.node.shuffleSealedShares !== undefined) {
+            ccf.node.shuffleSealedShares();
+          }
 
           // Also generate and record service-endorsed node certificate from node CSR
-          if (
-            nodeInfo.certificate_signing_request !== undefined &&
-            serviceConfig.consensus !== "BFT"
-          ) {
+          if (nodeInfo.certificate_signing_request !== undefined) {
             // Note: CSR and node certificate validity config are only present from 2.x
             const default_validity_period_days = 365;
             const max_allowed_cert_validity_period_days =
@@ -968,22 +1492,23 @@ const actions = new Map([
               args.validity_period_days > max_allowed_cert_validity_period_days
             ) {
               throw new Error(
-                `Validity period ${args.validity_period_days} is not allowed: max allowed is ${max_allowed_cert_validity_period_days}`
+                `Validity period ${args.validity_period_days} is not allowed: max allowed is ${max_allowed_cert_validity_period_days}`,
               );
             }
 
             const endorsed_node_cert = ccf.network.generateEndorsedCertificate(
               nodeInfo.certificate_signing_request,
               args.valid_from,
-              args.validity_period_days ?? max_allowed_cert_validity_period_days
+              args.validity_period_days ??
+                max_allowed_cert_validity_period_days,
             );
             ccf.kv["public:ccf.gov.nodes.endorsed_certificates"].set(
               ccf.strToBuf(args.node_id),
-              ccf.strToBuf(endorsed_node_cert)
+              ccf.strToBuf(endorsed_node_cert),
             );
           }
         }
-      }
+      },
     ),
   ],
   [
@@ -993,15 +1518,14 @@ const actions = new Map([
         checkEntityId(args.node_id, "node_id");
       },
       function (args) {
-        const rawConfig = ccf.kv["public:ccf.gov.service.config"].get(
-          getSingletonKvKey()
-        );
+        const rawConfig =
+          ccf.kv["public:ccf.gov.service.config"].get(getSingletonKvKey());
         if (rawConfig === undefined) {
           throw new Error("Service configuration could not be found");
         }
         const serviceConfig = ccf.bufToJsonCompatible(rawConfig);
         const node = ccf.kv["public:ccf.gov.nodes.info"].get(
-          ccf.strToBuf(args.node_id)
+          ccf.strToBuf(args.node_id),
         );
         if (node === undefined) {
           return;
@@ -1009,19 +1533,16 @@ const actions = new Map([
         const node_obj = ccf.bufToJsonCompatible(node);
         if (node_obj.status === "Pending") {
           ccf.kv["public:ccf.gov.nodes.info"].delete(
-            ccf.strToBuf(args.node_id)
+            ccf.strToBuf(args.node_id),
           );
         } else {
-          node_obj.status =
-            serviceConfig.reconfiguration_type === "TwoTransaction"
-              ? "Retiring"
-              : "Retired";
+          node_obj.status = "Retired";
           ccf.kv["public:ccf.gov.nodes.info"].set(
             ccf.strToBuf(args.node_id),
-            ccf.jsonCompatibleToBuf(node_obj)
+            ccf.jsonCompatibleToBuf(node_obj),
           );
         }
-      }
+      },
     ),
   ],
   [
@@ -1034,19 +1555,19 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
       function (args) {
         const node = ccf.kv["public:ccf.gov.nodes.info"].get(
-          ccf.strToBuf(args.node_id)
+          ccf.strToBuf(args.node_id),
         );
         if (node === undefined) {
           throw new Error(`No such node: ${args.node_id}`);
@@ -1060,9 +1581,9 @@ const actions = new Map([
           args.node_id,
           nodeInfo,
           args.valid_from,
-          args.validity_period_days
+          args.validity_period_days,
         );
-      }
+      },
     ),
   ],
   [
@@ -1074,13 +1595,13 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
@@ -1093,11 +1614,11 @@ const actions = new Map([
               nodeId,
               nodeInfo,
               args.valid_from,
-              args.validity_period_days
+              args.validity_period_days,
             );
           }
         });
-      }
+      },
     ),
   ],
   [
@@ -1109,22 +1630,22 @@ const actions = new Map([
           checkType(
             args.validity_period_days,
             "integer",
-            "validity_period_days"
+            "validity_period_days",
           );
           checkBounds(
             args.validity_period_days,
             1,
             null,
-            "validity_period_days"
+            "validity_period_days",
           );
         }
       },
       function (args) {
         setServiceCertificateValidityPeriod(
           args.valid_from,
-          args.validity_period_days
+          args.validity_period_days,
         );
-      }
+      },
     ),
   ],
   [
@@ -1132,19 +1653,36 @@ const actions = new Map([
     new Action(
       function (args) {
         for (var key in args) {
-          if (key !== "reconfiguration_type" && key !== "recovery_threshold") {
+          if (
+            ![
+              "reconfiguration_type",
+              "recovery_threshold",
+              "recent_cose_proposals_window_size",
+            ].includes(key)
+          ) {
             throw new Error(
-              `Cannot change ${key} via set_service_configuration.`
+              `Cannot change ${key} via set_service_configuration.`,
             );
           }
         }
         checkType(args.reconfiguration_type, "string?", "reconfiguration type");
         checkType(args.recovery_threshold, "integer?", "recovery threshold");
         checkBounds(args.recovery_threshold, 1, 254, "recovery threshold");
+        checkType(
+          args.recent_cose_proposals_window_size,
+          "integer?",
+          "recent cose proposals window size",
+        );
+        checkBounds(
+          args.recent_cose_proposals_window_size,
+          1,
+          10000,
+          "recent cose proposals window size",
+        );
       },
       function (args) {
         updateServiceConfig(args);
-      }
+      },
     ),
   ],
   [
@@ -1153,7 +1691,7 @@ const actions = new Map([
       function (args) {},
       function (args, proposalId) {
         ccf.node.triggerLedgerChunk();
-      }
+      },
     ),
   ],
   [
@@ -1162,7 +1700,77 @@ const actions = new Map([
       function (args) {},
       function (args, proposalId) {
         ccf.node.triggerSnapshot();
-      }
+      },
+    ),
+  ],
+  [
+    "assert_service_identity",
+    new Action(
+      function (args) {
+        checkX509CertBundle(args.service_identity, "service_identity");
+        const service_info = "public:ccf.gov.service.info";
+        const rawService = ccf.kv[service_info].get(getSingletonKvKey());
+        if (rawService === undefined) {
+          throw new Error("Service information could not be found");
+        }
+        const service = ccf.bufToJsonCompatible(rawService);
+        if (service.cert !== args.service_identity) {
+          throw new Error("Service identity certificate mismatch");
+        }
+      },
+      function (args) {},
+    ),
+  ],
+  [
+    "cleanup_legacy_jwt_records",
+    new Action(
+      function (args) {
+        checkType(
+          args.ensure_new_records_exist,
+          "boolean?",
+          "ensure_new_records_exist",
+        );
+      },
+      function (args) {
+        if (
+          args.ensure_new_records_exist &&
+          ccf.kv["public:ccf.gov.jwt.public_signing_keys_metadata_v2"].size ===
+            0
+        ) {
+          throw new Error("No new JWT public signing keys records found");
+        }
+
+        ccf.kv["public:ccf.gov.jwt.public_signing_keys"].clear();
+        ccf.kv["public:ccf.gov.jwt.public_signing_keys_metadata"].clear();
+        ccf.kv["public:ccf.gov.jwt.public_signing_key_issuer"].clear();
+      },
+    ),
+  ],
+  [
+    "set_node_join_policy",
+    new Action(
+      function (args) {
+        checkType(args.policy, "string", "policy");
+      },
+      function (args, proposalId) {
+        const codeUpdatePolicyTable =
+          ccf.kv["public:ccf.gov.nodes.node_join_policy"];
+        codeUpdatePolicyTable.set(
+          getSingletonKvKey(),
+          ccf.strToBuf(args.policy),
+        );
+      },
+    ),
+  ],
+  [
+    "remove_node_join_policy",
+    new Action(
+      function (args) {},
+      function (args, proposalId) {
+        const codeUpdatePolicyTable =
+          ccf.kv["public:ccf.gov.nodes.node_join_policy"];
+        codeUpdatePolicyTable.delete(getSingletonKvKey());
+      },
     ),
   ],
 ]);

--- a/app/constitution/validate.js
+++ b/app/constitution/validate.js
@@ -9,7 +9,7 @@ export function validate(input) {
         definition.validate(action.args);
       } catch (e) {
         errors.push(
-          `${action.name} at position ${position} failed validation: ${e}\n${e.stack}`
+          `${action.name} at position ${position} failed validation: ${e}\n${e.stack}`,
         );
       }
     } else {

--- a/app/src/cbor.h
+++ b/app/src/cbor.h
@@ -223,6 +223,7 @@ namespace scitt::cbor
   // COSE EC curve constants (RFC 9052)
   static constexpr int64_t COSE_EC_CURVE_P256 = 1;
   static constexpr int64_t COSE_EC_CURVE_P384 = 2;
+  static constexpr int64_t COSE_EC_CURVE_P521 = 3;
 
   // COSE Key parameter labels (RFC 9052)
   static constexpr int64_t COSE_KEY_PARAM_KTY = 1;
@@ -243,6 +244,8 @@ namespace scitt::cbor
         return COSE_EC_CURVE_P256;
       case ccf::crypto::CurveID::SECP384R1:
         return COSE_EC_CURVE_P384;
+      case ccf::crypto::CurveID::SECP521R1:
+        return COSE_EC_CURVE_P521;
       case ccf::crypto::CurveID::NONE:
       case ccf::crypto::CurveID::CURVE25519:
       case ccf::crypto::CurveID::X25519:

--- a/app/src/did/document.h
+++ b/app/src/did/document.h
@@ -118,7 +118,9 @@ namespace scitt::did::alt
   struct DIDDocument
   {
     std::string id;
-    std::string context;
+    // @context may be a single string or an array of strings per the W3C DID
+    // spec, so it is stored as raw JSON rather than a fixed type.
+    nlohmann::json context = {};
     std::string type;
     std::vector<DIDDocumentVerificationMethod> verification_method = {};
     nlohmann::json assertion_method = {};

--- a/app/src/generated/constants.h.in
+++ b/app/src/generated/constants.h.in
@@ -15,9 +15,5 @@ namespace scitt
 
   const std::string SCITT_VERSION = "@SCITT_VERSION@";
   
-  const std::string ATTESTED_FETCH_MRENCLAVE_HEX = "@ATTESTED_FETCH_MRENCLAVE_HEX@"; // NOLINT(readability-redundant-string-init)
-
-  const std::string DID_WEB_RESOLVER_SCRIPT = "@DID_WEB_RESOLVER_SCRIPT@";
-
   // clang-format on
 }

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PRESET=${PRESET:-dev}
 BUILD_DEBUG_CCF_FROM_SOURCE=${BUILD_DEBUG_CCF_FROM_SOURCE:-OFF}
 
 if [ "$BUILD_DEBUG_CCF_FROM_SOURCE" = "ON" ]; then
-    CCF_SOURCE_VERSION="7.0.2"
+    CCF_SOURCE_VERSION="7.0.5"
     echo "Cloning CCF sources"
     rm -rf ccf-source
     rm -rf /opt/h2spec

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION="7.0.2"
+ARG CCF_VERSION="7.0.5"
 
 # Pin a specific Azure Linux base image tag for reproducibility.
 # Dependabot will monitor and update this FROM line.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -121,7 +121,7 @@ Now it is clear that the contents of the policy (image layers) can be trusted in
 
     ```sh
     $ cat docker/Dockerfile | grep CCF_VERSION=
-    ARG CCF_VERSION=7.0.2
+    ARG CCF_VERSION=7.0.5
 
     $ cat docker/Dockerfile | grep BASE_IMAGE=
     ARG BASE_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0.20250402
@@ -129,7 +129,7 @@ Now it is clear that the contents of the policy (image layers) can be trusted in
 - Run a build inside of the CCF docker image and make sure to use a specific path (`__w/1/s`) to the sources as this is where our Azure build server copies the sources before building. If the build was done somewhere else, make sure to obtain the required path value:
 
     ```sh
-    $ export CCF_VERSION="7.0.2"
+    $ export CCF_VERSION="7.0.5"
     $ export BASE_IMAGE="mcr.microsoft.com/azurelinux/base/core:3.0.20250402"
     $ docker run -it --rm \
         -w /__w/1/s -v $(pwd):/__w/1/s \

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-CCF_VERSION=${CCF_VERSION:-"7.0.2"}
+CCF_VERSION=${CCF_VERSION:-"7.0.5"}
 
 tdnf update -y
 

--- a/test/infra/jwt_issuer.py
+++ b/test/infra/jwt_issuer.py
@@ -7,10 +7,12 @@ from pyscitt import crypto
 
 
 class JwtIssuer:
-    def __init__(self, name="example.com"):
+    def __init__(self, name="https://example.com"):
         self.name = name
         self.key, _ = crypto.generate_rsa_keypair()
-        self.cert = crypto.generate_cert(self.key, cn=name)
+        # The certificate is self-signed, so it must be a CA to chain to itself
+        # as required by the constitution's set_jwt_issuer validation.
+        self.cert = crypto.generate_cert(self.key, cn=name, ca=True)
         self.key_id = crypto.get_cert_fingerprint(self.cert)
 
     def create_token(self, claims={}):


### PR DESCRIPTION
Update the CCF version to 7.0.5 across relevant files and remove unused constants to streamline the codebase. Additionally, sync the default constitution based on the latest CCF updates.