### PR TITLE
Read Endpoints JWT policy enforcement configurable with allowUnauthenticatedReads flag

### DIFF
--- a/app/constitution/scitt.js
+++ b/app/constitution/scitt.js
@@ -25,6 +25,7 @@ actions.set("set_scitt_configuration",
       checkType(args.configuration.authentication, "object?", "configuration.authentication");
       if (args.configuration.authentication) {
         checkType(args.configuration.authentication.allowUnauthenticated, "boolean?", "configuration.authentication.allowUnauthenticated");
+        checkType(args.configuration.authentication.allowUnauthenticatedReads, "boolean?", "configuration.authentication.allowUnauthenticatedReads");
         checkType(args.configuration.authentication.jwt, "object?", "configuration.authentication.jwt");
         if (args.configuration.authentication.jwt) {
           checkType(args.configuration.authentication.jwt.requiredClaims, "object?", "configuration.authentication.jwt.requiredClaims");

--- a/app/src/configurable_auth.h
+++ b/app/src/configurable_auth.h
@@ -106,36 +106,20 @@ namespace scitt
    * This policy is always included in the compile time set of policies, but the
    * `authentication.allow_unauthenticated` boolean service configuration option
    * controls whether it is active. The option is false by default.
+   *
+   * When constructed with is_read_policy=true, the policy also checks
+   * `allowUnauthenticatedReads`, enabling a split auth model where write
+   * endpoints require JWT while read endpoints remain publicly accessible.
    */
   class ConfigurableEmptyAuthnPolicy : public ccf::EmptyAuthnPolicy
   {
-    std::unique_ptr<ccf::AuthnIdentity> authenticate(
-      ccf::kv::ReadOnlyTx& tx,
-      const std::shared_ptr<ccf::RpcContext>& ctx,
-      std::string& error_reason) override
-    {
-      auto handle = tx.template ro<ConfigurationTable>(CONFIGURATION_TABLE);
-      auto cfg = handle->get().value_or(Configuration{});
-      if (cfg.authentication.allow_unauthenticated)
-      {
-        return EmptyAuthnPolicy::authenticate(tx, ctx, error_reason);
-      }
-      else
-      {
-        return nullptr;
-      }
-    }
-  };
+    bool is_read_policy_;
 
-  /**
-   * An authentication policy for read endpoints that allows unauthenticated
-   * access based on the `allowUnauthenticatedReads` configuration option.
-   *
-   * This enables a split auth model where write endpoints require JWT
-   * authentication while read endpoints remain publicly accessible.
-   */
-  class ConfigurableEmptyAuthnReadPolicy : public ccf::EmptyAuthnPolicy
-  {
+  public:
+    explicit ConfigurableEmptyAuthnPolicy(bool is_read_policy = false) :
+      is_read_policy_(is_read_policy)
+    {}
+
     std::unique_ptr<ccf::AuthnIdentity> authenticate(
       ccf::kv::ReadOnlyTx& tx,
       const std::shared_ptr<ccf::RpcContext>& ctx,
@@ -143,9 +127,14 @@ namespace scitt
     {
       auto handle = tx.template ro<ConfigurationTable>(CONFIGURATION_TABLE);
       auto cfg = handle->get().value_or(Configuration{});
-      if (
-        cfg.authentication.allow_unauthenticated ||
-        cfg.authentication.allow_unauthenticated_reads)
+
+      bool allow = cfg.authentication.allow_unauthenticated;
+      if (!allow && is_read_policy_)
+      {
+        allow = cfg.authentication.get_allow_unauthenticated_reads();
+      }
+
+      if (allow)
       {
         return EmptyAuthnPolicy::authenticate(tx, ctx, error_reason);
       }

--- a/app/src/configurable_auth.h
+++ b/app/src/configurable_auth.h
@@ -126,4 +126,33 @@ namespace scitt
       }
     }
   };
+
+  /**
+   * An authentication policy for read endpoints that allows unauthenticated
+   * access based on the `allowUnauthenticatedReads` configuration option.
+   *
+   * This enables a split auth model where write endpoints require JWT
+   * authentication while read endpoints remain publicly accessible.
+   */
+  class ConfigurableEmptyAuthnReadPolicy : public ccf::EmptyAuthnPolicy
+  {
+    std::unique_ptr<ccf::AuthnIdentity> authenticate(
+      ccf::kv::ReadOnlyTx& tx,
+      const std::shared_ptr<ccf::RpcContext>& ctx,
+      std::string& error_reason) override
+    {
+      auto handle = tx.template ro<ConfigurationTable>(CONFIGURATION_TABLE);
+      auto cfg = handle->get().value_or(Configuration{});
+      if (
+        cfg.authentication.allow_unauthenticated ||
+        cfg.authentication.allow_unauthenticated_reads)
+      {
+        return EmptyAuthnPolicy::authenticate(tx, ctx, error_reason);
+      }
+      else
+      {
+        return nullptr;
+      }
+    }
+  };
 }

--- a/app/src/configurable_auth.h
+++ b/app/src/configurable_auth.h
@@ -108,8 +108,8 @@ namespace scitt
    * controls whether it is active. The option is false by default.
    *
    * When constructed with is_read_policy=true, the policy also checks
-   * `allowUnauthenticatedReads`, enabling a split auth model where write
-   * endpoints require JWT while read endpoints remain publicly accessible.
+   * `allowUnauthenticatedReads`, enabling selected SCITT retrieval endpoints
+   * to allow unauthenticated access while write endpoints require JWT.
    */
   class ConfigurableEmptyAuthnPolicy : public ccf::EmptyAuthnPolicy
   {

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -136,9 +136,15 @@ namespace scitt
       JWT jwt;
       bool allow_unauthenticated = false;
 
-      // When true, read endpoints (GET) allow unauthenticated access even
-      // when allow_unauthenticated is false and JWT is configured for writes.
-      bool allow_unauthenticated_reads = true;
+      // When set, controls whether read endpoints (GET) allow unauthenticated
+      // access independently of allow_unauthenticated. When unset, inherits
+      // the value of allow_unauthenticated to preserve existing behavior.
+      std::optional<bool> allow_unauthenticated_reads;
+
+      bool get_allow_unauthenticated_reads() const
+      {
+        return allow_unauthenticated_reads.value_or(allow_unauthenticated);
+      }
 
       bool operator==(const Authentication& other) const = default;
     };

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -136,6 +136,10 @@ namespace scitt
       JWT jwt;
       bool allow_unauthenticated = false;
 
+      // When true, read endpoints (GET) allow unauthenticated access even
+      // when allow_unauthenticated is false and JWT is configured for writes.
+      bool allow_unauthenticated_reads = true;
+
       bool operator==(const Authentication& other) const = default;
     };
 
@@ -177,7 +181,9 @@ namespace scitt
     jwt,
     "jwt",
     allow_unauthenticated,
-    "allowUnauthenticated");
+    "allowUnauthenticated",
+    allow_unauthenticated_reads,
+    "allowUnauthenticatedReads");
 
   DECLARE_JSON_TYPE_WITH_OPTIONAL_FIELDS(Configuration);
   DECLARE_JSON_REQUIRED_FIELDS(Configuration);

