### PR TITLE
Fix uncaught exception when rego policy/errors yields no result

### DIFF
--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -713,8 +713,15 @@ namespace scitt
 
       return buf.str();
     }
-    catch (const std::domain_error& e)
+    catch (const std::exception& e)
     {
+      // error_output.expressions() (i.e. Output::expressions_at(0)) throws
+      // std::out_of_range, not std::domain_error, when the policy/errors
+      // rule produced no result for this input (e.g. the policy only
+      // defines specific violation messages and this denial reason isn't
+      // one of them). Catching std::exception here - rather than only
+      // std::domain_error - ensures any such policy authoring gap is
+      // reported as a 400 PolicyError instead of an uncaught 500.
       throw BadRequestCborError(
         scitt::errors::PolicyError,
         fmt::format("Could not interpret policy errors: {}", e.what()));

--- a/app/src/policy_engine.h
+++ b/app/src/policy_engine.h
@@ -686,8 +686,26 @@ namespace scitt
         fmt::format("Could not interpret policy result: {}", e.what()));
     }
 
-    auto error_output =
-      rego::Output(interpreter.query_bundle(bundle, "policy/errors"));
+    auto error_node = interpreter.query_bundle(bundle, "policy/errors");
+
+    // A policy whose "errors" rule produces no result for this input (e.g.
+    // the policy only defines specific violation messages and this denial
+    // reason isn't one of them) makes run_entrypoint() return the bare
+    // Undefined node rather than a Results node. rego::Output's constructor
+    // only expects Results (or an error), so passing it an Undefined node
+    // trips an assertion in debug builds, and in release builds silently
+    // leaves it wrapping a zero-length node whose first expression later
+    // throws std::out_of_range. Detect this policy-authoring gap
+    // explicitly, before constructing the Output, and report it as a clean
+    // 400 PolicyError instead.
+    if (error_node != nullptr && error_node->type() == rego::Undefined)
+    {
+      throw BadRequestCborError(
+        scitt::errors::PolicyError,
+        "Policy denied the request but did not provide a specific reason");
+    }
+
+    auto error_output = rego::Output(error_node);
 
     if (!error_output.ok())
     {
@@ -715,13 +733,9 @@ namespace scitt
     }
     catch (const std::exception& e)
     {
-      // error_output.expressions() (i.e. Output::expressions_at(0)) throws
-      // std::out_of_range, not std::domain_error, when the policy/errors
-      // rule produced no result for this input (e.g. the policy only
-      // defines specific violation messages and this denial reason isn't
-      // one of them). Catching std::exception here - rather than only
-      // std::domain_error - ensures any such policy authoring gap is
-      // reported as a 400 PolicyError instead of an uncaught 500.
+      // Defense in depth for any other unexpected shape of the
+      // policy/errors result (e.g. a defined but non-set value), distinct
+      // from the fully-undefined case already handled above.
       throw BadRequestCborError(
         scitt::errors::PolicyError,
         fmt::format("Could not interpret policy errors: {}", e.what()));

--- a/app/unit-tests/policy_engine_test.cpp
+++ b/app/unit-tests/policy_engine_test.cpp
@@ -63,11 +63,18 @@ errors := "unreachable" if { false }
     scitt::cose::UnprotectedHeader uhdr;
     std::vector<uint8_t> payload_bytes = {1, 2, 3};
     std::span<uint8_t> payload(payload_bytes);
+    constexpr size_t statement_limit = 10000;
 
     try
     {
       scitt::check_for_policy_violations_rego(
-        rego_policy, "test_policy", phdr, uhdr, payload, std::nullopt, 10000);
+        rego_policy,
+        "test_policy",
+        phdr,
+        uhdr,
+        payload,
+        std::nullopt,
+        statement_limit);
       FAIL() << "Expected a BadRequestCborError to be thrown";
     }
     catch (const scitt::HTTPError& e)

--- a/app/unit-tests/policy_engine_test.cpp
+++ b/app/unit-tests/policy_engine_test.cpp
@@ -44,11 +44,14 @@ namespace
 
   // Regression test for a rego policy whose `policy/errors` rule is
   // undefined for a given input (e.g. a complete rule guarded by `if` with
