### PR TITLE
Update Azure.Security.CodeTransparency SDK to 1.0.0-beta.10 and adapt e2e .NET client

### DIFF
--- a/test/e2e_dotnet_sdk/Program.cs
+++ b/test/e2e_dotnet_sdk/Program.cs
@@ -68,17 +68,15 @@ class Program
 
             Console.WriteLine(parsedArguments.UseAsync ? "Sending the signature (async)..." : "Sending the signature...");
             // CreateEntry (with waitForCommit) registers the statement and returns the
-            // registration receipt. The id needed to download the full transparent
-            // statement is returned in the Location response header (".../entries/{entryId}").
-            Response<BinaryData> createEntryResponse = parsedArguments.UseAsync
+            // registration receipt. The entry id (registration transaction id) is
+            // extracted directly from the receipt, which works whether the entry was
+            // committed inline or via a 303 redirect (the Location header is not
+            // preserved across the redirect).
+            Response<BinaryData> receiptResponse = parsedArguments.UseAsync
                 ? await client.CreateEntryAsync(content, true, default)
                 : client.CreateEntry(content, true, default);
-            if (!createEntryResponse.GetRawResponse().Headers.TryGetValue("Location", out string? location)
-                || string.IsNullOrEmpty(location))
-            {
-                throw new Exception("CreateEntry response did not include a Location header with the entry id");
-            }
-            string entryId = location[(location.LastIndexOf('/') + 1)..];
+            BinaryData receipt = receiptResponse.Value;
+            string entryId = CcfReceipt.GetRegistrationTransactionId(receipt.ToArray());
 
             Console.WriteLine($"Waiting for the transparent statement for entry {{{entryId}}}...");
             Response<BinaryData> transparentStatement = parsedArguments.UseAsync

--- a/test/e2e_dotnet_sdk/Program.cs
+++ b/test/e2e_dotnet_sdk/Program.cs
@@ -19,9 +19,10 @@ class Program
     private const string OperationVerify = "verify";
     private const string EndpointArgument = "--endpoint";
     private const string CaCertificateArgument = "--ca-certificate";
+    private const string AsyncArgument = "--async";
 
 
-    static void Main(string[] args)
+    static async Task Main(string[] args)
     {
         ParsedArguments parsedArguments = ParseArguments(args);
 
@@ -65,12 +66,24 @@ class Program
             }
             CodeTransparencyClient client = new CodeTransparencyClient(submitEndpoint, options);
 
-            Console.WriteLine("Sending the signature...");
-            Response<BinaryData> operationResult = client.CreateEntry(content, true, default);
-            string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
+            Console.WriteLine(parsedArguments.UseAsync ? "Sending the signature (async)..." : "Sending the signature...");
+            // CreateEntry (with waitForCommit) registers the statement and returns the
+            // registration receipt. The id needed to download the full transparent
+            // statement is returned in the Location response header (".../entries/{entryId}").
+            Response<BinaryData> createEntryResponse = parsedArguments.UseAsync
+                ? await client.CreateEntryAsync(content, true, default)
+                : client.CreateEntry(content, true, default);
+            if (!createEntryResponse.GetRawResponse().Headers.TryGetValue("Location", out string? location)
+                || string.IsNullOrEmpty(location))
+            {
+                throw new Exception("CreateEntry response did not include a Location header with the entry id");
+            }
+            string entryId = location[(location.LastIndexOf('/') + 1)..];
 