--- a/app/src/kv_types.h
+++ b/app/src/kv_types.h
@@ -136,9 +136,9 @@ namespace scitt
       JWT jwt;
       bool allow_unauthenticated = false;
 
-      // When set, controls whether read endpoints (GET) allow unauthenticated
-      // access independently of allow_unauthenticated. When unset, inherits
-      // the value of allow_unauthenticated to preserve existing behavior.
+      // When set, controls whether selected SCITT retrieval endpoints allow
+      // unauthenticated access. When unset, inherits allow_unauthenticated to
+      // preserve existing behavior.
       std::optional<bool> allow_unauthenticated_reads;
 
       bool get_allow_unauthenticated_reads() const

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -231,10 +231,10 @@ namespace scitt
         std::make_shared<ConfigurableJwtAuthnPolicy>(),
       };
 
-      // Read endpoints use a separate policy that respects
+      // Read endpoints use a read-aware policy that respects
       // allowUnauthenticatedReads, enabling write-only JWT enforcement.
       const ccf::AuthnPolicies read_authn_policy = {
-        std::make_shared<ConfigurableEmptyAuthnReadPolicy>(),
+        std::make_shared<ConfigurableEmptyAuthnPolicy>(true),
         std::make_shared<ConfigurableJwtAuthnPolicy>(),
       };
 

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -231,6 +231,13 @@ namespace scitt
         std::make_shared<ConfigurableJwtAuthnPolicy>(),
       };
 