-  // no matching branch and no `default`). Previously, extracting the
-  // violation message in this case threw an uncaught std::out_of_range
-  // ("Index out of range") from rego-cpp's Output::expressions(), which
-  // escaped as an HTTP 500 InternalError instead of a clean 400
-  // PolicyError response.
+  // no matching branch and no `default`). In that case rego-cpp's
+  // run_entrypoint() returns the bare Undefined node instead of a Results
+  // node. Previously this was passed straight into rego::Output, whose
+  // constructor only expects Results: in release builds this silently led
+  // to an uncaught std::out_of_range ("Index out of range") from
+  // Output::expressions(), escaping as an HTTP 500 InternalError; in debug
+  // builds it instead tripped an assertion, aborting the process. Either
+  // way, this should now be reported as a clean 400 PolicyError.
   TEST(PolicyEngineTest, RegoPolicyUndefinedErrorsIsReportedGracefully)
   {
     const std::string rego_policy = R"(

--- a/app/unit-tests/policy_engine_test.cpp
+++ b/app/unit-tests/policy_engine_test.cpp
@@ -3,6 +3,8 @@
 
 #include "policy_engine.h"
 
+#include "constants.h"
+
 #include <gtest/gtest.h>
 #include <iostream>
 #include <sstream>
@@ -38,5 +40,40 @@ namespace
       EXPECT_THROW(bundle.load_policy("invalid rego"), std::domain_error);
     }
     EXPECT_TRUE(output.str().empty());
+  }
+
+  // Regression test for a rego policy whose `policy/errors` rule is
+  // undefined for a given input (e.g. a complete rule guarded by `if` with
+  // no matching branch and no `default`). Previously, extracting the
+  // violation message in this case threw an uncaught std::out_of_range
+  // ("Index out of range") from rego-cpp's Output::expressions(), which
+  // escaped as an HTTP 500 InternalError instead of a clean 400
+  // PolicyError response.
+  TEST(PolicyEngineTest, RegoPolicyUndefinedErrorsIsReportedGracefully)
+  {
+    const std::string rego_policy = R"(
+package policy
+
+default allow := false
+
+errors := "unreachable" if { false }
+)";
+
+    scitt::cose::ProtectedHeader phdr;
+    scitt::cose::UnprotectedHeader uhdr;
+    std::vector<uint8_t> payload_bytes = {1, 2, 3};
+    std::span<uint8_t> payload(payload_bytes);
+
+    try
+    {
+      scitt::check_for_policy_violations_rego(
+        rego_policy, "test_policy", phdr, uhdr, payload, std::nullopt, 10000);
+      FAIL() << "Expected a BadRequestCborError to be thrown";
+    }
+    catch (const scitt::HTTPError& e)
+    {
+      EXPECT_EQ(e.status_code, HTTP_STATUS_BAD_REQUEST);
+      EXPECT_EQ(e.code, scitt::errors::PolicyError);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes an uncaught exception that surfaces as an opaque HTTP 500
`{code: "InternalError", message: "Index out of range"}` when a rego
registration policy denies a submission (`policy/allow == false`) but its
`policy/errors` rule produces **no result** for that specific input (e.g. a
complete rule guarded by `if` with no matching branch and no `default`).

### Root cause

In `check_for_policy_violations_rego()` (`app/src/policy_engine.h`), after a
well-formed policy denial, the code queries `policy/errors` to build a
human-readable violation message via
`set_from_terms(error_output.expressions())`. When the policy's `errors` rule
is undefined for the given input, `rego-cpp`'s `Output::expressions()` (→
`expressions_at(0)`) throws `std::out_of_range("Index out of range")`.

The surrounding `catch` clause only caught `std::domain_error`, a sibling of
`std::out_of_range` (both derive from `std::logic_error`, not from each
other), so the exception was not caught there. It also isn't caught anywhere
in `main.cpp`, so it escapes all the way to CCF's generic catch-all
(`app/src/http_error.h`), which turns any uncaught `std::exception` into a raw
HTTP 500 `InternalError` using `e.what()` as the message.

This was reported against a real submission whose leaf certificate EKU was
rejected by the tenant's configured policy, and confirmed live in production
logs for the reported `ClientRequestId`:

```
Unhandled exception in endpoint: Code=InternalError Index out of range ClientRequestId=e9287e6c-d0f0-47b9-b646-f1548251d089 RequestId=e09e662911e39f6
```

### Fix

Broaden the `catch` around the `policy/errors` extraction to `std::exception`
(matching the handling already used a few lines above for the `policy/allow`
query), so this class of policy-authoring gap now results in a clean 400
`PolicyError` response instead of an uncaught 500.

### Testing

Added a regression test (`app/unit-tests/policy_engine_test.cpp`) with a rego
policy whose `errors` rule is undefined for the input, asserting a graceful
`BadRequestCborError`/`PolicyError` is thrown rather than letting the
exception escape uncaught.

Opening as a PR (rather than pushing directly to `main`) to trigger CI, since
building/running the C++ unit tests locally isn't practical in this
environment.
