### PR TITLE
Verify CCF RPM checksum before install (AB#38023378)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,8 +17,15 @@ RUN tdnf update -y && \
     docker-buildx \
     clang-tools-extra-devel && \
     \
-    # Install the CCF development package
-    curl -L "https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_devel_${CCF_VERSION//-/_}_x86_64.rpm" -o ccf.rpm && \
+    # Download the CCF development package
+    CCF_RPM="ccf_devel_${CCF_VERSION//-/_}_x86_64.rpm" && \
+    curl -L "https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/${CCF_RPM}" -o ccf.rpm && \
+    \
+    # Verify against the SHA-256 GitHub publishes for the release asset (the API
+    # 'digest' field) instead of a hardcoded per-version hash; fails on mismatch.
+    CCF_RPM_SHA256=$(curl -sSL "https://api.github.com/repos/microsoft/CCF/releases/tags/ccf-${CCF_VERSION}" | jq -r --arg name "${CCF_RPM}" '.assets[] | select(.name == $name) | .digest | ltrimstr("sha256:")') && \
+    [ -n "${CCF_RPM_SHA256}" ] && \
+    echo "${CCF_RPM_SHA256}  ccf.rpm" | sha256sum -c - && \
     \
     tdnf install -y ./ccf.rpm && \
     rm ./ccf.rpm && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,10 +26,19 @@ ARG SCITT_VERSION_OVERRIDE
 # Copy the extracted snapshot time from the previous stage
 COPY --from=snapshot-extractor /tmp/tdnf_snapshottime /tmp/tdnf_snapshottime
 
-# Install dependencies and CCF development package first for better layer caching
+# Install dependencies and CCF development package first for better layer caching.
+# The CCF RPM is downloaded and verified against the SHA-256 that GitHub publishes
+# for the release asset (the API 'digest' field) before installation; a checksum
+# mismatch fails the build.
 RUN TDNF_SNAPSHOTTIME=$(cat /tmp/tdnf_snapshottime) && \
-    tdnf install -y --snapshottime=${TDNF_SNAPSHOTTIME} ca-certificates git rpm-build && \
-    tdnf install -y --snapshottime=${TDNF_SNAPSHOTTIME} "https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_devel_${CCF_VERSION//-/_}_x86_64.rpm"
+    tdnf install -y --snapshottime=${TDNF_SNAPSHOTTIME} ca-certificates git jq rpm-build && \
+    CCF_RPM="ccf_devel_${CCF_VERSION//-/_}_x86_64.rpm" && \
+    curl -L "https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/${CCF_RPM}" -o /tmp/ccf.rpm && \
+    CCF_RPM_SHA256=$(curl -sSL "https://api.github.com/repos/microsoft/CCF/releases/tags/ccf-${CCF_VERSION}" | jq -r --arg name "${CCF_RPM}" '.assets[] | select(.name == $name) | .digest | ltrimstr("sha256:")') && \
+    [ -n "${CCF_RPM_SHA256}" ] && \
+    echo "${CCF_RPM_SHA256}  /tmp/ccf.rpm" | sha256sum -c - && \
+    tdnf install -y --snapshottime=${TDNF_SNAPSHOTTIME} /tmp/ccf.rpm && \
+    rm -f /tmp/ccf.rpm
 
 # Copy the app source code after installing dependencies so that
 # changes to app/ don't invalidate the dependency layer above.

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -19,7 +19,20 @@ tdnf install -y \
     clang-tools-extra-devel
 
 # Download the CCF development package
-curl -L "https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/ccf_devel_${CCF_VERSION//-/_}_x86_64.rpm" -o ccf.rpm
+CCF_RPM="ccf_devel_${CCF_VERSION//-/_}_x86_64.rpm"
+curl -L "https://github.com/microsoft/CCF/releases/download/ccf-${CCF_VERSION}/${CCF_RPM}" -o ccf.rpm
+
+# Verify the download against the SHA-256 that GitHub publishes for the release
+# asset (the 'digest' field of the release API). This pulls the expected hash
+# from the CCF release instead of hardcoding it per version.
+CCF_RPM_SHA256=$(curl -sSL "https://api.github.com/repos/microsoft/CCF/releases/tags/ccf-${CCF_VERSION}" \
+    | jq -r --arg name "${CCF_RPM}" '.assets[] | select(.name == $name) | .digest | ltrimstr("sha256:")')
+if [ -z "${CCF_RPM_SHA256}" ]; then
+    echo "ERROR: could not resolve published SHA-256 for ${CCF_RPM} from the CCF release" >&2
+    exit 1
+fi
+# sha256sum exits non-zero (aborting via 'set -e') on mismatch.
+echo "${CCF_RPM_SHA256}  ccf.rpm" | sha256sum -c -
 
 tdnf install -y ./ccf.rpm
 rm -f ccf.rpm


### PR DESCRIPTION
## Summary
Adds download-time integrity verification for the CCF development package (the installer downloaded from Microsoft) before it is installed.

Previously the CCF RPM was pulled from `github.com/microsoft/CCF/releases` and installed with no signature/checksum verification. This change resolves the SHA-256 published with the release (the GitHub release API `digest` field) and verifies it via `sha256sum -c` **before** install, across all three ingestion paths:

- `scripts/setup-env.sh`
- `.devcontainer/Dockerfile`
- `docker/Dockerfile` (builder stage switched from direct-URL install to download → verify → install; `jq` added to the tdnf list)

A checksum mismatch aborts setup/build, so a tampered or substituted artifact can never be installed.

## Work item
Products must verify code signatures on installers/updates downloaded from Microsoft.

AB#38023378

## Validation
- `bash -n scripts/setup-env.sh` passes.
- The expected hash is resolved dynamically from the CCF release API rather than hardcoded, so it stays in sync with `CCF_VERSION`.

## Notes
- The expected hash comes from the CCF release API `digest` field; no per-version hash needs to be maintained manually.
- Possible follow-ups (not in this PR): cryptographic signature verification via `gh attestation verify` against CCF's `attestation.sigstore.json`; base-image digest pinning; `reproduce.json` checksum pinning.
