### PR TITLE
Update CHANGELOG for 0.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.19.0]
+### Changes
+- 9b81478 Read Endpoints JWT policy enforcement configurable with allowUnauthenticatedReads flag (#420)
+- 44a1ec3 use ccf dep (min 7.0.6) with expanded range of allowed crypto library versions (#431)
+- 0ffd897 Bump azurelinux/base/core from 3.0.20260711 to 3.0.20260722 in /docker (#430)
+- 6820111 Verify CCF RPM checksum before install (AB#38023378) (#429)
+- 8268ffb Adds dotnet sdk based load test (#428)
+
 ## [0.18.0]
 ### Changes
 - 09b5c99 Update CCF to v7 and align API with SCRAPI v09 (#390)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,3 +447,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.17.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.0
 [0.17.1]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.1
 [0.18.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.18.0
+[0.19.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.19.0


### PR DESCRIPTION
Adds the CHANGELOG entry for the upcoming 0.19.0 release, covering changes merged since 0.18.2:

- #420 Read Endpoints JWT policy enforcement configurable with allowUnauthenticatedReads flag
- #431 use ccf dep (min 7.0.6) with expanded range of allowed crypto library versions
- #430 Bump azurelinux/base/core from 3.0.20260711 to 3.0.20260722 in /docker
- #429 Verify CCF RPM checksum before install (AB#38023378)
- #428 Adds dotnet sdk based load test

Part of the ACL Data Plane release process (Step 1.2).