### PR TITLE
Adds dotnet sdk based load test

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -197,14 +197,14 @@ Also see `.github/workflow/bencher.yml`, and the [dashboard](https://bencher.dev
 
 #### HTTP based
 
-To run load tests, you can use the `load_test.py` script located in the `tests` directory. This script allows you to simulate a high load on the scitt-ccf-ledger application and measure its performance under stress.
+To run load tests, you can use the `test_load` test in `test/test_load.py` (with the load driver under `test/load_test/`). It simulates a high load on the scitt-ccf-ledger application and measures its performance under stress.
 
 ```bash
 ./docker/build.sh
 DOCKER=1 ./run_functional_tests.sh -m perf -k test_load --enable-perf
 ```
 
-The output will be stored in the `tests/load_test/locust_stats.json` file, and the chart images generated in `tests/load_test/charts`.
+The output will be stored in the `test/load_test/locust_stats.json` file, and the chart images generated in `test/load_test/charts`.
 
 #### .NET SDK based
 
@@ -215,7 +215,7 @@ To run the same load through the .NET SDK (single process, concurrent, `waitForC
 DOCKER=1 ENABLE_DOTNET_TESTS=1 ./run_functional_tests.sh -m perf -k test_dotnet_load --enable-perf
 ```
 
-The run stats are stored in `tests/load_test/dotnet_load_stats.json` (throughput, latency percentiles, per-second completions), and chart images are generated in `tests/load_test/charts` (`dotnet_throughput.png`, `dotnet_latency.png`, and `dotnet_docker_resources.png` in Docker mode).
+The run stats are stored in `test/load_test/dotnet_load_stats.json` (throughput, latency percentiles, per-second completions), and chart images are generated in `test/load_test/charts` (`dotnet_throughput.png`, `dotnet_latency.png`, and `dotnet_docker_resources.png` in Docker mode).
 
 ### Address sanitization
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -195,6 +195,8 @@ Also see `.github/workflow/bencher.yml`, and the [dashboard](https://bencher.dev
 
 ### Load tests
 
+#### HTTP based
+
 To run load tests, you can use the `load_test.py` script located in the `tests` directory. This script allows you to simulate a high load on the scitt-ccf-ledger application and measure its performance under stress.
 
 ```bash
@@ -203,6 +205,17 @@ DOCKER=1 ./run_functional_tests.sh -m perf -k test_load --enable-perf
 ```
 
 The output will be stored in the `tests/load_test/locust_stats.json` file, and the chart images generated in `tests/load_test/charts`.
+
+#### .NET SDK based
+
+To run the same load through the .NET SDK (single process, concurrent, `waitForCommit`):
+
+```bash
+./docker/build.sh
+DOCKER=1 ENABLE_DOTNET_TESTS=1 ./run_functional_tests.sh -m perf -k test_dotnet_load --enable-perf
+```
+
+The run stats are stored in `tests/load_test/dotnet_load_stats.json` (throughput, latency percentiles, per-second completions), and chart images are generated in `tests/load_test/charts` (`dotnet_throughput.png`, `dotnet_latency.png`, and `dotnet_docker_resources.png` in Docker mode).
 
 ### Address sanitization
 

--- a/docker/dev-config.tmpl.json
+++ b/docker/dev-config.tmpl.json
@@ -19,6 +19,7 @@
       "dNSName:localhost"
     ]
   },
+  "worker_threads": 1,
   "command": {
     "type": "Start",
     "service_certificate_file": "/host/service_cert.pem",

--- a/docker/dev-config.tmpl.json
+++ b/docker/dev-config.tmpl.json
@@ -20,6 +20,10 @@
     ]
   },
   "worker_threads": 1,
+  "ledger_signatures": {
+    "tx_count": 5000,
+    "delay": "100ms"
+  },
   "command": {
     "type": "Start",
     "service_certificate_file": "/host/service_cert.pem",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -23,6 +23,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "perf: only run test if performance testing is enabled."
     )
+    config.addinivalue_line(
+        "markers", "dotnet: only run test if .NET SDK testing is enabled."
+    )
     config.addinivalue_line("markers", "bencher: benchmark tests using bencher.")
 
 

--- a/test/e2e_dotnet_sdk/Program.cs
+++ b/test/e2e_dotnet_sdk/Program.cs
@@ -368,16 +368,19 @@ class Program
         await Task.WhenAll(tasks);
         stopwatch.Stop();
 
+        int successes = inputFiles.Length - failures;
         double seconds = stopwatch.Elapsed.TotalSeconds;
