### PR TITLE
use ccf dep (min 7.0.6) with expanded range of allowed crypto library versions

### DIFF
--- a/pyscitt/README.md
+++ b/pyscitt/README.md
@@ -1,7 +1,15 @@
 # pyscitt: Python CLI tools for SCITT CCF Ledger
 
-Tools to sign claims and interact with a SCITT CCF Ledger.
+Tools to interact with a SCITT CCF Ledger and to verify transparent statements.
 
 For more information, please find the `scitt-ccf-ledger` repository at https://github.com/microsoft/scitt-ccf-ledger.
 
 Package sources are available at https://github.com/microsoft/scitt-ccf-ledger/tree/main/pyscitt.
+
+## Installation
+
+```bash
+pip install pyscitt
+```
+
+

--- a/pyscitt/setup.py
+++ b/pyscitt/setup.py
@@ -6,7 +6,7 @@ from os import path
 from setuptools import find_packages, setup
 
 PACKAGE_NAME = "pyscitt"
-PACKAGE_VERSION = "0.14.0"
+PACKAGE_VERSION = "0.14.1"
 
 path_here = path.abspath(path.dirname(__file__))
 
@@ -25,8 +25,8 @@ setup(
     },
     python_requires=">=3.12",
     install_requires=[
-        "ccf==7.*",
-        "cryptography==46.*",  # needs to match ccf
+        "ccf>=7.0.6,<8",
+        "cryptography>=48.0.1,<50",  # needs to match ccf
         "httpx",
         "cbor2==5.8.*",
         "pycose==1.1.0",

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -4,8 +4,8 @@ httpx
 pytest
 loguru
 aiotools
-ccf==7.*
-cryptography==46.*
+ccf>=7.0.6,<8
+cryptography==48.*
 jwcrypto==1.5.*
 types-jwcrypto
 cbor2


### PR DESCRIPTION
- bump pyscitt package version to `0.14.1`
- use min ccf 7.0.6 which allows a wider range of cryptography versions 46 to 50
- bump cryptography to 48.0.1
- minor doc changes to pypi index page