+      // Read endpoints use a separate policy that respects
+      // allowUnauthenticatedReads, enabling write-only JWT enforcement.
+      const ccf::AuthnPolicies read_authn_policy = {
+        std::make_shared<ConfigurableEmptyAuthnReadPolicy>(),
+        std::make_shared<ConfigurableJwtAuthnPolicy>(),
+      };
+
       SCITT_DEBUG("Get historical state from CCF");
       auto& state_cache = context.get_historical_state();
 
@@ -505,7 +512,7 @@ namespace scitt
         HTTP_GET,
         scitt::historical::entry_adapter_with_polling(
           get_entry_receipt, state_cache, is_tx_committed),
-        authn_policy)
+        read_authn_policy)
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
         .install();
@@ -563,7 +570,7 @@ namespace scitt
         HTTP_GET,
         scitt::historical::entry_adapter(
           get_entry_statement, state_cache, is_tx_committed),
-        authn_policy)
+        read_authn_policy)
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .set_redirection_strategy(ccf::endpoints::RedirectionStrategy::None)
         .install();
@@ -698,7 +705,7 @@ namespace scitt
         get_entries_tx_ids_path,
         HTTP_GET,
         ccf::json_adapter(get_entries_tx_ids),
-        authn_policy)
+        read_authn_policy)
         .set_auto_schema<void, GetEntriesTransactionIds::Out>()
         .add_query_parameter<size_t>(
           "from", ccf::endpoints::QueryParamPresence::OptionalParameter)
@@ -710,7 +717,7 @@ namespace scitt
 
       register_service_endpoints(context, *this);
 
-      register_operations_endpoints(context, *this, authn_policy);
+      register_operations_endpoints(context, *this, read_authn_policy);
     }
   };
 } // namespace scitt

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -231,8 +231,8 @@ namespace scitt
         std::make_shared<ConfigurableJwtAuthnPolicy>(),
       };
 
