### PR TITLE
Enable CoseAllowDualJoin ledger signatures

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -59,7 +59,9 @@ FetchContent_MakeAvailable(regocpp)
 # add linking options
 # add SAN options if CCF is built with them
 add_ccf_app(scitt
-  SRCS src/main.cpp
+  SRCS
+    src/ledger_sign_mode.cpp
+    src/main.cpp
 )
 
 # Mark third-party targets as SYSTEM so their headers (and transitive deps)

--- a/app/src/ledger_sign_mode.cpp
+++ b/app/src/ledger_sign_mode.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <ccf/node/ledger_sign_mode.h>
+
+namespace ccf
+{
+  LedgerSignMode get_ledger_sign_mode()
+  {
+    return LedgerSignMode::CoseAllowDualJoin;
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -417,6 +417,12 @@ This can also be used to restrict the maximum size to a value smaller than the d
 
 Please refer to the latest [CCF configuration documentation](https://microsoft.github.io/CCF/main/operations/configuration.html) to understand all of the possible options.
 
+### Ledger signature mode
+
+The application selects the CCF ledger signature mode at link time through [`ccf::get_ledger_sign_mode()`](../app/src/ledger_sign_mode.cpp). This build uses `CoseAllowDualJoin`: nodes emit only COSE Sign1 ledger signatures while continuing to accept join requests from nodes using CCF's default `Dual` mode. This supports the first phase of a rolling upgrade to COSE-only ledger signatures.
+
+The mode is not part of the CCF node JSON configuration. Once every node in every ledger has been upgraded, change the callback to return `CoseOnly` and perform a second rolling upgrade. After COSE-only signatures have advanced beyond the latest traditional signature, the ledger cannot be recovered with a `Dual` binary; use a `CoseAllowDualJoin` or `CoseOnly` binary. See [Upgrading to COSE-Only Ledger Signatures](https://ccf.dev/main/operations/configuration.html#upgrading-to-cose-only-ledger-signatures) for the complete sequence.
+
 ### Historical cache soft limit
 
 The size of the historical state cache can be configured per node using the `historical_cache_soft_limit` option in the [CCF node configuration](https://ccf.dev/main/operations/configuration.html#historical-cache-soft-limit). Once the soft limit is exceeded, least recently used states will be evicted from the cache.

--- a/test/test_blocking.py
+++ b/test/test_blocking.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import time
 from hashlib import sha256
+from http import HTTPStatus
 
 import cbor2
 import ccf.cose
@@ -70,5 +72,23 @@ def test_blocking_entries(
         submission.response_bytes,
         service_key,
         sha256(signed_statement).digest(),
+    )
+
+    deadline = time.monotonic() + 3
+    regular_receipt = client.session.get(
+        "/node/receipt", params={"transaction_id": submission.tx}
+    )
+    while (
+        regular_receipt.status_code == HTTPStatus.ACCEPTED
+        and time.monotonic() < deadline
+    ):
+        time.sleep(0.1)
+        regular_receipt = client.session.get(
+            "/node/receipt", params={"transaction_id": submission.tx}
+        )
+
+    assert regular_receipt.status_code == HTTPStatus.INTERNAL_SERVER_ERROR, (
+        "Traditional receipt should be unavailable with COSE-only ledger "
+        f"signatures, got {regular_receipt.status_code}"
     )
     LOG.info("Receipt verification: PASSED")


### PR DESCRIPTION
Configures `cchost` to emit COSE-only ledger signatures while allowing Dual-mode nodes to join during the rolling upgrade. 

Adds receipt coverage and documents the transition to `CoseOnly`.

Validated with build, static checks, and functional tests.