-        double throughput = seconds > 0 ? inputFiles.Length / seconds : 0;
+        // Base throughput on successful submissions so it stays consistent with
+        // the recorded latency and per-second samples (which only count successes).
+        double throughput = seconds > 0 ? successes / seconds : 0;
         Console.WriteLine(
-            $"Load test complete: {inputFiles.Length} submissions, {failures} failures, " +
-            $"total {seconds:F2}s, throughput {throughput:F2} req/s");
+            $"Load test complete: {inputFiles.Length} submissions, {successes} successes, " +
+            $"{failures} failures, total {seconds:F2}s, throughput {throughput:F2} req/s");
 
         if (parsedArguments.StatsFile is string statsFile)
         {
             WriteLoadStats(
-                statsFile, inputFiles.Length, failures, seconds, throughput,
+                statsFile, inputFiles.Length, successes, failures, seconds, throughput,
                 concurrency, useAsync, latenciesMs, completionsPerSecond);
             Console.WriteLine($"Load stats written to {{{statsFile}}}");
         }
@@ -396,6 +399,7 @@ class Program
     private static void WriteLoadStats(
         string path,
         int submissions,
+        int successes,
         int failures,
         double totalSeconds,
         double throughput,
@@ -419,6 +423,7 @@ class Program
         var stats = new
         {
             submissions,
+            successes,
             failures,
             total_seconds = Math.Round(totalSeconds, 3),
             throughput_rps = Math.Round(throughput, 2),

--- a/test/e2e_dotnet_sdk/Program.cs
+++ b/test/e2e_dotnet_sdk/Program.cs
@@ -1,12 +1,15 @@
 ﻿namespace dotnetctscli;
 
+using System.Collections.Concurrent;
 using System.Formats.Cbor;
 using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.Cose;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.Json;
 using Azure;
+using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Security.CodeTransparency;
 
@@ -20,6 +23,11 @@ class Program
     private const string EndpointArgument = "--endpoint";
     private const string CaCertificateArgument = "--ca-certificate";
     private const string AsyncArgument = "--async";
+    private const string SkipTransparentStatementArgument = "--skip-transparent-statement";
+    private const string OperationLoad = "load";
+    private const string ConcurrencyArgument = "--concurrency";
+    private const string StatsFileArgument = "--stats-file";
+    private const int DefaultLoadConcurrency = 10;
 
 
     static async Task Main(string[] args)
@@ -27,9 +35,9 @@ class Program
         ParsedArguments parsedArguments = ParseArguments(args);
 
         string operationArgumentValue = parsedArguments.Operation;
-        if (operationArgumentValue != OperationSubmit && operationArgumentValue != OperationVerify)
+        if (operationArgumentValue != OperationSubmit && operationArgumentValue != OperationVerify && operationArgumentValue != OperationLoad)
         {
-            Console.WriteLine($"First argument must be the operation name, one of [{OperationSubmit}, {OperationVerify}], got {{{ operationArgumentValue }}}");
+            Console.WriteLine($"First argument must be the operation name, one of [{OperationSubmit}, {OperationVerify}, {OperationLoad}], got {{{ operationArgumentValue }}}");
             throw new ArgumentException("Invalid operation name");
         }
 
@@ -45,6 +53,13 @@ class Program
             Console.WriteLine($"Using CA certificate {{{caCertificatePath}}}");
         }
 
+        if (operationArgumentValue == OperationLoad)
+        {
+            await RunLoad(parsedArguments, endpoint, caCertificatePath);
+            Console.WriteLine("Done");
+            return;
+        }
+
         Console.WriteLine("Reading the input file...");
         using FileStream fileStream = File.OpenRead(parsedArguments.InputPath);
         BinaryData content = BinaryData.FromStream(fileStream);
@@ -53,18 +68,7 @@ class Program
         {
             Uri submitEndpoint = endpoint ?? throw new ArgumentException(
                 $"Command line argument {EndpointArgument} must be set when {OperationSubmit} is called");
-            CodeTransparencyClientOptions options = new();
-            // For non-prod endpoints, we expect the identity service to be running in the same environment and can be reached via the same endpoint.
-            Uri? resolvedIdentityEndpoint = ResolveDefaultIdentityEndpoint(submitEndpoint);
-            if (resolvedIdentityEndpoint is not null)
-            {
-                options.IdentityClientEndpoint = resolvedIdentityEndpoint.ToString();
-            }
-            if (caCertificatePath is not null)
-            {
-                options.Transport = CreateHttpClientTransport(caCertificatePath);
-            }
-            CodeTransparencyClient client = new CodeTransparencyClient(submitEndpoint, options);
+            CodeTransparencyClient client = CreateClient(submitEndpoint, caCertificatePath);
 
             Console.WriteLine(parsedArguments.UseAsync ? "Sending the signature (async)..." : "Sending the signature...");
             // CreateEntry (with waitForCommit) registers the statement and returns the
@@ -78,19 +82,26 @@ class Program
             BinaryData receipt = receiptResponse.Value;
             string entryId = CcfReceipt.GetRegistrationTransactionId(receipt.ToArray());
 
-            Console.WriteLine($"Waiting for the transparent statement for entry {{{entryId}}}...");
-            Response<BinaryData> transparentStatement = parsedArguments.UseAsync
-                ? await client.GetEntryStatementAsync(entryId)
-                : client.GetEntryStatement(entryId);
-            if (transparentStatement.GetRawResponse().Status != 200)
+            if (parsedArguments.SkipTransparentStatement)
             {
-                Console.WriteLine($"Get transparent statement did not succeed {transparentStatement.GetRawResponse().Status}");
-                throw new Exception($"Get transparent statement did not succeed {transparentStatement.GetRawResponse().Status}");
+                Console.WriteLine($"Skipping the transparent statement download for entry {{{entryId}}}");
             }
+            else
+            {
+                Console.WriteLine($"Waiting for the transparent statement for entry {{{entryId}}}...");
+                Response<BinaryData> transparentStatement = parsedArguments.UseAsync
+                    ? await client.GetEntryStatementAsync(entryId)
+                    : client.GetEntryStatement(entryId);
+                if (transparentStatement.GetRawResponse().Status != 200)
+                {
+                    Console.WriteLine($"Get transparent statement did not succeed {transparentStatement.GetRawResponse().Status}");
+                    throw new Exception($"Get transparent statement did not succeed {transparentStatement.GetRawResponse().Status}");
+                }
 
-            BinaryData signatureWithReceipt = transparentStatement.Value;
-            Console.WriteLine($"Writing the receipt bytes {{{signatureWithReceipt.ToMemory().Length}}} to {{{parsedArguments.OutputPath}}}");
-            File.WriteAllBytes(parsedArguments.OutputPath!, signatureWithReceipt.ToArray());
+                BinaryData signatureWithReceipt = transparentStatement.Value;
+                Console.WriteLine($"Writing the receipt bytes {{{signatureWithReceipt.ToMemory().Length}}} to {{{parsedArguments.OutputPath}}}");
+                File.WriteAllBytes(parsedArguments.OutputPath!, signatureWithReceipt.ToArray());
+            }
         }
         else if (operationArgumentValue == OperationVerify)
         {
@@ -124,6 +135,9 @@ class Program
         Uri? endpoint = null;
         string? caCertificatePath = null;
         bool useAsync = false;
+        bool skipTransparentStatement = false;
+        int concurrency = DefaultLoadConcurrency;
+        string? statsFile = null;
 
         for (int index = 0; index < args.Length; index++)
         {
@@ -157,6 +171,37 @@ class Program
                 continue;
             }
 
+            if (argument == SkipTransparentStatementArgument)
+            {
+                skipTransparentStatement = true;
+                continue;
+            }
+
+            if (argument == ConcurrencyArgument)
+            {
+                if (index + 1 >= args.Length)
+                {
+                    throw new ArgumentException($"Missing value for {ConcurrencyArgument}");
+                }
+
+                if (!int.TryParse(args[++index], out concurrency) || concurrency < 1)
+                {
+                    throw new ArgumentException($"{ConcurrencyArgument} must be a positive integer");
+                }
+                continue;
+            }
+
+            if (argument == StatsFileArgument)
+            {
+                if (index + 1 >= args.Length)
+                {
+                    throw new ArgumentException($"Missing value for {StatsFileArgument}");
+                }
+
+                statsFile = args[++index];
+                continue;
+            }
+
             if (argument.StartsWith("--", StringComparison.Ordinal))
             {
                 throw new ArgumentException($"Unknown command line argument {{{argument}}}");
@@ -177,25 +222,225 @@ class Program
 
         if (operation == OperationSubmit)
         {
-            if (positionals.Count < 3)
+            if (skipTransparentStatement)
             {
-                Console.WriteLine("Third argument must be a path to the output file");
-                throw new ArgumentException("Missing output file path");
+                // The output file only holds the downloaded transparent statement,
+                // so it is neither required nor used when the download is skipped.
+                if (positionals.Count > 2)
+                {
+                    throw new ArgumentException("Too many positional arguments for submit");
+                }
             }
-
-            outputPath = positionals[2];
-
-            if (positionals.Count > 3)
+            else
             {
-                throw new ArgumentException("Too many positional arguments for submit");
+                if (positionals.Count < 3)
+                {
+                    Console.WriteLine("Third argument must be a path to the output file");
+                    throw new ArgumentException("Missing output file path");
+                }
+
+                outputPath = positionals[2];
+
+                if (positionals.Count > 3)
+                {
+                    throw new ArgumentException("Too many positional arguments for submit");
+                }
             }
         }
         else if (operation == OperationVerify && positionals.Count > 2)
         {
             throw new ArgumentException("Too many positional arguments for verify");
         }
+        else if (operation == OperationLoad && positionals.Count > 2)
+        {
+            throw new ArgumentException("Too many positional arguments for load");
+        }
 
-        return new ParsedArguments(operation, inputPath, outputPath, endpoint, caCertificatePath, useAsync);
+        return new ParsedArguments(operation, inputPath, outputPath, endpoint, caCertificatePath, useAsync, skipTransparentStatement, concurrency, statsFile);
+    }
+
+    private static CodeTransparencyClient CreateClient(Uri endpoint, string? caCertificatePath)
+    {
+        // Cap the exponential backoff and reduce the number of retries so that
+        // submissions fail fast rather than retrying for a long time under load.
+        DelayStrategy aggressiveDelayStrategy = DelayStrategy.CreateExponentialDelayStrategy(
+            TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(60));
+        CodeTransparencyClientOptions options = new()
+        {
+            RetryPolicy = new RetryPolicy(maxRetries: 10, delayStrategy: aggressiveDelayStrategy),
+        };
+        // For non-prod endpoints, we expect the identity service to be running in
+        // the same environment and can be reached via the same endpoint.
+        Uri? resolvedIdentityEndpoint = ResolveDefaultIdentityEndpoint(endpoint);
+        if (resolvedIdentityEndpoint is not null)
+        {
+            options.IdentityClientEndpoint = resolvedIdentityEndpoint.ToString();
+        }
+        if (caCertificatePath is not null)
+        {
+            options.Transport = CreateHttpClientTransport(caCertificatePath);
+        }
+        return new CodeTransparencyClient(endpoint, options);
+    }
+
+    /// <summary>
+    /// Submits every *.cose statement found in the input directory concurrently
+    /// using a single shared client. Reusing one client keeps the TLS
+    /// connection, HTTP pipeline and JIT-compiled code warm across submissions,
+    /// so the measured throughput reflects the service rather than per-process
+    /// or per-connection startup overhead.
+    /// </summary>
+    private static async Task RunLoad(
+        ParsedArguments parsedArguments, Uri? endpoint, string? caCertificatePath)
+    {
+        Uri loadEndpoint = endpoint ?? throw new ArgumentException(
+            $"Command line argument {EndpointArgument} must be set when {OperationLoad} is called");
+
+        string inputDirectory = parsedArguments.InputPath;
+        if (!Directory.Exists(inputDirectory))
+        {
+            throw new ArgumentException(
+                $"Load input path must be a directory, got {{{inputDirectory}}}");
+        }
+
+        string[] inputFiles = Directory.GetFiles(inputDirectory, "*.cose");
+        if (inputFiles.Length == 0)
+        {
+            throw new ArgumentException(
+                $"No .cose files found in {{{inputDirectory}}}");
+        }
+
+        int concurrency = parsedArguments.Concurrency;
+        bool useAsync = parsedArguments.UseAsync;
+        Console.WriteLine(
+            $"Load test: submitting {inputFiles.Length} statements with concurrency " +
+            $"{concurrency} ({(useAsync ? "async" : "sync")})...");
+
+        CodeTransparencyClient client = CreateClient(loadEndpoint, caCertificatePath);
+
+        using SemaphoreSlim gate = new(concurrency);
+        int failures = 0;
+        // Per-request latencies (ms) and per-second completion counts, collected
+        // concurrently so the run can emit a stats summary similar to the locust
+        // load test's JSON output.
+        var latenciesMs = new ConcurrentBag<double>();
+        var completionsPerSecond = new ConcurrentDictionary<long, int>();
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        IEnumerable<Task> tasks = inputFiles.Select(async inputFile =>
+        {
+            await gate.WaitAsync();
+            long startedMs = stopwatch.ElapsedMilliseconds;
+            try
+            {
+                BinaryData body = BinaryData.FromBytes(
+                    await File.ReadAllBytesAsync(inputFile));
+                // Registration-only load: wait for commit but skip the
+                // transparent statement download.
+                if (useAsync)
+                {
+                    await client.CreateEntryAsync(body, true, default);
+                }
+                else
+                {
+                    // The synchronous SDK call blocks its thread until commit;
+                    // offload to the thread pool so submissions still run
+                    // concurrently (this trades an async continuation for a
+                    // blocked pool thread per in-flight request).
+                    await Task.Run(() => client.CreateEntry(body, true, default));
+                }
+
+                long finishedMs = stopwatch.ElapsedMilliseconds;
+                latenciesMs.Add(finishedMs - startedMs);
+                completionsPerSecond.AddOrUpdate(finishedMs / 1000, 1, (_, count) => count + 1);
+            }
+            catch (Exception e)
+            {
+                Interlocked.Increment(ref failures);
+                Console.WriteLine($"Submission failed for {{{inputFile}}}: {e.Message}");
+            }
+            finally
+            {
+                gate.Release();
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        stopwatch.Stop();
+
+        double seconds = stopwatch.Elapsed.TotalSeconds;
+        double throughput = seconds > 0 ? inputFiles.Length / seconds : 0;
+        Console.WriteLine(
+            $"Load test complete: {inputFiles.Length} submissions, {failures} failures, " +
+            $"total {seconds:F2}s, throughput {throughput:F2} req/s");
+
+        if (parsedArguments.StatsFile is string statsFile)
+        {
+            WriteLoadStats(
+                statsFile, inputFiles.Length, failures, seconds, throughput,
+                concurrency, useAsync, latenciesMs, completionsPerSecond);
+            Console.WriteLine($"Load stats written to {{{statsFile}}}");
+        }
+
+        if (failures > 0)
+        {
+            throw new Exception($"{failures} submission(s) failed during load test");
+        }
+    }
+
+    /// <summary>
+    /// Writes a JSON summary of a load run (aggregate metrics, latency
+    /// percentiles and per-second completion counts) that downstream tooling can
+    /// turn into charts, mirroring the locust load test's stats output.
+    /// </summary>
+    private static void WriteLoadStats(
+        string path,
+        int submissions,
+        int failures,
+        double totalSeconds,
+        double throughput,
+        int concurrency,
+        bool useAsync,
+        IReadOnlyCollection<double> latenciesMs,
+        IDictionary<long, int> completionsPerSecond)
+    {
+        double[] sorted = latenciesMs.OrderBy(value => value).ToArray();
+
+        double Percentile(double percentile)
+        {
+            if (sorted.Length == 0)
+            {
+                return 0;
+            }
+            int rank = (int)Math.Ceiling(percentile / 100.0 * sorted.Length) - 1;
+            return sorted[Math.Clamp(rank, 0, sorted.Length - 1)];
+        }
+
+        var stats = new
+        {
+            submissions,
+            failures,
+            total_seconds = Math.Round(totalSeconds, 3),
+            throughput_rps = Math.Round(throughput, 2),
+            concurrency,
+            mode = useAsync ? "async" : "sync",
+            latency_ms = new
+            {
+                min = sorted.Length > 0 ? Math.Round(sorted[0], 2) : 0,
+                mean = sorted.Length > 0 ? Math.Round(sorted.Average(), 2) : 0,
+                p50 = Math.Round(Percentile(50), 2),
+                p90 = Math.Round(Percentile(90), 2),
+                p99 = Math.Round(Percentile(99), 2),
+                max = sorted.Length > 0 ? Math.Round(sorted[^1], 2) : 0,
+            },
+            requests_per_sec = completionsPerSecond
+                .OrderBy(pair => pair.Key)
+                .ToDictionary(pair => pair.Key.ToString(), pair => pair.Value),
+        };
+
+        string json = JsonSerializer.Serialize(
+            stats, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(path, json);
     }
 
     private static HttpClientTransport CreateHttpClientTransport(string caCertificatePath)
@@ -276,7 +521,10 @@ class Program
         string? outputPath,
         Uri? endpoint,
         string? caCertificatePath,
-        bool useAsync)
+        bool useAsync,
+        bool skipTransparentStatement,
+        int concurrency,
+        string? statsFile)
     {
         public string Operation { get; } = operation;
         public string InputPath { get; } = inputPath;
@@ -284,5 +532,8 @@ class Program
         public Uri? Endpoint { get; } = endpoint;
         public string? CaCertificatePath { get; } = caCertificatePath;
         public bool UseAsync { get; } = useAsync;
+        public bool SkipTransparentStatement { get; } = skipTransparentStatement;
+        public int Concurrency { get; } = concurrency;
+        public string? StatsFile { get; } = statsFile;
     }
 }

--- a/test/load_test/generate_dotnet_charts.py
+++ b/test/load_test/generate_dotnet_charts.py
@@ -1,0 +1,126 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+Generate charts for the .NET SDK load test from its JSON stats output.
+
+The stats file is produced by the .NET CLI `load` operation (via --stats-file)
+and contains aggregate metrics, latency percentiles and per-second completion
+counts. Optionally, Docker resource samples (from docker_monitor) can be
+overlaid.
+
+Usage:
+    python -m test.load_test.generate_dotnet_charts <stats_json> <output_dir> \
+        [--docker-stats <docker_stats_json>]
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def _plot_throughput(stats: dict, out_dir: Path) -> None:
+    rps = stats.get("requests_per_sec", {})
+    if not rps:
+        return
+    seconds = sorted(int(k) for k in rps)
+    values = [rps[str(s)] for s in seconds]
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.plot(seconds, values, marker="o", markersize=3)
+    ax.axhline(
+        stats.get("throughput_rps", 0),
+        color="tab:orange",
+        linestyle="--",
+        label=f"avg {stats.get('throughput_rps', 0):.1f} req/s",
+    )
+    ax.set_title(
+        f"Completions per second "
+        f"(concurrency {stats.get('concurrency', '?')}, {stats.get('mode', '')})"
+    )
+    ax.set_xlabel("elapsed seconds")
+    ax.set_ylabel("completions/s")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "dotnet_throughput.png", dpi=120)
+    plt.close(fig)
+
+
+def _plot_latency(stats: dict, out_dir: Path) -> None:
+    latency = stats.get("latency_ms", {})
+    if not latency:
+        return
+    labels = ["min", "mean", "p50", "p90", "p99", "max"]
+    values = [latency.get(name, 0) for name in labels]
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    bars = ax.bar(labels, values, color="tab:blue")
+    ax.bar_label(bars, fmt="%.0f", padding=2, fontsize=8)
+    ax.set_title("Per-request latency (ms)")
+    ax.set_ylabel("milliseconds")
+    ax.grid(True, axis="y", alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(out_dir / "dotnet_latency.png", dpi=120)
+    plt.close(fig)
+
+
+def _plot_docker(docker_stats_path: Path, out_dir: Path) -> None:
+    data = json.loads(docker_stats_path.read_text())
+    samples = data.get("samples", [])
+    if not samples:
+        return
+    elapsed = [s.get("elapsed_seconds", 0) for s in samples]
+    cpu = [s.get("cpu_percent", 0) for s in samples]
+    mem = [s.get("mem_used_mb", 0) for s in samples]
+
+    fig, ax_cpu = plt.subplots(figsize=(10, 4))
+    ax_cpu.plot(elapsed, cpu, color="tab:red", label="CPU %")
+    ax_cpu.set_xlabel("elapsed seconds")
+    ax_cpu.set_ylabel("CPU %", color="tab:red")
+    ax_cpu.tick_params(axis="y", labelcolor="tab:red")
+    ax_cpu.grid(True, alpha=0.3)
+
+    ax_mem = ax_cpu.twinx()
+    ax_mem.plot(elapsed, mem, color="tab:green", label="Memory (MiB)")
+    ax_mem.set_ylabel("Memory (MiB)", color="tab:green")
+    ax_mem.tick_params(axis="y", labelcolor="tab:green")
+
+    ax_cpu.set_title(f"Container resource usage ({data.get('container', '')})")
+    fig.tight_layout()
+    fig.savefig(out_dir / "dotnet_docker_resources.png", dpi=120)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate charts for the .NET SDK load test stats."
+    )
+    parser.add_argument("stats_json", type=Path, help="Path to the .NET load stats JSON")
+    parser.add_argument("output_dir", type=Path, help="Directory to write charts to")
+    parser.add_argument(
+        "--docker-stats",
+        type=Path,
+        default=None,
+        help="Optional docker_monitor JSON to overlay resource usage",
+    )
+    args = parser.parse_args()
+
+    stats = json.loads(args.stats_json.read_text())
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    _plot_throughput(stats, args.output_dir)
+    _plot_latency(stats, args.output_dir)
+    if args.docker_stats is not None and args.docker_stats.exists():
+        _plot_docker(args.docker_stats, args.output_dir)
+
+    print(f"Charts written to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/load_test/generate_dotnet_charts.py
+++ b/test/load_test/generate_dotnet_charts.py
@@ -101,7 +101,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Generate charts for the .NET SDK load test stats."
     )
-    parser.add_argument("stats_json", type=Path, help="Path to the .NET load stats JSON")
+    parser.add_argument(
+        "stats_json", type=Path, help="Path to the .NET load stats JSON"
+    )
     parser.add_argument("output_dir", type=Path, help="Directory to write charts to")
     parser.add_argument(
         "--docker-stats",

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from test.load_test.docker_monitor import DockerMonitor
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.serialization import Encoding
 
 from pyscitt import crypto
 from pyscitt.client import Client
@@ -17,6 +20,17 @@ NUM_STATEMENTS = 100
 LOCUST_PEAK_USERS = 800
 LOCUST_USERS_SPAWN_RATE = 20
 LOCUST_RUNTIME_SEC = 120
+
+# The .NET SDK load test submits all statements from a single long-lived process
+# using one shared client with waitForCommit. CCF batches many concurrent
+# in-flight submissions into a single commit/signature, so throughput scales with
+# concurrency rather than the ~1s per-request commit latency; a high concurrency
+# is therefore used to approach the service's registration throughput. Batch size
+# and concurrency are tuned to the peak sustained rate of a single-node dev
+# service (which shares the host with the client); larger runs degrade as the
+# ledger and indexes grow, and higher concurrency saturates the shared CPU.
+DOTNET_LOAD_NUM_STATEMENTS = 8000
+DOTNET_LOAD_CONCURRENCY = 800
 
 LOAD_TEST_DIR = Path(__file__).parent / "load_test"
 STATS_FILE = LOAD_TEST_DIR / "locust_stats.json"
@@ -105,3 +119,126 @@ class TestLoad:
         subprocess.run(chart_cmd, check=True)
 
         assert all([s["num_failures"] == 0 for s in stats])
+
+    @pytest.mark.dotnet
+    def test_dotnet_load(
+        self,
+        service_url: str,
+        cert_authority,
+        configure_service,
+        client: Client,
+        tmp_path: Path,
+    ):
+        """
+        Load test the service through the .NET SDK.
+
+        Similar to test_load, but instead of driving the HTTP API directly with
+        locust, statements are submitted using the .NET SDK. A single long-lived
+        process submits all statements concurrently through one shared
+        CodeTransparencyClient (the SDK CLI's `load` operation), so the TLS
+        connection, HTTP pipeline and JIT-compiled code stay warm and the
+        measured throughput reflects the service rather than per-process startup.
+        """
+        configure_service(
+            {"policy": {"policyScript": "export function apply() { return true; }"}}
+        )
+
+        # Generate the signed statements into a dedicated directory so the .NET
+        # load operation only picks up the .cose statements. A single identity is
+        # reused across all statements to keep generation fast for large batches;
+        # each statement is still individually signed and verified by the service.
+        statements_dir = tmp_path / "statements"
+        statements_dir.mkdir()
+        identity = cert_authority.create_identity(
+            alg="ES256", kty="ec", add_eku="2.999"
+        )
+        for i in range(DOTNET_LOAD_NUM_STATEMENTS):
+            signed_statement = crypto.sign_json_statement(
+                identity, {"foo": "bar", "idx": i}, cwt=True
+            )
+            (statements_dir / f"signed_statement{i}.cose").write_bytes(
+                signed_statement
+            )
+
+        # Write the service CA certificate so the SDK can trust the endpoint.
+        repo_root = Path(__file__).resolve().parent.parent
+        project_path = repo_root / "test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj"
+        ca_certificate_path = tmp_path / "service-cert.pem"
+        cacert_pem = client.get_service_certificate()
+        ca_certificate = x509.load_pem_x509_certificate(
+            cacert_pem.encode(), default_backend()
+        )
+        ca_certificate_path.write_bytes(ca_certificate.public_bytes(Encoding.PEM))
+
+        # Build the project once up front so the load run can use --no-build.
+        build = subprocess.run(
+            ["dotnet", "build", "--no-restore", str(project_path)],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert (
+            build.returncode == 0
+        ), f"dotnet build failed\nstdout:\n{build.stdout}\nstderr:\n{build.stderr}"
+
+        # Submit every statement from a single process using one shared client.
+        # Collect a stats JSON (and, in Docker mode, container resource samples)
+        # and turn them into charts, mirroring the locust load test's outputs.
+        stats_file = LOAD_TEST_DIR / "dotnet_load_stats.json"
+        docker_stats_file = LOAD_TEST_DIR / "dotnet_docker_stats.json"
+
+        use_docker_monitor = os.environ.get("DOCKER", "0") == "1"
+        monitor = None
+        if use_docker_monitor:
+            monitor = DockerMonitor(interval=1.0)
+            monitor.start()
+
+        try:
+            result = subprocess.run(
+                [
+                    "dotnet",
+                    "run",
+                    "--no-build",
+                    "--no-restore",
+                    "--project",
+                    str(project_path),
+                    "--",
+                    "--endpoint",
+                    service_url,
+                    "--ca-certificate",
+                    str(ca_certificate_path),
+                    "--concurrency",
+                    str(DOTNET_LOAD_CONCURRENCY),
+                    "--async",
+                    "--stats-file",
+                    str(stats_file),
+                    "load",
+                    str(statements_dir),
+                ],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            if monitor is not None:
+                monitor.stop()
+                monitor.save(docker_stats_file)
+
+        print(result.stdout)
+        assert result.returncode == 0, (
+            f"dotnet load failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        # Generate charts from the stats produced by the .NET load run.
+        chart_cmd = [
+            sys.executable,
+            "-m",
+            "test.load_test.generate_dotnet_charts",
+            str(stats_file),
+            str(CHARTS_DIR),
+        ]
+        if use_docker_monitor and docker_stats_file.exists():
+            chart_cmd += ["--docker-stats", str(docker_stats_file)]
+        subprocess.run(chart_cmd, check=True)

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -9,9 +9,6 @@ from pathlib import Path
 from test.load_test.docker_monitor import DockerMonitor
 
 import pytest
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization import Encoding
 
 from pyscitt import crypto
 from pyscitt.client import Client
@@ -156,23 +153,21 @@ class TestLoad:
             signed_statement = crypto.sign_json_statement(
                 identity, {"foo": "bar", "idx": i}, cwt=True
             )
-            (statements_dir / f"signed_statement{i}.cose").write_bytes(
-                signed_statement
-            )
+            (statements_dir / f"signed_statement{i}.cose").write_bytes(signed_statement)
 
         # Write the service CA certificate so the SDK can trust the endpoint.
+        # get_service_certificate() already returns PEM, so write it as-is to
+        # preserve the full content (including any chain).
         repo_root = Path(__file__).resolve().parent.parent
         project_path = repo_root / "test/e2e_dotnet_sdk/pipeline-dotnet-cts-cli.csproj"
         ca_certificate_path = tmp_path / "service-cert.pem"
-        cacert_pem = client.get_service_certificate()
-        ca_certificate = x509.load_pem_x509_certificate(
-            cacert_pem.encode(), default_backend()
-        )
-        ca_certificate_path.write_bytes(ca_certificate.public_bytes(Encoding.PEM))
+        ca_certificate_path.write_text(client.get_service_certificate())
 
         # Build the project once up front so the load run can use --no-build.
+        # Allow restore here so the test is self-contained when run directly with
+        # pytest (the wrapper script restores separately for warmed CI builds).
         build = subprocess.run(
-            ["dotnet", "build", "--no-restore", str(project_path)],
+            ["dotnet", "build", str(project_path)],
             cwd=repo_root,
             check=False,
             capture_output=True,
@@ -227,9 +222,9 @@ class TestLoad:
                 monitor.save(docker_stats_file)
 
         print(result.stdout)
-        assert result.returncode == 0, (
-            f"dotnet load failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
+        assert (
+            result.returncode == 0
+        ), f"dotnet load failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
         # Generate charts from the stats produced by the .NET load run.
         chart_cmd = [


### PR DESCRIPTION
An example showing that dotnet SDK is capable of pushing many registrations, close to what locust test with fasthttp can do.

Local run produced the following:

Config was:
- Statements: 8000
- Worker threads: 1
- Signature interval: 100 ms (new prod default)

Results:
- **Submissions:** 8000
- **Failures:** 0
- **Total time:** 17.12 s
- **Throughput:** 467.2 req/s
- **Concurrency:** 800
- **Mode:** async (`waitForCommit`)

Latency (ms):
| min | mean | p50 | p90 | p99 | max |
|----:|-----:|----:|----:|----:|----:|
| 323 | 1670 | 1320 | 2994 | 6058 | 6130 |