-      // Read endpoints use a read-aware policy that respects
-      // allowUnauthenticatedReads, enabling write-only JWT enforcement.
+      // Selected SCITT retrieval endpoints use a read-aware policy that
+      // respects allowUnauthenticatedReads.
       const ccf::AuthnPolicies read_authn_policy = {
         std::make_shared<ConfigurableEmptyAuthnPolicy>(true),
         std::make_shared<ConfigurableJwtAuthnPolicy>(),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,30 @@ To enable JWT authentication in SCITT, add the following config to a `set_scitt_
 }
 ```
 
+### Per-Endpoint Authentication (Write-Only JWT)
+
+By default, when `allowUnauthenticated` is `false`, all endpoints (reads and writes) require JWT authentication. The optional `allowUnauthenticatedReads` field can be set to decouple read and write authentication:
+
+- When `allowUnauthenticatedReads` is **not set**, it inherits the value of `allowUnauthenticated` (preserving existing behavior).
+- When `allowUnauthenticatedReads` is **true**, read endpoints (`GET /entries/*`, `GET /operations/*`) allow unauthenticated access while write endpoints (`POST /entries`) still require JWT.
+- When `allowUnauthenticatedReads` is **false**, all endpoints require JWT.
+
+Example: require JWT for writes only, reads are open:
+```json
+"authentication": {
+  "allowUnauthenticated": false,
+  "allowUnauthenticatedReads": true,
+  "jwt": {
+    "requiredClaims": {
+      "aud": "https://mst-instance.confidential-ledger.azure.com",
+      "iss": "https://login.microsoftonline.com/{tenant-id}/v2.0"
+    }
+  }
+}
+```
+
+Note: Service endpoints (`/configuration`, `/version`, `/jwks`) are always publicly accessible regardless of authentication settings.
+
 ## Policy object
 
 ### Accepted algorithms

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,11 +103,20 @@ To enable JWT authentication in SCITT, add the following config to a `set_scitt_
 
 ### Per-Endpoint Authentication (Write-Only JWT)
 
-By default, when `allowUnauthenticated` is `false`, all endpoints (reads and writes) require JWT authentication. The optional `allowUnauthenticatedReads` field can be set to decouple read and write authentication:
+The optional `allowUnauthenticatedReads` field can widen unauthenticated access to selected SCITT retrieval endpoints while keeping statement registration protected by JWT. It does not override `allowUnauthenticated` when the service is already configured to allow unauthenticated access.
 
-- When `allowUnauthenticatedReads` is **not set**, it inherits the value of `allowUnauthenticated` (preserving existing behavior).
-- When `allowUnauthenticatedReads` is **true**, read endpoints (`GET /entries/*`, `GET /operations/*`) allow unauthenticated access while write endpoints (`POST /entries`) still require JWT.
-- When `allowUnauthenticatedReads` is **false**, all endpoints require JWT.
+| `allowUnauthenticated` | `allowUnauthenticatedReads` | Statement registration | Selected retrieval endpoints |
+| --- | --- | --- | --- |
+| `false` | not set or `false` | JWT required | JWT required |
+| `false` | `true` | JWT required | Unauthenticated access allowed |
+| `true` | any value | Unauthenticated access allowed | Unauthenticated access allowed |
+
+The selected retrieval endpoints are:
+
+- `GET /entries/{txid}`
+- `GET /entries/{txid}/statement`
+- `GET /entries/txIds`
+- `GET /operations/{txid}`
 
 Example: require JWT for writes only, reads are open:
 ```json
@@ -123,7 +132,7 @@ Example: require JWT for writes only, reads are open:
 }
 ```
 
-Note: Service endpoints (`/configuration`, `/version`, `/jwks`) are always publicly accessible regardless of authentication settings.
+Service metadata endpoints remain publicly accessible regardless of authentication settings. These include `/configuration`, `/version`, `/jwks`, `/.well-known/scitt-keys`, `/.well-known/scitt-keys/{kid_value}`, and `/.well-known/transparency-configuration`.
 
 ## Policy object
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -30,13 +30,21 @@ class TestAuthentication:
 
     @pytest.fixture
     def setup(self, configure_service):
-        def f(*, allow_unauthenticated: bool, required_claims=None):
+        def f(
+            *,
+            allow_unauthenticated: bool,
+            required_claims=None,
+            allow_unauthenticated_reads=None,
+        ):
+            auth_config = {
+                "allowUnauthenticated": allow_unauthenticated,
+                "jwt": {"requiredClaims": required_claims},
+            }
+            if allow_unauthenticated_reads is not None:
+                auth_config["allowUnauthenticatedReads"] = allow_unauthenticated_reads
             configure_service(
                 {
-                    "authentication": {
-                        "allowUnauthenticated": allow_unauthenticated,
-                        "jwt": {"requiredClaims": required_claims},
-                    },
+                    "authentication": auth_config,
                     "policy": {
                         "policyScript": "export function apply(phdr) { return true; }"
                     },
@@ -103,3 +111,176 @@ class TestAuthentication:
         submit()
         submit(auth_token=valid_issuer.create_token())
         submit(auth_token=invalid_issuer.create_token())
+
+
+class TestPerEndpointAuthentication:
+    """
+    Tests for the allowUnauthenticatedReads configuration option, which
+    enables a split auth model where writes require JWT while reads are open.
+    """
+
+    @pytest.fixture(scope="class")
+    def signed_statement(self, cert_authority):
+        identity = cert_authority.create_identity(
+            alg="PS384", kty="rsa", add_eku="2.999"
+        )
+        return crypto.sign_json_statement(identity, {"foo": "bar"}, cwt=True)
+
+    @pytest.fixture(scope="class")
+    def valid_issuer(self, client):
+        issuer = JwtIssuer()
+        client.governance.propose(issuer.create_proposal(), must_pass=True)
+        return issuer
+
+    @pytest.fixture
+    def setup(self, configure_service):
+        def f(
+            *,
+            allow_unauthenticated: bool,
+            required_claims=None,
+            allow_unauthenticated_reads=None,
+        ):
+            auth_config = {
+                "allowUnauthenticated": allow_unauthenticated,
+                "jwt": {"requiredClaims": required_claims},
+            }
+            if allow_unauthenticated_reads is not None:
+                auth_config["allowUnauthenticatedReads"] = allow_unauthenticated_reads
+            configure_service(
+                {
+                    "authentication": auth_config,
+                    "policy": {
+                        "policyScript": "export function apply(phdr) { return true; }"
+                    },
+                }
+            )
+
+        return f
+
+    def test_default_inherits_allow_unauthenticated(
+        self, setup, client: Client, signed_statement, valid_issuer
+    ):
+        """
+        When allowUnauthenticatedReads is not set, reads should inherit
+        the value of allowUnauthenticated (ie. existing behavior).
+        """
+        # With JWT required and no allowUnauthenticatedReads set,
+        # both reads and writes should require JWT.
+        setup(allow_unauthenticated=False, required_claims={})
+
+        # Write without JWT should fail
+        with service_error("InvalidAuthenticationInfo"):
+            client.submit_signed_statement_and_wait(signed_statement)
+
+        # Write with JWT should succeed
+        tx = (
+            client.replace(
+                auth_token=valid_issuer.create_token()
+            ).submit_signed_statement_and_wait(signed_statement)
+        ).tx
+
+        # Read without JWT should also fail (inherits allowUnauthenticated=false)
+        with service_error("InvalidAuthenticationInfo"):
+            client.get_receipt(tx)
+
+        # Read with JWT should succeed
+        client.replace(auth_token=valid_issuer.create_token()).get_receipt(tx)
+
+    def test_unauthenticated_reads_with_jwt_writes(
+        self, setup, client: Client, signed_statement, valid_issuer
+    ):
+        """
+        When allowUnauthenticatedReads is true and JWT is configured,
+        writes require JWT but reads are open.
+        """
+        setup(
+            allow_unauthenticated=False,
+            required_claims={},
+            allow_unauthenticated_reads=True,
+        )
+
+        # Write without JWT should fail
+        with service_error("InvalidAuthenticationInfo"):
+            client.submit_signed_statement_and_wait(signed_statement)
+
+        # Write with JWT should succeed
+        tx = (
+            client.replace(
+                auth_token=valid_issuer.create_token()
+            ).submit_signed_statement_and_wait(signed_statement)
+        ).tx
+
+        # Read without JWT should succeed (allowUnauthenticatedReads=true)
+        client.get_receipt(tx)
+
+    def test_all_endpoints_require_jwt(
+        self, setup, client: Client, signed_statement, valid_issuer
+    ):
+        """
+        When both allowUnauthenticated and allowUnauthenticatedReads are false,
+        all endpoints require JWT.
+        """
+        setup(
+            allow_unauthenticated=False,
+            required_claims={},
+            allow_unauthenticated_reads=False,
+        )
+
+        # Write without JWT should fail
+        with service_error("InvalidAuthenticationInfo"):
+            client.submit_signed_statement_and_wait(signed_statement)
+
+        # Write with JWT should succeed
+        tx = (
+            client.replace(
+                auth_token=valid_issuer.create_token()
+            ).submit_signed_statement_and_wait(signed_statement)
+        ).tx
+
+        # Read without JWT should fail
+        with service_error("InvalidAuthenticationInfo"):
+            client.get_receipt(tx)
+
+        # Read with JWT should succeed
+        client.replace(auth_token=valid_issuer.create_token()).get_receipt(tx)
+
+    def test_allow_unauthenticated_overrides_reads(
+        self, setup, client: Client, signed_statement
+    ):
+        """
+        When allowUnauthenticated is true, everything is open regardless
+        of allowUnauthenticatedReads.
+        """
+        setup(
+            allow_unauthenticated=True,
+            allow_unauthenticated_reads=False,
+        )
+
+        # Both write and read should succeed without JWT
+        tx = client.submit_signed_statement_and_wait(signed_statement).tx
+        client.get_receipt(tx)
+
+    def test_backward_compatibility_no_new_field(
+        self, setup, client: Client, signed_statement, valid_issuer
+    ):
+        """
+        When allowUnauthenticatedReads is not set at all in the config,
+        behavior should be identical to pre-change: if allowUnauthenticated
+        is false, both reads and writes are gated.
+        """
+        setup(allow_unauthenticated=False, required_claims={"aud": "compat"})
+
+        # Write without correct JWT should fail
+        with service_error("InvalidAuthenticationInfo"):
+            client.submit_signed_statement_and_wait(signed_statement)
+
+        # Write with correct JWT should succeed
+        tx = (
+            client.replace(
+                auth_token=valid_issuer.create_token({"aud": "compat"})
+            ).submit_signed_statement_and_wait(signed_statement)
+        ).tx
+
+        # Read without JWT should also fail (backward compat)
+        with service_error("InvalidAuthenticationInfo"):
+            client.get_receipt(tx)

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -10,6 +10,47 @@ from .infra.assertions import service_error
 from .infra.jwt_issuer import JwtIssuer
 
 
+def configure_authentication(
+    configure_service,
+    *,
+    allow_unauthenticated: bool,
+    required_claims=None,
+    allow_unauthenticated_reads=None,
+):
+    auth_config = {
+        "allowUnauthenticated": allow_unauthenticated,
+        "jwt": {"requiredClaims": required_claims},
+    }
+    if allow_unauthenticated_reads is not None:
+        auth_config["allowUnauthenticatedReads"] = allow_unauthenticated_reads
+    configure_service(
+        {
+            "authentication": auth_config,
+            "policy": {"policyScript": "export function apply(phdr) { return true; }"},
+        }
+    )
+
+
+def application_read_requests(client: Client, tx: str):
+    return {
+        "entry receipt": lambda: client.get_receipt(tx),
+        "transparent statement": lambda: client.get_transparent_statement(tx),
+        "transaction ID enumeration": lambda: client.get("/entries/txIds"),
+        "operation status": lambda: client.get(f"/operations/{tx}"),
+    }
+
+
+def assert_application_reads_succeed(client: Client, tx: str):
+    for request in application_read_requests(client, tx).values():
+        request()
+
+
+def assert_application_reads_require_authentication(client: Client, tx: str):
+    for request in application_read_requests(client, tx).values():
+        with service_error("InvalidAuthenticationInfo"):
+            request()
+
+
 class TestAuthentication:
     @pytest.fixture(scope="class")
     def signed_statement(self, cert_authority):
@@ -30,26 +71,8 @@ class TestAuthentication:
 
     @pytest.fixture
     def setup(self, configure_service):
-        def f(
-            *,
-            allow_unauthenticated: bool,
-            required_claims=None,
-            allow_unauthenticated_reads=None,
-        ):
-            auth_config = {
-                "allowUnauthenticated": allow_unauthenticated,
-                "jwt": {"requiredClaims": required_claims},
-            }
-            if allow_unauthenticated_reads is not None:
-                auth_config["allowUnauthenticatedReads"] = allow_unauthenticated_reads
-            configure_service(
-                {
-                    "authentication": auth_config,
-                    "policy": {
-                        "policyScript": "export function apply(phdr) { return true; }"
-                    },
-                }
-            )
+        def f(**kwargs):
+            configure_authentication(configure_service, **kwargs)
 
         return f
 
@@ -134,26 +157,8 @@ class TestPerEndpointAuthentication:
 
     @pytest.fixture
     def setup(self, configure_service):
-        def f(
-            *,
-            allow_unauthenticated: bool,
-            required_claims=None,
-            allow_unauthenticated_reads=None,
-        ):
-            auth_config = {
-                "allowUnauthenticated": allow_unauthenticated,
-                "jwt": {"requiredClaims": required_claims},
-            }
-            if allow_unauthenticated_reads is not None:
-                auth_config["allowUnauthenticatedReads"] = allow_unauthenticated_reads
-            configure_service(
-                {
-                    "authentication": auth_config,
-                    "policy": {
-                        "policyScript": "export function apply(phdr) { return true; }"
-                    },
-                }
-            )
+        def f(**kwargs):
+            configure_authentication(configure_service, **kwargs)
 
         return f
 
@@ -179,12 +184,13 @@ class TestPerEndpointAuthentication:
             ).submit_signed_statement_and_wait(signed_statement)
         ).tx
 
-        # Read without JWT should also fail (inherits allowUnauthenticated=false)
-        with service_error("InvalidAuthenticationInfo"):
-            client.get_receipt(tx)
+        # Reads without JWT should also fail (inherits allowUnauthenticated=false)
+        assert_application_reads_require_authentication(client, tx)
 
-        # Read with JWT should succeed
-        client.replace(auth_token=valid_issuer.create_token()).get_receipt(tx)
+        # Reads with JWT should succeed
+        assert_application_reads_succeed(
+            client.replace(auth_token=valid_issuer.create_token()), tx
+        )
 
     def test_unauthenticated_reads_with_jwt_writes(
         self, setup, client: Client, signed_statement, valid_issuer
@@ -210,15 +216,15 @@ class TestPerEndpointAuthentication:
             ).submit_signed_statement_and_wait(signed_statement)
         ).tx
 
-        # Read without JWT should succeed (allowUnauthenticatedReads=true)
-        client.get_receipt(tx)
+        # Selected reads should succeed without JWT.
+        assert_application_reads_succeed(client, tx)
 
-    def test_all_endpoints_require_jwt(
+    def test_application_endpoints_require_jwt(
         self, setup, client: Client, signed_statement, valid_issuer
     ):
         """
         When both allowUnauthenticated and allowUnauthenticatedReads are false,
-        all endpoints require JWT.
+        statement registration and selected retrieval endpoints require JWT.
         """
         setup(
             allow_unauthenticated=False,
@@ -237,12 +243,13 @@ class TestPerEndpointAuthentication:
             ).submit_signed_statement_and_wait(signed_statement)
         ).tx
 
-        # Read without JWT should fail
-        with service_error("InvalidAuthenticationInfo"):
-            client.get_receipt(tx)
+        # Reads without JWT should fail
+        assert_application_reads_require_authentication(client, tx)
 
-        # Read with JWT should succeed
-        client.replace(auth_token=valid_issuer.create_token()).get_receipt(tx)
+        # Reads with JWT should succeed
+        assert_application_reads_succeed(
+            client.replace(auth_token=valid_issuer.create_token()), tx
+        )
 
     def test_allow_unauthenticated_overrides_reads(
         self, setup, client: Client, signed_statement
@@ -256,9 +263,9 @@ class TestPerEndpointAuthentication:
             allow_unauthenticated_reads=False,
         )
 
-        # Both write and read should succeed without JWT
+        # Both writes and selected reads should succeed without JWT.
         tx = client.submit_signed_statement_and_wait(signed_statement).tx
-        client.get_receipt(tx)
+        assert_application_reads_succeed(client, tx)
 
     def test_backward_compatibility_no_new_field(
         self, setup, client: Client, signed_statement, valid_issuer
@@ -281,6 +288,11 @@ class TestPerEndpointAuthentication:
             ).submit_signed_statement_and_wait(signed_statement)
         ).tx
 
-        # Read without JWT should also fail (backward compat)
-        with service_error("InvalidAuthenticationInfo"):
-            client.get_receipt(tx)
+        # Reads without JWT should also fail (backward compat)
+        assert_application_reads_require_authentication(client, tx)
+
+        # Reads with the configured JWT should succeed.
+        assert_application_reads_succeed(
+            client.replace(auth_token=valid_issuer.create_token({"aud": "compat"})),
+            tx,
+        )


### PR DESCRIPTION
Adds an optional `allowUnauthenticatedReads` authentication setting for deployments that require JWT on statement registration while allowing unauthenticated access to selected SCITT retrieval endpoints.

## Behavior

`allowUnauthenticatedReads` is optional and inherits `allowUnauthenticated` when omitted, preserving existing behavior:

| `allowUnauthenticated` | `allowUnauthenticatedReads` | `POST /entries` | Selected retrieval endpoints |
| --- | --- | --- | --- |
| `false` | omitted or `false` | JWT required | JWT required |
| `false` | `true` | JWT required | Unauthenticated access allowed |
| `true` | any value | Unauthenticated access allowed | Unauthenticated access allowed |

The selected retrieval endpoints are:

- `GET /entries/{txid}`
- `GET /entries/{txid}/statement`
- `GET /entries/txIds`
- `GET /operations/{txid}`

Service metadata endpoints remain publicly accessible independently of these settings.

## Changes

- Adds the optional configuration field and constitution validation.
- Reuses `ConfigurableEmptyAuthnPolicy` with a read-aware mode.
- Applies the read-aware policy to the selected retrieval endpoints while leaving `POST /entries` on the existing policy.
- Documents the effective configuration modes and public service metadata endpoints.
- Tests every affected retrieval route under inherited, open-read, closed, global-open, and backward-compatible configurations.

## Example: JWT-protected writes with unauthenticated reads

```json
{
  "authentication": {
    "allowUnauthenticated": false,
    "allowUnauthenticatedReads": true,
    "jwt": {
      "requiredClaims": {
        "iss": "https://login.microsoftonline.com/{tenant-id}/v2.0",
        "aud": "https://mst-instance.confidential-ledger.azure.com"
      }
    }
  }
}
```