### PR TITLE
Fix Azure Linux CI bootstrap package installation

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
           tdnf update -y
-          tdnf install -y build-essential ca-certificates git
+          tdnf install -y --disablerepo azurelinux-official-ms-non-oss build-essential ca-certificates git
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       - run: |
           gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
           tdnf update -y
-          tdnf install -y build-essential ca-certificates git
+          tdnf install -y --disablerepo azurelinux-official-ms-non-oss build-essential ca-certificates git
       - name: Checkout repository
         uses: actions/checkout@v4
       - run: ./scripts/setup-env.sh
@@ -42,7 +42,7 @@ jobs:
         run: |
           gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
           tdnf update -y
-          tdnf install -y build-essential ca-certificates git
+          tdnf install -y --disablerepo azurelinux-official-ms-non-oss build-essential ca-certificates git
       - name: Checkout repository with tags
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
         tdnf update -y
-        tdnf install -y build-essential ca-certificates git
+        tdnf install -y --disablerepo azurelinux-official-ms-non-oss build-essential ca-certificates git
     - name: Checkout repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/long-test.yml
+++ b/.github/workflows/long-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
           tdnf update -y
-          tdnf install -y build-essential ca-certificates git
+          tdnf install -y --disablerepo azurelinux-official-ms-non-oss build-essential ca-certificates git
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -61,7 +61,7 @@ jobs:
         run: |
           gpg --import /etc/pki/rpm-gpg/MICROSOFT-RPM-GPG-KEY
           tdnf update -y
-          tdnf install -y build-essential ca-certificates git
+          tdnf install -y --disablerepo azurelinux-official-ms-non-oss build-essential ca-certificates git
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary

- exclude the Azure Linux Microsoft non-OSS repository from CI bootstrap package installation
- apply the fix consistently to build/test, performance, CodeQL, ASAN, and fuzz workflows
- prevent the unrelated `mdatp` package from entering the build-tool transaction

## Root cause

The floating `mcr.microsoft.com/azurelinux/base/core:3.0` tag currently resolves to the same digest as `3.0.20260711`. Installing `build-essential`, `ca-certificates`, and `git` with all repositories enabled unexpectedly selects `mdatp` from `azurelinux-official-ms-non-oss`. Its pre-install script fails in the minimal container, and the transaction subsequently encounters a missing `libseccomp.so.2`.

## Validation

- reproduced the original RPM transaction failure locally using the exact CI digest `sha256:4d0522bb656cfe2bc567c254bb87c2b086a002db6cba51f71870eb5c6630195c`
- reran the transaction on the same digest with `--disablerepo azurelinux-official-ms-non-oss`; installation completed successfully
- verified the resulting `git 2.45.4` and `gcc 13.2.0` executables
- validated all edited workflow YAML files and ran `git diff --check`