-            Console.WriteLine($"Waiting for the transparent statement...");
-            Response<BinaryData> transparentStatement = client.GetEntryStatement(entryId);
+            Console.WriteLine($"Waiting for the transparent statement for entry {{{entryId}}}...");
+            Response<BinaryData> transparentStatement = parsedArguments.UseAsync
+                ? await client.GetEntryStatementAsync(entryId)
+                : client.GetEntryStatement(entryId);
             if (transparentStatement.GetRawResponse().Status != 200)
             {
                 Console.WriteLine($"Get transparent statement did not succeed {transparentStatement.GetRawResponse().Status}");
@@ -112,6 +125,7 @@ class Program
         List<string> positionals = new();
         Uri? endpoint = null;
         string? caCertificatePath = null;
+        bool useAsync = false;
 
         for (int index = 0; index < args.Length; index++)
         {
@@ -136,6 +150,12 @@ class Program
                 }
 
                 caCertificatePath = args[++index];
+                continue;
+            }
+
+            if (argument == AsyncArgument)
+            {
+                useAsync = true;
                 continue;
             }
 
@@ -177,7 +197,7 @@ class Program
             throw new ArgumentException("Too many positional arguments for verify");
         }
 
-        return new ParsedArguments(operation, inputPath, outputPath, endpoint, caCertificatePath);
+        return new ParsedArguments(operation, inputPath, outputPath, endpoint, caCertificatePath, useAsync);
     }
 
     private static HttpClientTransport CreateHttpClientTransport(string caCertificatePath)
@@ -257,12 +277,14 @@ class Program
         string inputPath,
         string? outputPath,
         Uri? endpoint,
-        string? caCertificatePath)
+        string? caCertificatePath,
+        bool useAsync)
     {
         public string Operation { get; } = operation;
         public string InputPath { get; } = inputPath;
         public string? OutputPath { get; } = outputPath;
         public Uri? Endpoint { get; } = endpoint;
         public string? CaCertificatePath { get; } = caCertificatePath;
+        public bool UseAsync { get; } = useAsync;
     }
 }

--- a/test/e2e_dotnet_sdk/Program.cs
+++ b/test/e2e_dotnet_sdk/Program.cs
@@ -9,7 +9,6 @@ using System.Text;
 using Azure;
 using Azure.Core.Pipeline;
 using Azure.Security.CodeTransparency;
-using Azure.Security.CodeTransparency.Receipt;
 
 /// <summary>
 /// The main entry point of this script which will be executed in the python test.
@@ -67,7 +66,7 @@ class Program
             CodeTransparencyClient client = new CodeTransparencyClient(submitEndpoint, options);
 
             Console.WriteLine("Sending the signature...");
-            Operation<BinaryData> operationResult = client.CreateEntry(WaitUntil.Completed, content);
+            Response<BinaryData> operationResult = client.CreateEntry(content, true, default);
             string entryId = CborUtils.GetStringValueFromCborMapByKey(operationResult.Value.ToArray(), "EntryId");
 
             Console.WriteLine($"Waiting for the transparent statement...");

