### PR TITLE
Change Dependabot update interval from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/docker" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
Change Dependabot update interval from weekly to daily for consuming new base image updates faster