### PR TITLE
Convert kids to bstr and update to CCF 7.0.6

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION="7.0.5"
+ARG CCF_VERSION="7.0.6"
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,9 +39,9 @@ It is expected that you have Azure Linux 3.0. Follow the steps below to setup yo
 
 2. Install dependencies:
     ```sh
-    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-7.0.5.tar.gz
-    tar xvzf ccf-7.0.5.tar.gz
-    cd CCF-ccf-7.0.5/scripts/
+    wget https://github.com/microsoft/CCF/archive/refs/tags/ccf-7.0.6.tar.gz
+    tar xvzf ccf-7.0.6.tar.gz
+    cd CCF-ccf-7.0.6/scripts/
     ./setup-dev.sh
     ```
 

--- a/app/src/cbor.h
+++ b/app/src/cbor.h
@@ -275,7 +275,7 @@ namespace scitt::cbor
     QCBOREncode_Init(&ectx, output_buf);
     QCBOREncode_OpenMap(&ectx);
     QCBOREncode_AddInt64ToMapN(&ectx, COSE_KEY_PARAM_KTY, COSE_KEY_TYPE_EC2);
-    QCBOREncode_AddTextToMapN(&ectx, COSE_KEY_PARAM_KID, from_string(kid));
+    QCBOREncode_AddBytesToMapN(&ectx, COSE_KEY_PARAM_KID, from_string(kid));
     QCBOREncode_AddInt64ToMapN(&ectx, COSE_KEY_PARAM_CRV, crv);
     QCBOREncode_AddBytesToMapN(&ectx, COSE_KEY_PARAM_X, from_bytes(x));
     QCBOREncode_AddBytesToMapN(&ectx, COSE_KEY_PARAM_Y, from_bytes(y));

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ PRESET=${PRESET:-dev}
 BUILD_DEBUG_CCF_FROM_SOURCE=${BUILD_DEBUG_CCF_FROM_SOURCE:-OFF}
 
 if [ "$BUILD_DEBUG_CCF_FROM_SOURCE" = "ON" ]; then
-    CCF_SOURCE_VERSION="7.0.5"
+    CCF_SOURCE_VERSION="7.0.6"
     echo "Cloning CCF sources"
     rm -rf ccf-source
     rm -rf /opt/h2spec

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG CCF_VERSION="7.0.5"
+ARG CCF_VERSION="7.0.6"
 
 # Pin a specific Azure Linux base image tag for reproducibility.
 # Dependabot will monitor and update this FROM line.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -121,7 +121,7 @@ Now it is clear that the contents of the policy (image layers) can be trusted in
 
     ```sh
     $ cat docker/Dockerfile | grep CCF_VERSION=
-    ARG CCF_VERSION=7.0.5
+    ARG CCF_VERSION=7.0.6
 
     $ cat docker/Dockerfile | grep BASE_IMAGE=
     ARG BASE_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0.20250402
@@ -129,7 +129,7 @@ Now it is clear that the contents of the policy (image layers) can be trusted in
 - Run a build inside of the CCF docker image and make sure to use a specific path (`__w/1/s`) to the sources as this is where our Azure build server copies the sources before building. If the build was done somewhere else, make sure to obtain the required path value:
 
     ```sh
-    $ export CCF_VERSION="7.0.5"
+    $ export CCF_VERSION="7.0.6"
     $ export BASE_IMAGE="mcr.microsoft.com/azurelinux/base/core:3.0.20250402"
     $ docker run -it --rm \
         -w /__w/1/s -v $(pwd):/__w/1/s \

--- a/pyscitt/pyscitt/client.py
+++ b/pyscitt/pyscitt/client.py
@@ -608,7 +608,11 @@ class Client(BaseClient):
         resp.raise_for_status()
         return cbor2.loads(resp.read())
 
-    def get_scitt_key(self, kid: str) -> dict:
+    def get_scitt_key(self, kid: Union[str, bytes]) -> dict:
+        # The COSE_Key 'kid' is a bstr (RFC 9052), but the URL path expects its
+        # textual (hex) form, so decode bytes to str when needed.
+        if isinstance(kid, bytes):
+            kid = kid.decode()
         resp = self.get(f"/.well-known/scitt-keys/{kid}")
         resp.raise_for_status()
         return cbor2.loads(resp.read())

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-CCF_VERSION=${CCF_VERSION:-"7.0.5"}
+CCF_VERSION=${CCF_VERSION:-"7.0.6"}
 
 tdnf update -y
 

--- a/test/test_ccf.py
+++ b/test/test_ccf.py
@@ -48,7 +48,7 @@ def pem_cert_to_ccf_cose_key(cert_pem: str) -> dict:
     key_size = (curve.key_size + 7) // 8
     return {
         1: 2,  # kty: EC2
-        2: ccf_kid,  # kid
+        2: ccf_kid.encode(),  # kid (bstr per RFC 9052 Section 7)
         -1: crv,  # crv
         -2: numbers.x.to_bytes(key_size, "big"),  # x
         -3: numbers.y.to_bytes(key_size, "big"),  # y


### PR DESCRIPTION
- Update to CCF version 7.0.6 
- Treat 'kid' fields as byte strings in the `.well-known/scitt-keys` endpoint to comply with RFC 9052