--- a/test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj
+++ b/test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.8" />
+	  <PackageReference Include="Azure.Security.CodeTransparency" Version="1.0.0-beta.10" />
   </ItemGroup>
 
 </Project>

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -360,8 +360,10 @@ class TestPolicyEngine:
         transparent_statement.write_bytes(statement)
 
     @pytest.mark.dotnet
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
     def test_dotnet_submit_existing_cose_to_local_service(
         self,
+        use_async: bool,
         tmp_path: Path,
         service_url: str,
         configure_service,
@@ -370,6 +372,7 @@ class TestPolicyEngine:
         """
         This test submits an existing COSE message to the service using the .NET SDK, which applies the policy and returns a transparent statement.
         This allows avoiding unexpected regressions for the exisiting users of the SDK.
+        Both the synchronous and asynchronous CreateEntry (waitForCommit) code paths are exercised.
         """
         configure_service({"policy": policies.SAMPLE["js"]})
 
@@ -387,6 +390,7 @@ class TestPolicyEngine:
         def run_dotnet(
             operation: str, *paths: Path
         ) -> subprocess.CompletedProcess[str]:
+            optional_flags = ["--async"] if use_async else []
             return subprocess.run(
                 [
                     "dotnet",
@@ -399,6 +403,7 @@ class TestPolicyEngine:
                     service_url,
                     "--ca-certificate",
                     str(ca_certificate_path),
+                    *optional_flags,
                     operation,
                     *(str(path) for path in paths),
                 ],


### PR DESCRIPTION
## Summary

Updates the `Azure.Security.CodeTransparency` .NET SDK used by the end-to-end test client (`test/e2e_dotnet_sdk`) from `1.0.0-beta.8` to `1.0.0-beta.10`, adapts the client to the SDK's breaking API changes, and adds regression coverage for both the **synchronous** and **asynchronous** submission paths.

## Why these changes are needed

`1.0.0-beta.10` introduced breaking changes that the e2e client relied on:

1. **`Azure.Security.CodeTransparency.Receipt` namespace removed** — `CborUtils` moved to the root `Azure.Security.CodeTransparency` namespace, so the old `using Azure.Security.CodeTransparency.Receipt;` no longer compiles (`CS0234`).
2. **`CreateEntry(WaitUntil, BinaryData, …)` is now `[Obsolete]`** — the replacement is `CreateEntry(BinaryData, bool waitForCommit, …)` (plus an async `CreateEntryAsync`).
3. **Registration response contract changed** — the new `CreateEntry` no longer returns a CBOR map containing `EntryId`. Its body is now the standalone registration **receipt** (`Content-Type: application/scitt-receipt+cose`), and the entry id (registration transaction id) is obtained from that receipt via `CcfReceipt.GetRegistrationTransactionId(...)`. The previous code parsed `EntryId` out of the `CreateEntry` body and threw at runtime under beta.10 (`the next CBOR data item is of major type '6'`).

## Changes

- **`test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj`** — bump `Azure.Security.CodeTransparency` to `1.0.0-beta.10`.
- **`test/e2e_dotnet_sdk/Program.cs`**
  - Remove the obsolete `using Azure.Security.CodeTransparency.Receipt;`.
  - Rework the submit flow to the beta.10 contract using only **non-obsolete** APIs: `CreateEntry(content, waitForCommit: true)` → extract the entry id from the receipt with `CcfReceipt.GetRegistrationTransactionId(receipt)` → `GetEntryStatement(entryId)` → write the resulting transparent statement.
  - Add an `--async` flag that routes submission through `CreateEntryAsync` / `GetEntryStatementAsync` (`Main` is now `async Task`).
- **`test/test_configuration.py`** — parametrize `test_dotnet_submit_existing_cose_to_local_service` over `use_async` (`sync`, `async`) so both SDK code paths are exercised by the same assertions.

## Why the SDK flow works (submit → receipt → transparent statement)

- `CreateEntry(content, waitForCommit: true)` registers the signed statement and blocks until it is **committed** to the ledger, returning the **registration receipt** (`application/scitt-receipt+cose`).
- The entry id (registration transaction id) is embedded in the receipt and is read with `CcfReceipt.GetRegistrationTransactionId(receipt)`. This is robust regardless of whether the service commits the entry inline or via a `303 See Other` redirect — the `Location` header is **not** preserved across that redirect, so it cannot be relied upon.
- The standalone receipt is not what downstream verifiers consume. The **transparent statement** is the original `COSE_Sign1` with the receipt embedded in its unprotected header (`SCITTReceipts`). It is produced by the service and downloaded via `GetEntryStatement(entryId)`.
- So the client extracts the entry id from the receipt, calls `GetEntryStatement`, and writes the transparent statement. This preserves the beta.8 end result (a statement carrying an embedded receipt) while using beta.10's new response shape — which is exactly why the existing test assertions (`assert output_receipts`) continue to hold.

## Testing

Validated locally against a real SCITT ledger (built the service image, started it, ran the .NET client through pytest):

- `test_dotnet_submit_existing_cose_to_local_service[sync]` — **PASSED**
- `test_dotnet_submit_existing_cose_to_local_service[async]` — **PASSED**
- `dotnet build` is clean (0 warnings, 0 errors) — no obsolete SDK APIs are used.
