### PR TITLE
Reduce application log volume and harden log forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 6820111 Verify CCF RPM checksum before install (AB#38023378) (#429)
 - 8268ffb Adds dotnet sdk based load test (#428)
 
+## [0.18.2]
+### Changes
+- f797484 Bump azurelinux/base/core from 3.0.20260706 to 3.0.20260711 in /docker (#422)
+- c114a66 Fix Azure Linux CI bootstrap package installation (#423)
+- 668d188 Change Dependabot update interval from weekly to daily (#421)
+- 377f58b Update CCF to 7.0.10 (#419)
+- 0c00ba9 Update Azure.Security.CodeTransparency SDK to 1.0.0-beta.10 (#417)
+- ec8d4f5 Bump azurelinux/base/core from 3.0.20260616 to 3.0.20260706 in /docker (#416)
+- 8ae99bb Update CCF version to 7.0.9 (#415)
+
+## [0.18.1]
+### Changes
+- b6ebc05 Bump azurelinux/base/core from 3.0.20260602 to 3.0.20260616 in /docker (#412)
+- 055bb73 Convert kids to bstr and update to CCF 7.0.6 (#411)
+- f0fef49 Simplify did:x509 resolution to use resolve_jwk() (#409)
+- c83e83d Update README submit example to SCRAPI v09 redirect flow (#410)
+- b5a4b5c Sync CCF version to 7.0.5, update constitution, and clean up constants (#408)
+- 97f0b25 Suppressed CodeQL-SM04458 bug that is flagged in [SFI-PS3.1] (#406)
+- f283198 Bump azurelinux/base/core from 3.0.20260519 to 3.0.20260602 in /docker (#405)
+- 3425abe Bump azurelinux/base/core from 3.0.20260517 to 3.0.20260519 in /docker (#403)
+- 30352ca Bump azurelinux/base/core from 3.0.20260510 to 3.0.20260517 in /docker (#402)
+- 5eae0c0 Bump azurelinux/base/core from 3.0.20260506 to 3.0.20260510 in /docker (#401)
+- bb0ff02 Bump azurelinux/base/core from 3.0.20260401 to 3.0.20260506 in /docker (#400)
+- 5b75e08 Restrict permissions of token provided to bencher job (#399)
+
 ## [0.18.0]
 ### Changes
 - 09b5c99 Update CCF to v7 and align API with SCRAPI v09 (#390)
@@ -448,3 +473,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.17.1]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.17.1
 [0.18.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.18.0
 [0.19.0]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.19.0
+[0.18.1]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.18.1
+[0.18.2]: https://github.com/microsoft/scitt-ccf-ledger/releases/tag/0.18.2

--- a/app/src/app_data.h
+++ b/app/src/app_data.h
@@ -28,6 +28,7 @@ namespace scitt
     // Used by tracing.h
     std::optional<std::string> request_id;
     std::optional<std::string> client_request_id;
+    std::optional<std::string> error_code;
     timespec start_time;
   };
 

--- a/app/src/configurable_auth.h
+++ b/app/src/configurable_auth.h
@@ -86,15 +86,15 @@ namespace scitt
     static void log_auth_error(
       const std::shared_ptr<ccf::RpcContext>& ctx, std::string& error_reason)
     {
-      // CCF returns any errors in the auth policy with a 401 status
+      // Authentication runs before the tracing adapter creates a server
+      // request ID, so emit a self-contained audit record using the optional
+      // client request ID. CCF returns all auth policy errors with status 401.
       CCF_APP_INFO(
-        "ClientRequestId={} Verb={} URL={} Status=401",
+        "ClientRequestId={} Verb={} URL={} Status=401 "
+        "Code=InvalidAuthenticationInfo Reason={}",
         ctx->get_request_header("x-ms-client-request-id").value_or(""),
         ctx->get_request_verb().c_str(),
-        ctx->get_request_url());
-      CCF_APP_INFO(
-        "ClientRequestId={} Code=InvalidAuthenticationInfo {}",
-        ctx->get_request_header("x-ms-client-request-id").value_or(""),
+        ctx->get_request_url(),
         error_reason);
     }
   };

--- a/app/src/cose.h
+++ b/app/src/cose.h
@@ -370,7 +370,7 @@ namespace scitt::cose
         // byte string, not an array.
         // But other implementations mistakenly serialise single certs as bstrs
         // in arrays, so we are not strict here.
-        SCITT_INFO("Single cert found in x5chain array in COSE header.");
+        SCITT_DEBUG("Single cert found in x5chain array in COSE header.");
       }
     }
     else if (x5chain.uDataType == QCBOR_TYPE_BYTE_STRING)
@@ -379,7 +379,7 @@ namespace scitt::cose
     }
     else
     {
-      SCITT_FAIL("Type: {}", x5chain.uDataType);
+      SCITT_DEBUG("Unsupported x5chain value type: {}", x5chain.uDataType);
       throw COSEDecodeError(
         "Value type of x5chain in COSE header is not array or byte "
         "string.");

--- a/app/src/http_error.h
+++ b/app/src/http_error.h
@@ -7,10 +7,14 @@
 #include "tracing.h"
 
 #include <ccf/endpoint.h>
+#include <functional>
 #include <qcbor/qcbor_decode.h>
 #include <qcbor/qcbor_encode.h>
 #include <qcbor/qcbor_spiffy_decode.h>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace scitt
 {

--- a/app/src/http_error.h
+++ b/app/src/http_error.h
@@ -104,22 +104,28 @@ namespace scitt
   };
 
   template <typename Fn, typename Ctx>
-  Fn generic_error_adapter(Fn fn)
+  Fn generic_error_adapter(
+    Fn fn, std::function<void(Ctx&, const std::string&)> record_error_code = {})
   {
-    return [fn](Ctx& ctx) {
+    return [fn, record_error_code](Ctx& ctx) {
       try
       {
         fn(ctx);
       }
       catch (const HTTPError& e)
       {
-        if (e.code == errors::InternalError)
+        if (e.code == errors::InternalError || e.code == errors::PolicyError)
         {
           SCITT_FAIL("Code={} {}", e.code, e.what());
         }
         else
         {
-          SCITT_INFO("Code={}", e.code);
+          SCITT_DEBUG("Code={} {}", e.code, e.what());
+        }
+
+        if (record_error_code)
+        {
+          record_error_code(ctx, e.code);
         }
 
         if (e.returns_cbor_error)
@@ -146,6 +152,10 @@ namespace scitt
           "Unhandled exception in endpoint: Code={} {}",
           uncaught_error.code,
           uncaught_error.what());
+        if (record_error_code)
+        {
+          record_error_code(ctx, uncaught_error.code);
+        }
         ctx.rpc_ctx->set_response_status(uncaught_error.status_code);
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::CONTENT_TYPE, cbor::CBOR_ERROR_CONTENT_TYPE);
@@ -163,6 +173,10 @@ namespace scitt
   {
     return generic_error_adapter<
       ccf::endpoints::EndpointFunction,
-      ccf::endpoints::EndpointContext>(fn);
+      ccf::endpoints::EndpointContext>(
+      fn,
+      [](ccf::endpoints::EndpointContext& ctx, const std::string& error_code) {
+        get_app_data(ctx.rpc_ctx).error_code = error_code;
+      });
   }
 }

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -67,7 +67,7 @@ namespace scitt
   std::optional<T> get_query_value(
     const ccf::http::ParsedQuery& pq, std::string_view name)
   {
-    SCITT_DEBUG("Get parameter value from parsed query");
+    SCITT_TRACE("Get parameter value from parsed query");
     auto it = pq.find(name);
     if (it == pq.end())
     {
@@ -161,7 +161,7 @@ namespace scitt
 
     std::optional<ccf::TxStatus> get_tx_status(ccf::SeqNo seqno)
     {
-      SCITT_DEBUG("Get transaction status");
+      SCITT_TRACE("Get transaction status");
 
       ccf::View view_of_seqno;
       ccf::ApiResult result = get_view_for_seqno_v1(seqno, view_of_seqno);
@@ -171,12 +171,10 @@ namespace scitt
         result = get_status_for_txid_v1(view_of_seqno, seqno, status);
         if (result == ccf::ApiResult::OK)
         {
-          SCITT_DEBUG("Transaction status: {}", ccf::tx_status_to_str(status));
+          SCITT_TRACE("Transaction status: {}", ccf::tx_status_to_str(status));
           return status;
         }
       }
-
-      SCITT_FAIL("Transaction status could not be retrieved");
 
       return std::nullopt;
     }
@@ -307,17 +305,16 @@ namespace scitt
         }
 
         const auto& body = ctx.rpc_ctx->get_request_body();
-        SCITT_DEBUG(
-          "Signed Statement Registration body size: {} bytes", body.size());
-
         auto cfg = ctx.tx.template ro<ConfigurationTable>(CONFIGURATION_TABLE)
                      ->get()
                      .value_or(Configuration{});
 
         const auto max_entry_size =
           cfg.max_signed_statement_bytes.value_or(MAX_ENTRY_SIZE_BYTES_DEFAULT);
-        SCITT_DEBUG(
-          "Maximum allowed Signed Statement size: {} bytes", max_entry_size);
+        SCITT_TRACE(
+          "Signed statement size={} bytes, maximum allowed size={} bytes",
+          body.size(),
+          max_entry_size);
 
         if (body.size() > max_entry_size)
         {
@@ -343,13 +340,12 @@ namespace scitt
         std::optional<verifier::VerifiedSevSnpAttestationDetails> details;
         try
         {
-          SCITT_DEBUG("Verify submitted signed statement");
+          SCITT_TRACE("Verify submitted signed statement");
           std::tie(phdr, uhdr, payload, details) =
             verifier->verify_signed_statement(body, ctx.tx, host_time, cfg);
         }
         catch (const verifier::VerificationError& e)
         {
-          SCITT_DEBUG("Signed statement verification failed: {}", e.what());
           throw BadRequestCborError(errors::InvalidInput, e.what());
         }
 
@@ -358,7 +354,7 @@ namespace scitt
         // CWT issuer is present.
         if (cfg.policy.policy_rego.has_value())
         {
-          SCITT_DEBUG("Using Rego Policy");
+          SCITT_TRACE("Using Rego Policy");
           auto start = std::chrono::steady_clock::now();
           const auto policy_violation_reason = check_for_policy_violations_rego(
             cfg.policy.policy_rego.value(),
@@ -370,8 +366,6 @@ namespace scitt
             cfg.policy.get_policy_rego_statement_limit());
           if (policy_violation_reason.has_value())
           {
-            SCITT_DEBUG(
-              "Policy check failed: {}", policy_violation_reason.value());
             throw BadRequestCborError(
               errors::PolicyFailed,
               fmt::format(
@@ -380,11 +374,11 @@ namespace scitt
           auto end = std::chrono::steady_clock::now();
           auto elapsed =
             std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-          CCF_APP_DEBUG("Rego Policy check passed in {}us", elapsed.count());
+          SCITT_TRACE("Rego Policy check passed in {}us", elapsed.count());
         }
         else if (cfg.policy.policy_script.has_value())
         {
-          SCITT_DEBUG("Using JS Policy");
+          SCITT_TRACE("Using JS Policy");
           auto start = std::chrono::steady_clock::now();
           const auto policy_violation_reason = check_for_policy_violations(
             cfg.policy.policy_script.value(),
@@ -395,8 +389,6 @@ namespace scitt
             details);
           if (policy_violation_reason.has_value())
           {
-            SCITT_DEBUG(
-              "Policy check failed: {}", policy_violation_reason.value());
             throw BadRequestCborError(
               errors::PolicyFailed,
               fmt::format(
@@ -405,13 +397,12 @@ namespace scitt
           auto end = std::chrono::steady_clock::now();
           auto elapsed =
             std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-          CCF_APP_DEBUG("JS Policy check passed in {}us", elapsed.count());
+          SCITT_TRACE("JS Policy check passed in {}us", elapsed.count());
         }
         else
         {
           if (verifier::contains_cwt_issuer(phdr))
           {
-            SCITT_DEBUG("No policy applied, but CWT issuer present");
             throw BadRequestCborError(
               errors::PolicyFailed,
               "Policy was not met: CWT issuer present but no policy "
@@ -419,7 +410,7 @@ namespace scitt
           }
           else
           {
-            SCITT_DEBUG("No policy applied");
+            SCITT_TRACE("No policy applied");
           }
         }
 
@@ -436,13 +427,9 @@ namespace scitt
         // Store the original COSE_Sign1 message in the KV, so we can retrieve
         // it later, inject the receipt in it, and serve a transparent
         // statement.
-        SCITT_DEBUG("Signed statement stored in the ledger");
         auto* entry_table = ctx.tx.template rw<EntryTable>(ENTRY_TABLE);
         entry_table->put(signed_statement);
-
-        SCITT_INFO("SignedStatementSizeKb={}", body.size() / 1024);
-
-        SCITT_DEBUG("SignedStatement was submitted synchronously");
+        SCITT_TRACE("Signed statement stored in the ledger");
 
         record_synchronous_operation(host_time, ctx.tx);
       };
@@ -476,7 +463,7 @@ namespace scitt
         [](
           EndpointContext& ctx,
           const ccf::historical::StatePtr& historical_state) {
-          SCITT_DEBUG("Get transaction historical state");
+          SCITT_TRACE("Get transaction historical state");
           auto historical_tx = historical_state->store->create_read_only_tx();
 
           auto* entries = historical_tx.template ro<EntryTable>(ENTRY_TABLE);
@@ -490,7 +477,7 @@ namespace scitt
                 historical_state->transaction_id.to_str()));
           }
 
-          SCITT_DEBUG("Get receipt from the ledger");
+          SCITT_TRACE("Get receipt from the ledger");
           auto cose_receipt = get_cose_receipt(historical_state->receipt);
 
           ctx.rpc_ctx->set_response_body(cose_receipt);
@@ -523,7 +510,7 @@ namespace scitt
         [](
           EndpointContext& ctx,
           const ccf::historical::StatePtr& historical_state) {
-          SCITT_DEBUG("Get transaction historical state");
+          SCITT_TRACE("Get transaction historical state");
           auto historical_tx = historical_state->store->create_read_only_tx();
 
           auto* entries = historical_tx.template ro<EntryTable>(ENTRY_TABLE);
@@ -537,7 +524,7 @@ namespace scitt
                 historical_state->transaction_id.to_str()));
           }
 
-          SCITT_DEBUG("Get receipt from the ledger");
+          SCITT_TRACE("Get receipt from the ledger");
           auto cose_receipt = get_cose_receipt(historical_state->receipt);
 
           // See https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/
@@ -549,7 +536,7 @@ namespace scitt
           ccf::cose::edit::desc::Value receipts_desc{
             ccf::cose::edit::pos::InArray{}, receipts, cose_receipt};
 
-          SCITT_DEBUG("Embed receipt into transparent statement");
+          SCITT_TRACE("Embed receipt into transparent statement");
           auto statement =
             ccf::cose::edit::set_unprotected_header(*entry, receipts_desc);
 
@@ -583,7 +570,7 @@ namespace scitt
           const auto parsed_query =
             ccf::http::parse_query(ctx.rpc_ctx->get_request_query());
 
-          SCITT_DEBUG("Parse input params and determine entries range");
+          SCITT_TRACE("Parse input params and determine entries range");
           ccf::SeqNo from_seqno =
             get_query_value<uint64_t>(parsed_query, "from").value_or(1);
           std::optional<ccf::SeqNo> to_seqno_opt =
@@ -658,7 +645,7 @@ namespace scitt
               "Index of requested range not available yet, retry later");
           }
 
-          SCITT_DEBUG("Get entries for the target range");
+          SCITT_TRACE("Get entries for the target range");
           std::vector<std::string> tx_ids;
           for (auto seqno : interesting_seqnos.value())
           {
@@ -681,7 +668,7 @@ namespace scitt
           // next page and tell the caller how to retrieve it
           if (range_end != to_seqno)
           {
-            SCITT_DEBUG("Add next link to retrieve the rest of entries");
+            SCITT_TRACE("Add next link to retrieve the rest of entries");
             const auto next_page_start = range_end + 1;
             const auto next_range_end =
               std::min(to_seqno, next_page_start + max_seqno_per_page);

--- a/app/src/operations_endpoints.h
+++ b/app/src/operations_endpoints.h
@@ -250,10 +250,10 @@ namespace scitt
       {
         if (log.status == Succeeded || log.status == Failed)
         {
-          // This is a less severe invalid transition. We just log it as INFO
+          // This is a less severe invalid transition. We just log it as DEBUG
           // and don't abort. We still return false, to stop the indexing
           // strategy from proceeding further.
-          SCITT_INFO(
+          SCITT_DEBUG(
             "Repeated completion of operation {} at {}, from {} to {}",
             operation_id.to_str(),
             tx_id.to_str(),
@@ -269,7 +269,8 @@ namespace scitt
         if (current_status.has_value())
         {
           SCITT_FAIL(
-            "Got unexpected event {} at {} for existing operation {} in state",
+            "Got unexpected event {} at {} for existing operation {} in state "
+            "{}",
             nlohmann::json(log.status).dump(),
             tx_id.to_str(),
             operation_id.to_str(),
@@ -328,7 +329,7 @@ namespace scitt
       if (it != operations_.begin())
       {
         SCITT_DEBUG(
-          "Removing {} operations from indexing strategy",
+          "Removing {} expired operations from indexing strategy",
           std::distance(operations_.begin(), it));
 
         lower_bound = std::prev(it)->first + 1;
@@ -491,7 +492,7 @@ namespace scitt
     ccf::endpoints::CommandEndpointContext& ctx, const ccf::TxID& tx_id)
   {
     std::string tx_str = tx_id.to_str();
-    SCITT_DEBUG("New operation was locally committed with tx={}", tx_str);
+    SCITT_TRACE("New operation was locally committed with tx={}", tx_str);
 
     ctx.rpc_ctx->set_response_header(ccf::http::headers::CCF_TX_ID, tx_str);
 

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -85,21 +85,21 @@ namespace
       if (new_digest != policy_digest)
       {
         rego::Interpreter interpreter;
+        interpreter.log_level(rego::LogLevel::None);
         auto rv = interpreter.add_module("policy.rego", policy);
         if (rv != nullptr)
         {
-          CCF_APP_FAIL(
-            "Failed to load policy: {}", interpreter.output_to_string(rv));
-          throw std::domain_error("Invalid policy module (add_module)");
+          throw std::domain_error(fmt::format(
+            "Invalid policy module (add_module): {}",
+            interpreter.output_to_string(rv)));
         }
         interpreter.entrypoints({"policy/allow", "policy/errors"});
         trieste::Node bundle_node = interpreter.build();
         if (bundle_node->type() == rego::ErrorSeq)
         {
-          CCF_APP_FAIL(
-            "Failed to build policy bundle: {}",
-            interpreter.output_to_string(bundle_node));
-          throw std::domain_error("Invalid policy module (build)");
+          throw std::domain_error(fmt::format(
+            "Invalid policy module (build): {}",
+            interpreter.output_to_string(bundle_node)));
         }
         bundle = rego::BundleDef::from_node(bundle_node);
         policy_digest = new_digest;
@@ -434,7 +434,7 @@ namespace scitt
       auto end = std::chrono::steady_clock::now();
       auto elapsed =
         std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-      CCF_APP_INFO("JS runtime setup in {}us", elapsed.count());
+      SCITT_TRACE("JS runtime setup in {}us", elapsed.count());
       start = std::chrono::steady_clock::now();
 
       auto phdr_val = protected_header_to_js_val(interpreter, phdr);
@@ -449,7 +449,7 @@ namespace scitt
           10 * 1024 * 1024, // max_heap_bytes (10MB)
           1024 * 1024, // max_stack_bytes (1MB)
           1000, // max_execution_time_ms (1s)
-          true, // log_exception_details
+          false, // log_exception_details
           false, // return_exception_details
           0, // max_cached_interpreters
         },
@@ -471,7 +471,7 @@ namespace scitt
       end = std::chrono::steady_clock::now();
       elapsed =
         std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-      CCF_APP_INFO("JS input construction and eval in {}us", elapsed.count());
+      SCITT_TRACE("JS input construction and eval in {}us", elapsed.count());
 
       if (result.is_str())
       {
@@ -650,6 +650,7 @@ namespace scitt
 
     auto input = rego_input_mapping(phdr, payload, details);
     rego::Interpreter interpreter;
+    interpreter.log_level(rego::LogLevel::None);
     interpreter.stmt_limit(statement_limit);
 
     auto tv = interpreter.set_input(input);

--- a/app/src/tracing.h
+++ b/app/src/tracing.h
@@ -103,8 +103,10 @@ namespace scitt
     if (result != ccf::ApiResult::OK)
     {
       SCITT_FAIL(
-        "::END:: Stage={} Code=InternalError get_untrusted_host_time_v1 failed",
-        fn_stage_name);
+        "::END:: Stage={} Code=InternalError get_time failed "
+        "while recording end time: {}",
+        fn_stage_name,
+        ccf::api_result_to_str(result));
       rpc_ctx->set_response_status(500);
       rpc_ctx->set_response_header(
         ccf::http::headers::CONTENT_TYPE, cbor::CBOR_ERROR_CONTENT_TYPE);
@@ -116,14 +118,18 @@ namespace scitt
     auto duration_ms = diff_timespec_ms(app_data.start_time, end);
     if (duration_ms < 0)
     {
-      SCITT_INFO(
-        "Computed request duration is negative: {} ms. Ignoring.", duration_ms);
+      SCITT_DEBUG(
+        "Untrusted host time produced negative request duration: {} ms.",
+        duration_ms);
     }
+    const auto error_context = app_data.error_code.has_value() ?
+      fmt::format(" Code={}", app_data.error_code.value()) :
+      std::string{};
 
     if (txid.has_value())
     {
       SCITT_INFO(
-        "::END:: Stage={} Verb={} Path={} Query={} URL={} Status={} TxId={} "
+        "::END:: Stage={} Verb={} Path={} Query={} URL={} Status={}{} TxId={} "
         "TimeMs={}",
         fn_stage_name,
         rpc_ctx->get_request_verb().c_str(),
@@ -131,19 +137,22 @@ namespace scitt
         rpc_ctx->get_request_query().c_str(),
         rpc_ctx->get_request_url(),
         rpc_ctx->get_response_status(),
+        error_context,
         txid->to_str(),
         std::to_string(duration_ms));
     }
     else
     {
       SCITT_INFO(
-        "::END:: Stage={} Verb={} Path={} Query={} URL={} Status={} TimeMs={}",
+        "::END:: Stage={} Verb={} Path={} Query={} URL={} Status={}{} "
+        "TimeMs={}",
         fn_stage_name,
         rpc_ctx->get_request_verb().c_str(),
         path,
         rpc_ctx->get_request_query().c_str(),
         rpc_ctx->get_request_url(),
         rpc_ctx->get_response_status(),
+        error_context,
         std::to_string(duration_ms));
     }
   }
@@ -191,9 +200,10 @@ namespace scitt
       if (result != ccf::ApiResult::OK)
       {
         SCITT_FAIL(
-          "::END:: Stage={} Code=InternalError get_untrusted_host_time_v1 "
-          "failed",
-          FN_STAGE_MAIN);
+          "::END:: Stage={} Code=InternalError get_time failed "
+          "while recording start time: {}",
+          FN_STAGE_MAIN,
+          ccf::api_result_to_str(result));
         ctx.rpc_ctx->set_response_status(500);
         ctx.rpc_ctx->set_response_header(
           ccf::http::headers::CONTENT_TYPE, cbor::CBOR_ERROR_CONTENT_TYPE);

--- a/app/src/verifier.h
+++ b/app/src/verifier.h
@@ -498,7 +498,7 @@ namespace scitt::verifier
       if (!cert)
       {
         unsigned long ec = ERR_get_error();
-        SCITT_INFO(
+        SCITT_DEBUG(
           "Could not parse PEM certificate: {}",
           ccf::crypto::OpenSSL::error_string(ec));
         throw VerificationError("Could not parse certificate");
@@ -515,7 +515,7 @@ namespace scitt::verifier
       if (!cert)
       {
         unsigned long ec = ERR_get_error();
-        SCITT_INFO(
+        SCITT_DEBUG(
           "Could not parse DER certificate: {}",
           ccf::crypto::OpenSSL::error_string(ec));
         throw VerificationError("Could not parse certificate");

--- a/app/unit-tests/generic_error_adapter_test.cpp
+++ b/app/unit-tests/generic_error_adapter_test.cpp
@@ -35,6 +35,43 @@ namespace
 
   using EndpointFunction = std::function<void(MockContext& args)>;
 
+  class CapturingLogger : public ccf::logger::AbstractLogger
+  {
+  public:
+    std::vector<ccf::LoggerLevel> levels;
+
+    void write(const ccf::logger::LogLine& line) override
+    {
+      levels.push_back(line.log_level);
+    }
+  };
+
+  class ScopedLogger
+  {
+  private:
+    ccf::LoggerLevel previous_level;
+    std::vector<std::unique_ptr<ccf::logger::AbstractLogger>> previous_loggers;
+
+  public:
+    CapturingLogger* logger;
+
+    ScopedLogger() :
+      previous_level(ccf::logger::config::level()),
+      previous_loggers(std::move(ccf::logger::config::loggers()))
+    {
+      ccf::logger::config::level() = ccf::LoggerLevel::TRACE;
+      auto capturing_logger = std::make_unique<CapturingLogger>();
+      logger = capturing_logger.get();
+      ccf::logger::config::loggers().emplace_back(std::move(capturing_logger));
+    }
+
+    ~ScopedLogger()
+    {
+      ccf::logger::config::loggers() = std::move(previous_loggers);
+      ccf::logger::config::level() = previous_level;
+    }
+  };
+
   // Test function that throws an HTTPError
   void test_function(MockContext& ctx)
   {
@@ -42,11 +79,28 @@ namespace
     throw BadRequestCborError("BadRequest", "This is a bad request");
   }
 
+  void test_unhandled_exception(MockContext& ctx)
+  {
+    (void)ctx;
+    throw std::runtime_error("Unexpected failure");
+  }
+
+  void test_policy_error(MockContext& ctx)
+  {
+    (void)ctx;
+    throw BadRequestCborError(errors::PolicyError, "Invalid configured policy");
+  }
+
   // Unit test for generic_error_adapter
   TEST(GenericErrorAdapterTest, HandlesHTTPError)
   {
+    ScopedLogger logs;
+    std::optional<std::string> error_code;
     auto adapted_function =
-      generic_error_adapter<EndpointFunction, MockContext>(test_function);
+      generic_error_adapter<EndpointFunction, MockContext>(
+        test_function, [&error_code](MockContext&, const std::string& code) {
+          error_code = code;
+        });
 
     MockContext ctx;
 
@@ -82,6 +136,52 @@ namespace
       });
 
     adapted_function(ctx);
+    EXPECT_EQ(error_code, "BadRequest");
+    EXPECT_THAT(logs.logger->levels, ElementsAre(ccf::LoggerLevel::DEBUG));
+  }
+
+  TEST(GenericErrorAdapterTest, HandlesUnhandledException)
+  {
+    ScopedLogger logs;
+    std::optional<std::string> error_code;
+    auto adapted_function =
+      generic_error_adapter<EndpointFunction, MockContext>(
+        test_unhandled_exception,
+        [&error_code](MockContext&, const std::string& code) {
+          error_code = code;
+        });
+
+    MockContext ctx;
+
+    EXPECT_CALL(
+      *ctx.rpc_ctx, set_response_status(HTTP_STATUS_INTERNAL_SERVER_ERROR));
+    EXPECT_CALL(
+      *ctx.rpc_ctx,
+      set_response_header(
+        ccf::http::headers::CONTENT_TYPE, cbor::CBOR_ERROR_CONTENT_TYPE));
+    EXPECT_CALL(*ctx.rpc_ctx, set_response_body(_));
+
+    adapted_function(ctx);
+    EXPECT_EQ(error_code, errors::InternalError);
+    EXPECT_THAT(logs.logger->levels, ElementsAre(ccf::LoggerLevel::FAIL));
+  }
+
+  TEST(GenericErrorAdapterTest, LogsPolicyErrorAsFailure)
+  {
+    ScopedLogger logs;
+    auto adapted_function =
+      generic_error_adapter<EndpointFunction, MockContext>(test_policy_error);
+    MockContext ctx;
+
+    EXPECT_CALL(*ctx.rpc_ctx, set_response_status(HTTP_STATUS_BAD_REQUEST));
+    EXPECT_CALL(
+      *ctx.rpc_ctx,
+      set_response_header(
+        ccf::http::headers::CONTENT_TYPE, cbor::CBOR_ERROR_CONTENT_TYPE));
+    EXPECT_CALL(*ctx.rpc_ctx, set_response_body(_));
+
+    adapted_function(ctx);
+    EXPECT_THAT(logs.logger->levels, ElementsAre(ccf::LoggerLevel::FAIL));
   }
 
 }

--- a/app/unit-tests/generic_error_adapter_test.cpp
+++ b/app/unit-tests/generic_error_adapter_test.cpp
@@ -4,6 +4,7 @@
 #include "cbor.h"
 #include "http_error.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <gmock/gmock.h>
@@ -45,38 +46,53 @@ namespace
 
   class CapturingLogger : public ccf::logger::AbstractLogger
   {
-  public:
-    std::vector<ccf::LoggerLevel> levels;
+  private:
+    std::vector<ccf::LoggerLevel> levels_;
 
+  public:
     void write(const ccf::logger::LogLine& line) override
     {
-      levels.push_back(line.log_level);
+      levels_.push_back(line.log_level);
+    }
+
+    [[nodiscard]] const std::vector<ccf::LoggerLevel>& levels() const
+    {
+      return levels_;
     }
   };
 
   class ScopedLogger
   {
   private:
-    ccf::LoggerLevel previous_level;
-    std::vector<std::unique_ptr<ccf::logger::AbstractLogger>> previous_loggers;
+    ccf::LoggerLevel previous_level_;
+    CapturingLogger* logger_;
 
   public:
-    CapturingLogger* logger;
-
-    ScopedLogger() :
-      previous_level(ccf::logger::config::level()),
-      previous_loggers(std::move(ccf::logger::config::loggers()))
+    ScopedLogger() : previous_level_(ccf::logger::config::level())
     {
       ccf::logger::config::level() = ccf::LoggerLevel::TRACE;
       auto capturing_logger = std::make_unique<CapturingLogger>();
-      logger = capturing_logger.get();
+      logger_ = capturing_logger.get();
       ccf::logger::config::loggers().emplace_back(std::move(capturing_logger));
     }
 
     ~ScopedLogger()
     {
-      ccf::logger::config::loggers() = std::move(previous_loggers);
-      ccf::logger::config::level() = previous_level;
+      auto& loggers = ccf::logger::config::loggers();
+      const auto it = std::find_if(
+        loggers.begin(), loggers.end(), [this](const auto& candidate) {
+          return candidate.get() == logger_;
+        });
+      if (it != loggers.end())
+      {
+        loggers.erase(it);
+      }
+      ccf::logger::config::level() = previous_level_;
+    }
+
+    [[nodiscard]] const std::vector<ccf::LoggerLevel>& levels() const
+    {
+      return logger_->levels();
     }
   };
 
@@ -145,7 +161,7 @@ namespace
 
     adapted_function(ctx);
     EXPECT_EQ(error_code, "BadRequest");
-    EXPECT_THAT(logs.logger->levels, ElementsAre(ccf::LoggerLevel::DEBUG));
+    EXPECT_THAT(logs.levels(), ElementsAre(ccf::LoggerLevel::DEBUG));
   }
 
   TEST(GenericErrorAdapterTest, HandlesUnhandledException)
@@ -171,7 +187,7 @@ namespace
 
     adapted_function(ctx);
     EXPECT_EQ(error_code, errors::InternalError);
-    EXPECT_THAT(logs.logger->levels, ElementsAre(ccf::LoggerLevel::FAIL));
+    EXPECT_THAT(logs.levels(), ElementsAre(ccf::LoggerLevel::FAIL));
   }
 
   TEST(GenericErrorAdapterTest, LogsPolicyErrorAsFailure)
@@ -189,7 +205,7 @@ namespace
     EXPECT_CALL(*ctx.rpc_ctx, set_response_body(_));
 
     adapted_function(ctx);
-    EXPECT_THAT(logs.logger->levels, ElementsAre(ccf::LoggerLevel::FAIL));
+    EXPECT_THAT(logs.levels(), ElementsAre(ccf::LoggerLevel::FAIL));
   }
 
 }

--- a/app/unit-tests/generic_error_adapter_test.cpp
+++ b/app/unit-tests/generic_error_adapter_test.cpp
@@ -4,8 +4,16 @@
 #include "cbor.h"
 #include "http_error.h"
 
+#include <cstdint>
+#include <functional>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace testing;
 using namespace scitt;

--- a/app/unit-tests/policy_engine_test.cpp
+++ b/app/unit-tests/policy_engine_test.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "policy_engine.h"
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
+
+namespace
+{
+  class ScopedStreamRedirect
+  {
+  private:
+    std::ostream& stream;
+    std::streambuf* original;
+
+  public:
+    ScopedStreamRedirect(std::ostream& stream_, std::streambuf* replacement) :
+      stream(stream_),
+      original(stream.rdbuf(replacement))
+    {}
+
+    ~ScopedStreamRedirect()
+    {
+      stream.rdbuf(original);
+    }
+  };
+
+  TEST(PolicyEngineTest, InvalidRegoDoesNotWriteDirectlyToStdout)
+  {
+    std::ostringstream output;
+    {
+      ScopedStreamRedirect redirect(std::cout, output.rdbuf());
+
+      BundleWrapper bundle;
+      EXPECT_THROW(bundle.load_policy("invalid rego"), std::domain_error);
+    }
+    EXPECT_TRUE(output.str().empty());
+  }
+}

--- a/app/unit-tests/policy_engine_test.cpp
+++ b/app/unit-tests/policy_engine_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 namespace
 {

--- a/docker/start-app.sh
+++ b/docker/start-app.sh
@@ -2,24 +2,65 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+set -u
+
 # This script just runs cchost with some arguments. Due to cce policy limitations, we cannot
 # express a container command containing an environment variable as the value is dynamic. By
 # "hiding" the environment variable usage, the policy can hardcode a static startup command.
 
 # Usage:
-# ./start-app.sh $CONFIG_ROOT $CONFIG_FILE_NAME $ADDITIONAL_ARGS
+# ./start-app.sh CONFIG_ROOT CONFIG_FILE_NAME [ADDITIONAL_ARGS...]
+
+if (( $# < 2 )); then
+    echo "Usage: $0 CONFIG_ROOT CONFIG_FILE_NAME [ADDITIONAL_ARGS...]" >&2
+    exit 64
+fi
+
+if [[ -z "$1" || -z "$2" ]]; then
+    echo "CONFIG_ROOT and CONFIG_FILE_NAME must not be empty" >&2
+    exit 64
+fi
+
+if [[ -z "${NODE_NAME:-}" ]]; then
+    echo "NODE_NAME must be set" >&2
+    exit 64
+fi
+
+if [[ -n "${OUTPUT_LOGS_FILE:-}" && -n "${OUTPUT_LOCAL_PORT:-}" ]]; then
+    echo "OUTPUT_LOGS_FILE and OUTPUT_LOCAL_PORT cannot both be set" >&2
+    exit 64
+fi
+
+if [[ -n "${OUTPUT_LOCAL_PORT:-}" ]]; then
+    if [[ ! "$OUTPUT_LOCAL_PORT" =~ ^[0-9]{1,5}$ ]] ||
+        (( 10#$OUTPUT_LOCAL_PORT < 1 || 10#$OUTPUT_LOCAL_PORT > 65535 )); then
+        echo "OUTPUT_LOCAL_PORT must be an integer between 1 and 65535" >&2
+        exit 64
+    fi
+fi
+
+config_path="${1}/${NODE_NAME}/${2}"
+shift 2
 
 # Use exec to replace the shell process with cchost, so that cchost receives signals sent to the main process.
 # Since we replace the shell process, it is not possible to run any additional logic in this script after this command is executed.
 # At the moment, this is not a problem as this script is only used to run cchost at the end. If we ever need in the future to run additional
 # logic after cchost completes, we will need a different solution (e.g., https://unix.stackexchange.com/a/146770).
 
-# If the OUTPUT_LOGS_FILE is not empty, redirect the command output to the file
-# If OUTPUT_LOCAL_PORT is not empty, redirect the command output to the specified port on localhost
-if [ -n "${OUTPUT_LOGS_FILE}" ]; then
-    exec cchost --config="${1}/${NODE_NAME}/${2}" "${@:3}" > >(tee -a "$OUTPUT_LOGS_FILE") 2>&1
-elif [ -n "${OUTPUT_LOCAL_PORT}" ]; then
-    exec cchost --config="${1}/${NODE_NAME}/${2}" "${@:3}" > >(tee >(nc "127.0.0.1" "$OUTPUT_LOCAL_PORT")) 2>&1
+# If OUTPUT_LOGS_FILE is not empty, copy command output to the file.
+# Otherwise, if OUTPUT_LOCAL_PORT is not empty, copy it to the specified port
+# on localhost. In both cases output also remains on stdout.
+# warn-nopipe keeps cchost running if an optional mirror disconnects; stdout
+# remains available, but logs may be lost from that secondary destination.
+if [[ -n "${OUTPUT_LOGS_FILE:-}" ]]; then
+    exec cchost --config="$config_path" "$@" \
+        > >(tee --output-error=warn-nopipe -a -- "$OUTPUT_LOGS_FILE") 2>&1
+elif [[ -n "${OUTPUT_LOCAL_PORT:-}" ]]; then
+    exec cchost --config="$config_path" "$@" > >(
+        tee --output-error=warn-nopipe >(
+            ncat --send-only "127.0.0.1" "$OUTPUT_LOCAL_PORT"
+        )
+    ) 2>&1
 else
-    exec cchost --config="${1}/${NODE_NAME}/${2}" "${@:3}"
+    exec cchost --config="$config_path" "$@"
 fi


### PR DESCRIPTION
- Downlevel or remove noisy logs while preserving START/END records used for internal monitoring.
- Centralize structured error reporting and retain detailed policy diagnostics.
- Harden container log forwarding and add focused regression tests.
- Update the changelog to keep it consistent